### PR TITLE
assessment point entries log

### DIFF
--- a/lib/lanttern/application.ex
+++ b/lib/lanttern/application.ex
@@ -21,7 +21,10 @@ defmodule Lanttern.Application do
       # Start a worker by calling: Lanttern.Worker.start_link(arg)
       # {Lanttern.Worker, arg},
       # Start Joken JWKS token strategy
-      {Lanttern.GoogleTokenStrategy, time_interval: 600_000}
+      {Lanttern.GoogleTokenStrategy, time_interval: 600_000},
+      # Start the task supervisor
+      # see https://hexdocs.pm/elixir/Task.Supervisor.html
+      {Task.Supervisor, name: Lanttern.TaskSupervisor}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/lib/lanttern/assessments.ex
+++ b/lib/lanttern/assessments.ex
@@ -10,6 +10,7 @@ defmodule Lanttern.Assessments do
   alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.Assessments.AssessmentPointEntry
   alias Lanttern.Assessments.Feedback
+  alias Lanttern.AssessmentsLog
   alias Lanttern.Conversation.Comment
   alias Lanttern.Rubrics
   alias Lanttern.Schools.Student
@@ -359,9 +360,10 @@ defmodule Lanttern.Assessments do
   @doc """
   Creates an assessment_point_entry.
 
-  ### Options:
+  ## Options:
 
-  `:preloads` – preloads associated data
+  - `:preloads` – preloads associated data
+  - `:log_profile_id` - logs the operation, linked to given profile
 
   ## Examples
 
@@ -377,15 +379,17 @@ defmodule Lanttern.Assessments do
     |> AssessmentPointEntry.changeset(attrs)
     |> Repo.insert()
     |> maybe_preload(opts)
+    |> AssessmentsLog.maybe_create_assessment_point_entry_log("CREATE", opts)
   end
 
   @doc """
   Updates a assessment_point_entry.
 
-  ### Options:
+  ## Options:
 
-  `:preloads` – preloads associated data
-  `:force_preloads` - force preload. useful for update actions
+  - `:preloads` – preloads associated data
+  - `:force_preloads` - force preload. useful for update actions
+  - `:log_profile_id` - logs the operation, linked to given profile
 
   ## Examples
 
@@ -405,10 +409,15 @@ defmodule Lanttern.Assessments do
     |> AssessmentPointEntry.changeset(attrs)
     |> Repo.update()
     |> maybe_preload(opts)
+    |> AssessmentsLog.maybe_create_assessment_point_entry_log("UPDATE", opts)
   end
 
   @doc """
   Deletes a assessment_point_entry.
+
+  ## Options:
+
+  - `:log_profile_id` - logs the operation, linked to given profile
 
   ## Examples
 
@@ -419,8 +428,9 @@ defmodule Lanttern.Assessments do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_assessment_point_entry(%AssessmentPointEntry{} = assessment_point_entry) do
+  def delete_assessment_point_entry(%AssessmentPointEntry{} = assessment_point_entry, opts \\ []) do
     Repo.delete(assessment_point_entry)
+    |> AssessmentsLog.maybe_create_assessment_point_entry_log("DELETE", opts)
   end
 
   @doc """

--- a/lib/lanttern/assessments_log.ex
+++ b/lib/lanttern/assessments_log.ex
@@ -59,19 +59,19 @@ defmodule Lanttern.AssessmentsLog do
   @doc """
   Util for create a assessment_point_entry log.
 
-  Accepts `%AssessmentPointEntry{}` or `{:ok, %AssessmentPointEntry{}}` tuple as first arg.
+  Accepts `{:ok, %AssessmentPointEntry{}}` or `{:error, %Ecto.Changeset{}}` tuple as first arg.
 
   Always returns the entry or tuple as is. The log are handled in an async task.
   """
   @spec maybe_create_assessment_point_entry_log(
-          AssessmentPointEntry.t() | {:ok, AssessmentPointEntry.t()},
+          {:ok, AssessmentPointEntry.t()} | {:error, Ecto.Changeset.t()},
           String.t(),
           Keyword.t()
-        ) :: AssessmentPointEntry.t() | {:ok, AssessmentPointEntry.t()}
-  def maybe_create_assessment_point_entry_log(entry_or_tuple, operation, opts \\ []) do
+        ) ::
+          {:ok, AssessmentPointEntry.t()} | {:error, Ecto.Changeset.t()}
+  def maybe_create_assessment_point_entry_log(operation_tuple, operation, opts \\ []) do
     entry =
