### PR TITLE
updated robots.txt to allow landing page crawling

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2024.4.12-alpha.11",
+      version: "2024.4.15-alpha.12",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -1,2 +1,3 @@
 User-agent: *
+Allow: /$
 Disallow: /


### PR DESCRIPTION
part of the #125 process.

Google's message:

---

### New reason preventing your pages from being indexed

Search Console has identified that some pages on your site are not being indexed due to the following new reason:

```
Blocked by robots.txt
```

If this reason is not intentional, we recommend that you fix it in order to get affected pages indexed and appearing on Google.