-      case entry_or_tuple do
-        %AssessmentPointEntry{} = entry -> entry
+      case operation_tuple do
         {:ok, %AssessmentPointEntry{} = entry} -> entry
         _ -> nil
       end
@@ -84,7 +84,7 @@ defmodule Lanttern.AssessmentsLog do
       )
     end
 
-    entry_or_tuple
+    operation_tuple
   end
 
   defp do_create_assessment_point_entry_log(_, _, nil), do: nil

--- a/lib/lanttern/assessments_log.ex
+++ b/lib/lanttern/assessments_log.ex
@@ -1,0 +1,57 @@
+defmodule Lanttern.AssessmentsLog do
+  @moduledoc """
+  The AssessmentsLog context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Lanttern.Repo
+
+  alias Lanttern.AssessmentsLog.AssessmentPointEntryLog
+
+  @doc """
+  Returns the list of assessment_point_entries logs.
+
+  ## Examples
+
+      iex> list_assessment_point_entries_logs()
+      [%AssessmentPointEntryLog{}, ...]
+
+  """
+  def list_assessment_point_entries_logs do
+    Repo.all(AssessmentPointEntryLog)
+  end
+
+  @doc """
+  Gets a single assessment_point_entry log.
+
+  Raises `Ecto.NoResultsError` if the Assessment point entry does not exist.
+
+  ## Examples
+
+      iex> get_assessment_point_entry_log!(123)
+      %AssessmentPointEntryLog{}
+
+      iex> get_assessment_point_entry_log!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_assessment_point_entry_log!(id), do: Repo.get!(AssessmentPointEntryLog, id)
+
+  @doc """
+  Creates a assessment_point_entry log.
+
+  ## Examples
+
+      iex> create_assessment_point_entry_log(%{field: value})
+      {:ok, %AssessmentPointEntryLog{}}
+
+      iex> create_assessment_point_entry_log(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_assessment_point_entry_log(attrs \\ %{}) do
+    %AssessmentPointEntryLog{}
+    |> AssessmentPointEntryLog.changeset(attrs)
+    |> Repo.insert()
+  end
+end

--- a/lib/lanttern/assessments_log/assessment_point_entry_log.ex
+++ b/lib/lanttern/assessments_log/assessment_point_entry_log.ex
@@ -1,0 +1,50 @@
+defmodule Lanttern.AssessmentsLog.AssessmentPointEntryLog do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @schema_prefix "log"
+  schema "assessment_point_entries" do
+    field :assessment_point_entry_id, :integer
+    field :profile_id, :integer
+    field :operation, :string
+    field :observation, :string
+    field :score, :float
+    field :assessment_point_id, :integer
+    field :student_id, :integer
+    field :ordinal_value_id, :integer
+    field :scale_id, :integer
+    field :scale_type, :string
+    field :differentiation_rubric_id, :integer
+    field :report_note, :string
+
+    timestamps(updated_at: false)
+  end
+
+  @doc false
+  def changeset(assessment_point_entry, attrs) do
+    assessment_point_entry
+    |> cast(attrs, [
+      :assessment_point_entry_id,
+      :profile_id,
+      :operation,
+      :observation,
+      :score,
+      :assessment_point_id,
+      :student_id,
+      :ordinal_value_id,
+      :scale_id,
+      :scale_type,
+      :differentiation_rubric_id,
+      :report_note
+    ])
+    |> validate_required([
+      :assessment_point_entry_id,
+      :profile_id,
+      :operation,
+      :assessment_point_id,
+      :student_id,
+      :scale_id,
+      :scale_type
+    ])
+  end
+end

--- a/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
@@ -6,7 +6,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
   alias Lanttern.Reporting
   alias Lanttern.Schools.Student
 
-  import LantternWeb.AssessmentsHelpers, only: [save_entry_editor_component_changes: 1]
+  import LantternWeb.AssessmentsHelpers, only: [save_entry_editor_component_changes: 2]
   import LantternWeb.PersonalizationHelpers, only: [assign_user_filters: 4]
 
   # shared components
@@ -351,8 +351,16 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
   end
 
   def handle_event("save_changes", _params, socket) do
+    %{
+      entries_changes_map: entries_changes_map,
+      current_user: current_user
+    } = socket.assigns
+
     socket =
-      case save_entry_editor_component_changes(socket.assigns.entries_changes_map) do
+      case save_entry_editor_component_changes(
+             entries_changes_map,
+             current_user.current_profile_id
+           ) do
         {:ok, msg} -> put_flash(socket, :info, msg)
         {:error, msg} -> put_flash(socket, :error, msg)
       end

--- a/lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex
@@ -4,7 +4,7 @@ defmodule LantternWeb.MomentLive.AssessmentComponent do
   alias Lanttern.Assessments
   alias Lanttern.Assessments.AssessmentPoint
 
-  import LantternWeb.AssessmentsHelpers, only: [save_entry_editor_component_changes: 1]
+  import LantternWeb.AssessmentsHelpers, only: [save_entry_editor_component_changes: 2]
   import LantternWeb.PersonalizationHelpers, only: [assign_user_filters: 4]
   import Lanttern.Utils, only: [swap: 3]
 
@@ -439,8 +439,16 @@ defmodule LantternWeb.MomentLive.AssessmentComponent do
 
   @impl true
   def handle_event("save_changes", _params, socket) do
+    %{
+      entries_changes_map: entries_changes_map,
+      current_user: current_user
+    } = socket.assigns
+
     socket =
-      case save_entry_editor_component_changes(socket.assigns.entries_changes_map) do
+      case save_entry_editor_component_changes(
+             entries_changes_map,
+             current_user.current_profile_id
+           ) do
         {:ok, msg} -> put_flash(socket, :info, msg)
         {:error, msg} -> put_flash(socket, :error, msg)
       end

--- a/priv/repo/migrations/20240416123611_create_assessment_point_entries.exs
+++ b/priv/repo/migrations/20240416123611_create_assessment_point_entries.exs
@@ -1,0 +1,33 @@
+defmodule Lanttern.Repo.Migrations.CreateAssessmentPointEntries do
+  use Ecto.Migration
+
+  @prefix "log"
+
+  def change do
+    execute "CREATE SCHEMA IF NOT EXISTS log", ""
+
+    create table(:assessment_point_entries, prefix: @prefix) do
+      add :assessment_point_entry_id, :bigint, null: false
+      add :profile_id, :bigint, null: false
+      add :operation, :text, null: false
+      add :observation, :text
+      add :score, :float
+      add :assessment_point_id, :bigint, null: false
+      add :student_id, :bigint, null: false
+      add :ordinal_value_id, :bigint
+      add :scale_id, :bigint, null: false
+      add :scale_type, :text, null: false
+      add :differentiation_rubric_id, :bigint
+      add :report_note, :text
+
+      timestamps(updated_at: false)
+    end
+
+    create constraint(
+             :assessment_point_entries,
+             :valid_operations,
+             prefix: @prefix,
+             check: "operation IN ('CREATE', 'UPDATE', 'DELETE')"
+           )
+  end
+end

--- a/priv/repo/migrations/20240416123611_create_assessment_point_entries_logs.exs
+++ b/priv/repo/migrations/20240416123611_create_assessment_point_entries_logs.exs
@@ -1,4 +1,4 @@
-defmodule Lanttern.Repo.Migrations.CreateAssessmentPointEntries do
+defmodule Lanttern.Repo.Migrations.CreateAssessmentPointEntriesLogs do
   use Ecto.Migration
 
   @prefix "log"

--- a/test/lanttern/assessments_log_test.exs
+++ b/test/lanttern/assessments_log_test.exs
@@ -1,0 +1,76 @@
+defmodule Lanttern.AssessmentsLogTest do
+  use Lanttern.DataCase
+
+  alias Lanttern.AssessmentsLog
+
+  describe "assessment_point_entries" do
+    alias Lanttern.AssessmentsLog.AssessmentPointEntryLog
+
+    import Lanttern.AssessmentsLogFixtures
+
+    @invalid_attrs %{
+      assessment_point_entry_id: nil,
+      profile_id: nil,
+      operation: nil,
+      observation: nil,
+      score: nil,
+      assessment_point_id: nil,
+      student_id: nil,
+      ordinal_value_id: nil,
+      scale_id: nil,
+      scale_type: nil,
+      differentiation_rubric_id: nil,
+      report_note: nil
+    }
+
+    test "list_assessment_point_entries_logs/0 returns all assessment_point_entries" do
+      assessment_point_entry_log = assessment_point_entry_log_fixture()
+      assert AssessmentsLog.list_assessment_point_entries_logs() == [assessment_point_entry_log]
+    end
+
+    test "get_assessment_point_entry_log!/1 returns the assessment_point_entry with given id" do
+      assessment_point_entry_log = assessment_point_entry_log_fixture()
+
+      assert AssessmentsLog.get_assessment_point_entry_log!(assessment_point_entry_log.id) ==
+               assessment_point_entry_log
+    end
+
+    test "create_assessment_point_entry_log/1 with valid data creates a assessment_point_entry" do
+      valid_attrs = %{
+        assessment_point_entry_id: 42,
+        profile_id: 42,
+        operation: "UPDATE",
+        observation: "some observation",
+        score: 120.5,
+        assessment_point_id: 42,
+        student_id: 42,
+        ordinal_value_id: 42,
+        scale_id: 42,
+        scale_type: "some scale_type",
+        differentiation_rubric_id: 42,
+        report_note: "some report_note"
+      }
+
+      assert {:ok, %AssessmentPointEntryLog{} = assessment_point_entry_log} =
+               AssessmentsLog.create_assessment_point_entry_log(valid_attrs)
+
+      assert assessment_point_entry_log.assessment_point_entry_id == 42
+      assert assessment_point_entry_log.profile_id == 42
+      assert assessment_point_entry_log.operation == "UPDATE"
+      assert assessment_point_entry_log.observation == "some observation"
+      assert assessment_point_entry_log.score == 120.5
+      assert assessment_point_entry_log.assessment_point_id == 42
+      assert assessment_point_entry_log.student_id == 42
+      assert assessment_point_entry_log.ordinal_value_id == 42
+      assert assessment_point_entry_log.scale_id == 42
+      assert assessment_point_entry_log.scale_type == "some scale_type"
+      assert assessment_point_entry_log.differentiation_rubric_id == 42
+      assert assessment_point_entry_log.report_note == "some report_note"
+    end
+
+    test "create_assessment_point_entry_log/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} =
+               AssessmentsLog.create_assessment_point_entry_log(@invalid_attrs)
+    end
+  end
+end

--- a/test/support/fixtures/assessments_fixtures.ex
+++ b/test/support/fixtures/assessments_fixtures.ex
@@ -91,4 +91,12 @@ defmodule Lanttern.AssessmentsFixtures do
 
   def maybe_gen_assessment_point_id(_attrs),
     do: assessment_point_fixture().id
+
+  def maybe_gen_assessment_point_entry_id(
+        %{assessment_point_entry_id: assessment_point_entry_id} = _attrs
+      ),
+      do: assessment_point_entry_id
+
+  def maybe_gen_assessment_point_entry_id(_attrs),
+    do: assessment_point_entry_fixture().id
 end

--- a/test/support/fixtures/assessments_log_fixtures.ex
+++ b/test/support/fixtures/assessments_log_fixtures.ex
@@ -1,0 +1,33 @@
+defmodule Lanttern.AssessmentsLogFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Lanttern.AssessmentsLog` context.
+  """
+
+  import Lanttern.AssessmentsFixtures
+  alias Lanttern.GradingFixtures
+  alias Lanttern.IdentityFixtures
+  alias Lanttern.SchoolsFixtures
+
+  @doc """
+  Generate a assessment_point_entry log.
+  """
+  def assessment_point_entry_log_fixture(attrs \\ %{}) do
+    scale = GradingFixtures.scale_fixture()
+
+    {:ok, assessment_point_entry_log} =
+      attrs
+      |> Enum.into(%{
+        assessment_point_entry_id: maybe_gen_assessment_point_entry_id(attrs),
+        assessment_point_id: maybe_gen_assessment_point_id(attrs),
+        operation: "CREATE",
+        profile_id: IdentityFixtures.maybe_gen_profile_id(attrs),
+        scale_id: attrs[:scale_id] || scale.id,
+        scale_type: attrs[:scale_type] || scale.type,
+        student_id: SchoolsFixtures.maybe_gen_student_id(attrs)
+      })
+      |> Lanttern.AssessmentsLog.create_assessment_point_entry_log()
+
+    assessment_point_entry_log
+  end
+end

--- a/test/support/fixtures/rubrics_fixtures.ex
+++ b/test/support/fixtures/rubrics_fixtures.ex
@@ -15,19 +15,13 @@ defmodule Lanttern.RubricsFixtures do
       attrs
       |> Enum.into(%{
         criteria: "some criteria",
-        scale_id: scale_id(attrs),
+        scale_id: GradingFixtures.maybe_gen_scale_id(attrs),
         is_differentiation: false
       })
       |> Lanttern.Rubrics.create_rubric()
 
     rubric
   end
-
-  defp scale_id(%{scale_id: scale_id} = _attrs),
-    do: scale_id
-
-  defp scale_id(_attrs),
-    do: GradingFixtures.scale_fixture().id
 
   @doc """
   Generate a rubric_descriptor.


### PR DESCRIPTION
adds some new functions and options to support assessment point entries create, update, and delete operations logging, which can help debugging future issues (see #139)