### PR TITLE
Adjusted students listing in report cards

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -23,6 +23,7 @@ module.exports = {
           },
           dark: colors.slate["700"],
           subtle: colors.slate["400"],
+          light: colors.slate["300"],
           lighter: colors.slate["200"],
           lightest: colors.slate["100"],
           mesh: {

--- a/lib/lanttern/personalization.ex
+++ b/lib/lanttern/personalization.ex
@@ -9,8 +9,10 @@ defmodule Lanttern.Personalization do
   alias Lanttern.Personalization.MomentNoteRelationship
   alias Lanttern.Personalization.Note
   alias Lanttern.Personalization.ProfileSettings
-  alias Lanttern.Personalization.ProfileView
   alias Lanttern.Personalization.StrandNoteRelationship
+  alias Lanttern.Personalization.ProfileView
+  alias Lanttern.Personalization.ProfileStrandFilter
+  alias Lanttern.Personalization.ProfileReportCardFilter
   alias Lanttern.Identity.User
   alias Lanttern.LearningContext.Moment
   alias Lanttern.LearningContext.Strand
@@ -551,8 +553,6 @@ defmodule Lanttern.Personalization do
     end
   end
 
-  alias Lanttern.Personalization.ProfileStrandFilter
-
   @doc """
   Returns the list of profile_strand_filters.
 
@@ -732,5 +732,105 @@ defmodule Lanttern.Personalization do
   """
   def change_profile_strand_filter(%ProfileStrandFilter{} = profile_strand_filter, attrs \\ %{}) do
     ProfileStrandFilter.changeset(profile_strand_filter, attrs)
+  end
+
+  @doc """
+  Returns the list of profile_report_card_filters.
+
+  ## Examples
+
+      iex> list_profile_report_card_filters()
+      [%ProfileReportCardFilter{}, ...]
+
+  """
+  def list_profile_report_card_filters do
+    Repo.all(ProfileReportCardFilter)
+  end
+
+  @doc """
+  Gets a single profile_report_card_filters.
+
+  Raises `Ecto.NoResultsError` if the Profile report card filters does not exist.
+
+  ## Examples
+
+      iex> get_profile_report_card_filters!(123)
+      %ProfileReportCardFilter{}
+
+      iex> get_profile_report_card_filters!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_profile_report_card_filters!(id), do: Repo.get!(ProfileReportCardFilter, id)
+
+  @doc """
+  Creates a profile_report_card_filters.
+
+  ## Examples
+
+      iex> create_profile_report_card_filters(%{field: value})
+      {:ok, %ProfileReportCardFilter{}}
+
+      iex> create_profile_report_card_filters(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_profile_report_card_filters(attrs \\ %{}) do
+    %ProfileReportCardFilter{}
+    |> ProfileReportCardFilter.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a profile_report_card_filters.
+
+  ## Examples
+
+      iex> update_profile_report_card_filters(profile_report_card_filters, %{field: new_value})
+      {:ok, %ProfileReportCardFilter{}}
+
+      iex> update_profile_report_card_filters(profile_report_card_filters, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_profile_report_card_filters(
+        %ProfileReportCardFilter{} = profile_report_card_filters,
+        attrs
+      ) do
+    profile_report_card_filters
+    |> ProfileReportCardFilter.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a profile_report_card_filters.
+
+  ## Examples
+
+      iex> delete_profile_report_card_filters(profile_report_card_filters)
+      {:ok, %ProfileReportCardFilter{}}
+
+      iex> delete_profile_report_card_filters(profile_report_card_filters)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_profile_report_card_filters(%ProfileReportCardFilter{} = profile_report_card_filters) do
+    Repo.delete(profile_report_card_filters)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking profile_report_card_filters changes.
+
+  ## Examples
+
+      iex> change_profile_report_card_filters(profile_report_card_filters)
+      %Ecto.Changeset{data: %ProfileReportCardFilter{}}
+
+  """
+  def change_profile_report_card_filters(
+        %ProfileReportCardFilter{} = profile_report_card_filters,
+        attrs \\ %{}
+      ) do
+    ProfileReportCardFilter.changeset(profile_report_card_filters, attrs)
   end
 end

--- a/lib/lanttern/personalization.ex
+++ b/lib/lanttern/personalization.ex
@@ -6,13 +6,14 @@ defmodule Lanttern.Personalization do
   import Ecto.Query, warn: false
   alias Lanttern.Repo
   import Lanttern.RepoHelpers
-  alias Lanttern.Personalization.Note
-  alias Lanttern.Personalization.StrandNoteRelationship
-  alias Lanttern.LearningContext.Strand
   alias Lanttern.Personalization.MomentNoteRelationship
-  alias Lanttern.LearningContext.Moment
-  alias Lanttern.Personalization.ProfileView
+  alias Lanttern.Personalization.Note
   alias Lanttern.Personalization.ProfileSettings
+  alias Lanttern.Personalization.ProfileView
+  alias Lanttern.Personalization.StrandNoteRelationship
+  alias Lanttern.Identity.User
+  alias Lanttern.LearningContext.Moment
+  alias Lanttern.LearningContext.Strand
 
   @doc """
   Returns the list of notes.
@@ -445,6 +446,8 @@ defmodule Lanttern.Personalization do
       {:error, %Ecto.Changeset{}}
 
   """
+  @spec set_profile_current_filters(User.t(), attrs :: map()) ::
+          {:ok, ProfileSettings.t()} | {:error, Ecto.Changeset.t()}
   def set_profile_current_filters(%{current_profile: %{id: profile_id}}, attrs \\ %{}),
     do: insert_settings_or_update_filters(get_profile_settings(profile_id), profile_id, attrs)
 

--- a/lib/lanttern/personalization/profile_report_card_filter.ex
+++ b/lib/lanttern/personalization/profile_report_card_filter.ex
@@ -1,0 +1,35 @@
+defmodule Lanttern.Personalization.ProfileReportCardFilter do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Lanttern.Identity.Profile
+  alias Lanttern.Reporting.ReportCard
+  alias Lanttern.Schools.Class
+
+  @type t :: %__MODULE__{
+          id: pos_integer(),
+          profile: Profile.t(),
+          profile_id: pos_integer(),
+          report_card: ReportCard.t(),
+          report_card_id: pos_integer(),
+          class: Class.t(),
+          class_id: pos_integer(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "profile_report_card_filters" do
+    belongs_to :profile, Profile
+    belongs_to :report_card, ReportCard
+    belongs_to :class, Class
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(profile_report_card_filter, attrs) do
+    profile_report_card_filter
+    |> cast(attrs, [:profile_id, :report_card_id, :class_id])
+    |> validate_required([:profile_id, :report_card_id, :class_id])
+  end
+end

--- a/lib/lanttern/personalization/profile_report_card_filter.ex
+++ b/lib/lanttern/personalization/profile_report_card_filter.ex
@@ -2,6 +2,8 @@ defmodule Lanttern.Personalization.ProfileReportCardFilter do
   use Ecto.Schema
   import Ecto.Changeset
 
+  import LantternWeb.Gettext
+
   alias Lanttern.Identity.Profile
   alias Lanttern.Reporting.ReportCard
   alias Lanttern.Schools.Class
@@ -14,6 +16,8 @@ defmodule Lanttern.Personalization.ProfileReportCardFilter do
           report_card_id: pos_integer(),
           class: Class.t(),
           class_id: pos_integer(),
+          linked_students_class: Class.t(),
+          linked_students_class_id: pos_integer(),
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -22,6 +26,7 @@ defmodule Lanttern.Personalization.ProfileReportCardFilter do
     belongs_to :profile, Profile
     belongs_to :report_card, ReportCard
     belongs_to :class, Class
+    belongs_to :linked_students_class, Class
 
     timestamps()
   end
@@ -29,7 +34,11 @@ defmodule Lanttern.Personalization.ProfileReportCardFilter do
   @doc false
   def changeset(profile_report_card_filter, attrs) do
     profile_report_card_filter
-    |> cast(attrs, [:profile_id, :report_card_id, :class_id])
-    |> validate_required([:profile_id, :report_card_id, :class_id])
+    |> cast(attrs, [:profile_id, :report_card_id, :class_id, :linked_students_class_id])
+    |> validate_required([:profile_id, :report_card_id])
+    |> check_constraint(:class_id,
+      name: :required_filter_value,
+      message: gettext("Filter value (class or linked students class) is required")
+    )
   end
 end

--- a/lib/lanttern/reporting.ex
+++ b/lib/lanttern/reporting.ex
@@ -425,54 +425,94 @@ defmodule Lanttern.Reporting do
   ## Options
 
   - `:classes_ids` - filter results by given classes
-  - `:only_with_report` - boolean, remove students without linked reports from results
 
   ## Examples
 
-      iex> list_students_for_report_card()
+      iex> list_students_with_report_card()
       [{%Student{}, %StudentReportCard{}}, ...]
 
   """
-  @spec list_students_for_report_card(integer(), Keyword.t()) :: [
+  @spec list_students_with_report_card(report_card_id :: pos_integer(), Keyword.t()) :: [
           {Student.t(), StudentReportCard.t() | nil}
         ]
-  def list_students_for_report_card(report_card_id, opts \\ []) do
+  def list_students_with_report_card(report_card_id, opts \\ []) do
     from(
       s in Student,
       left_join: c in assoc(s, :classes),
-      as: :class,
-      left_join: sr in StudentReportCard,
+      as: :classes,
+      join: sr in StudentReportCard,
       on: sr.student_id == s.id and sr.report_card_id == ^report_card_id,
-      as: :student_report_card,
       select: {s, sr},
       preload: [classes: c],
       order_by: [asc: c.name, asc: s.name]
     )
-    |> apply_list_students_for_report_card_opts(opts)
+    |> apply_list_students_with_report_card_opts(opts)
     |> Repo.all()
   end
 
-  defp apply_list_students_for_report_card_opts(queryable, []), do: queryable
+  defp apply_list_students_with_report_card_opts(queryable, []), do: queryable
 
-  defp apply_list_students_for_report_card_opts(queryable, [{:classes_ids, classes_ids} | opts])
+  defp apply_list_students_with_report_card_opts(queryable, [{:classes_ids, classes_ids} | opts])
        when is_list(classes_ids) and classes_ids != [] do
     from(
-      [s, class: c] in queryable,
+      [s, classes: c] in queryable,
       where: c.id in ^classes_ids
     )
-    |> apply_list_students_for_report_card_opts(opts)
+    |> apply_list_students_with_report_card_opts(opts)
   end
 
-  defp apply_list_students_for_report_card_opts(queryable, [{:only_with_report, true} | opts]) do
+  defp apply_list_students_with_report_card_opts(queryable, [_opt | opts]),
+    do: apply_list_students_with_report_card_opts(queryable, opts)
+
+  @doc """
+  Returns the list of all students not linked to
+  given base report card.
+
+  Results are ordered by class name, and them by student name.
+
+  ## Options
+
+  - `:classes_ids` - filter results by given classes
+
+  ## Examples
+
+      iex> list_students_without_report_card()
+      [%Student{}, ...]
+
+  """
+  @spec list_students_without_report_card(report_card_id :: pos_integer(), Keyword.t()) :: [
+          Student.t()
+        ]
+  def list_students_without_report_card(report_card_id, opts \\ []) do
     from(
-      [s, student_report_card: src] in queryable,
-      where: not is_nil(src)
+      s in Student,
+      left_join: c in assoc(s, :classes),
+      as: :classes,
+      left_join: sr in StudentReportCard,
+      on: sr.student_id == s.id and sr.report_card_id == ^report_card_id,
+      preload: [classes: c],
+      order_by: [asc: c.name, asc: s.name],
+      where: is_nil(sr)
     )
-    |> apply_list_students_for_report_card_opts(opts)
+    |> apply_list_students_without_report_card_opts(opts)
+    |> Repo.all()
   end
 
-  defp apply_list_students_for_report_card_opts(queryable, [_opt | opts]),
-    do: apply_list_students_for_report_card_opts(queryable, opts)
+  defp apply_list_students_without_report_card_opts(queryable, []), do: queryable
+
+  defp apply_list_students_without_report_card_opts(queryable, [
+         {:classes_ids, classes_ids} | opts
+       ])
+       when is_list(classes_ids) and classes_ids != [] do
+    from(
+      [s, classes: c] in queryable,
+      where: c.id in ^classes_ids
+    )
+    |> apply_list_students_without_report_card_opts(opts)
+  end
+
+  defp apply_list_students_without_report_card_opts(queryable, [_opt | opts]),
+    do: apply_list_students_without_report_card_opts(queryable, opts)
 
   @doc """
   Gets a single student report card.

--- a/lib/lanttern/reporting.ex
+++ b/lib/lanttern/reporting.ex
@@ -525,7 +525,7 @@ defmodule Lanttern.Reporting do
   @spec get_student_report_card_by_student_and_parent_report(
           student_id :: non_neg_integer(),
           report_card_id :: non_neg_integer()
-        ) :: StudentReportCard.t()
+        ) :: StudentReportCard.t() | nil
   def get_student_report_card_by_student_and_parent_report(student_id, report_card_id) do
     StudentReportCard
     |> Repo.get_by(student_id: student_id, report_card_id: report_card_id)

--- a/lib/lanttern/reporting.ex
+++ b/lib/lanttern/reporting.ex
@@ -15,6 +15,7 @@ defmodule Lanttern.Reporting do
   alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.Assessments.AssessmentPointEntry
   alias Lanttern.Schools
+  alias Lanttern.Schools.Class
   alias Lanttern.Schools.Cycle
   alias Lanttern.Schools.Student
 
@@ -713,6 +714,30 @@ defmodule Lanttern.Reporting do
       preload: [
         assessment_point: {ap, strand: s, curriculum_item: {ci, curriculum_component: cc}}
       ]
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Returns a list of all classes from students linked to given report card.
+
+  Useful for building report card linked students class filter.
+
+  ## Examples
+
+      iex> list_report_card_linked_students_classes(report_card_id)
+      [%Class{}, ...]
+
+  """
+  @spec list_report_card_linked_students_classes(report_card_id :: integer()) :: [Class.t()]
+  def list_report_card_linked_students_classes(report_card_id) do
+    from(c in Class,
+      left_join: y in assoc(c, :years),
+      join: s in assoc(c, :students),
+      join: src in assoc(s, :student_report_cards),
+      where: src.report_card_id == ^report_card_id,
+      group_by: c.id,
+      order_by: [asc: min(y.id), asc: c.name]
     )
     |> Repo.all()
   end

--- a/lib/lanttern/schools/student.ex
+++ b/lib/lanttern/schools/student.ex
@@ -5,6 +5,7 @@ defmodule Lanttern.Schools.Student do
 
   alias Lanttern.Repo
 
+  alias Lanttern.Reporting.StudentReportCard
   alias Lanttern.Rubrics.Rubric
   alias Lanttern.Schools.School
   alias Lanttern.Schools.Class
@@ -18,6 +19,7 @@ defmodule Lanttern.Schools.Student do
           school_id: pos_integer(),
           classes: [Class.t()],
           diff_rubrics: [Rubric.t()],
+          student_report_cards: [StudentReportCard.t()],
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
         }
@@ -35,6 +37,8 @@ defmodule Lanttern.Schools.Student do
       preload_order: [asc: :name]
 
     many_to_many :diff_rubrics, Rubric, join_through: "differentiation_rubrics_students"
+
+    has_many :student_report_cards, StudentReportCard
 
     timestamps()
   end

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -345,8 +345,10 @@ defmodule LantternWeb.CoreComponents do
   def empty_state(assigns) do
     ~H"""
     <div class={["text-center", @class]}>
-      <div class="p-10">
+      <div class="relative p-10">
         <div class="animate-pulse h-24 w-24 rounded-full mx-auto bg-ltrn-lighter blur-md"></div>
+        <div class="absolute top-1/2 left-1/2 h-20 w-20 -mt-10 -ml-10 rounded-full border border-dashed border-ltrn-light">
+        </div>
       </div>
       <%!-- <div class="relative flex h-16 w-16 mx-auto">
         <span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-ltrn-primary opacity-75 blur-[2px]">

--- a/lib/lanttern_web/helpers/live_component_helpers.ex
+++ b/lib/lanttern_web/helpers/live_component_helpers.ex
@@ -7,6 +7,7 @@ defmodule LantternWeb.LiveComponentHelpers do
   Send notification to parent or component based on
   `:notify_parent` and `:notify_component` assigns.
   """
+  @spec notify(module :: atom(), msg :: any(), assigns :: map()) :: any()
   def notify(module, msg, %{notify_parent: true}),
     do: send(self(), {module, msg})
 

--- a/lib/lanttern_web/helpers/personalization_helpers.ex
+++ b/lib/lanttern_web/helpers/personalization_helpers.ex
@@ -15,6 +15,7 @@ defmodule LantternWeb.PersonalizationHelpers do
   ## Supported opts
 
   - `:strand_id` - will get the contextualized strand filters. supports `:classes` type
+  - `:report_card_id` - will get the contextualized report card filters. supports `:classes` type
 
   ## Filter types and assigns
 
@@ -59,6 +60,13 @@ defmodule LantternWeb.PersonalizationHelpers do
   defp get_current_filters(profile_id, strand_id: strand_id) do
     classes_ids =
       Personalization.list_profile_strand_filters_classes_ids(profile_id, strand_id)
+
+    %{classes_ids: classes_ids}
+  end
+
+  defp get_current_filters(profile_id, report_card_id: report_card_id) do
+    classes_ids =
+      Personalization.list_profile_report_card_filter_classes_ids(profile_id, report_card_id)
 
     %{classes_ids: classes_ids}
   end
@@ -189,6 +197,7 @@ defmodule LantternWeb.PersonalizationHelpers do
   ## Supported opts
 
   - `:strand_id` - will persist data in the strand context. supports `:classes` type
+  - `:report_card_id` - will persist data in the report card context. supports `:classes` type
 
   ## Supported types
 
@@ -224,6 +233,7 @@ defmodule LantternWeb.PersonalizationHelpers do
   ## Supported opts
 
   - `:strand_id` - will persist data in the strand context. supports `:classes` type
+  - `:report_card_id` - will persist data in the report card context. supports `:classes` type
 
   ## Supported types
 
@@ -258,6 +268,9 @@ defmodule LantternWeb.PersonalizationHelpers do
 
   defp apply_save_profile_filters(current_user, attrs, strand_id: strand_id),
     do: Personalization.set_profile_strand_filters(current_user, strand_id, attrs)
+
+  defp apply_save_profile_filters(current_user, attrs, report_card_id: report_card_id),
+    do: Personalization.set_profile_report_card_filters(current_user, report_card_id, attrs)
 
   defp apply_save_profile_filters(current_user, attrs, _),
     do: Personalization.set_profile_current_filters(current_user, attrs)

--- a/lib/lanttern_web/helpers/personalization_helpers.ex
+++ b/lib/lanttern_web/helpers/personalization_helpers.ex
@@ -4,6 +4,7 @@ defmodule LantternWeb.PersonalizationHelpers do
   alias Lanttern.Personalization
 
   alias Lanttern.Identity.User
+  alias Lanttern.Reporting
   alias Lanttern.Schools
   alias Lanttern.Taxonomy
 
@@ -15,7 +16,7 @@ defmodule LantternWeb.PersonalizationHelpers do
   ## Supported opts
 
   - `:strand_id` - will get the contextualized strand filters. supports `:classes` type
-  - `:report_card_id` - will get the contextualized report card filters. supports `:classes` type
+  - `:report_card_id` - will get the contextualized report card filters. supports `:classes` and `:linked_students_classes` types
 
   ## Filter types and assigns
 
@@ -43,6 +44,12 @@ defmodule LantternWeb.PersonalizationHelpers do
   - `:selected_classes_ids`
   - `:selected_classes`
 
+  ### `:linked_students_classes`' assigns
+
+  - `:linked_students_classes`
+  - `:selected_linked_students_classes_ids`
+  - `:selected_linked_students_classes`
+
   ## Examples
 
       iex> assign_user_filters(socket, [:subjects], user)
@@ -54,7 +61,7 @@ defmodule LantternWeb.PersonalizationHelpers do
     current_filters = get_current_filters(current_user.current_profile_id, opts)
 
     socket
-    |> assign_filter_type(current_user, current_filters, filter_types)
+    |> assign_filter_type(current_user, current_filters, filter_types, opts)
   end
 
   defp get_current_filters(profile_id, strand_id: strand_id) do
@@ -64,12 +71,8 @@ defmodule LantternWeb.PersonalizationHelpers do
     %{classes_ids: classes_ids}
   end
 
-  defp get_current_filters(profile_id, report_card_id: report_card_id) do
-    classes_ids =
-      Personalization.list_profile_report_card_filter_classes_ids(profile_id, report_card_id)
-
-    %{classes_ids: classes_ids}
-  end
+  defp get_current_filters(profile_id, report_card_id: report_card_id),
+    do: Personalization.list_profile_report_card_filters(profile_id, report_card_id)
 
   defp get_current_filters(profile_id, _) do
     case Personalization.get_profile_settings(profile_id) do
@@ -78,9 +81,9 @@ defmodule LantternWeb.PersonalizationHelpers do
     end
   end
 
-  defp assign_filter_type(socket, _current_user, _current_filters, []), do: socket
+  defp assign_filter_type(socket, _current_user, _current_filters, [], _opts), do: socket
 
-  defp assign_filter_type(socket, current_user, current_filters, [:subjects | filter_types]) do
+  defp assign_filter_type(socket, current_user, current_filters, [:subjects | filter_types], opts) do
     subjects =
       Taxonomy.list_subjects()
       |> translate_struct_list("taxonomy", :name, reorder: true)
@@ -92,10 +95,10 @@ defmodule LantternWeb.PersonalizationHelpers do
     |> assign(:subjects, subjects)
     |> assign(:selected_subjects_ids, selected_subjects_ids)
     |> assign(:selected_subjects, selected_subjects)
-    |> assign_filter_type(current_user, current_filters, filter_types)
+    |> assign_filter_type(current_user, current_filters, filter_types, opts)
   end
 
-  defp assign_filter_type(socket, current_user, current_filters, [:years | filter_types]) do
+  defp assign_filter_type(socket, current_user, current_filters, [:years | filter_types], opts) do
     years =
       Taxonomy.list_years()
       |> translate_struct_list("taxonomy")
@@ -107,10 +110,10 @@ defmodule LantternWeb.PersonalizationHelpers do
     |> assign(:years, years)
     |> assign(:selected_years_ids, selected_years_ids)
     |> assign(:selected_years, selected_years)
-    |> assign_filter_type(current_user, current_filters, filter_types)
+    |> assign_filter_type(current_user, current_filters, filter_types, opts)
   end
 
-  defp assign_filter_type(socket, current_user, current_filters, [:cycles | filter_types]) do
+  defp assign_filter_type(socket, current_user, current_filters, [:cycles | filter_types], opts) do
     cycles =
       Schools.list_cycles(schools_ids: [current_user.current_profile.school_id])
 
@@ -121,10 +124,10 @@ defmodule LantternWeb.PersonalizationHelpers do
     |> assign(:cycles, cycles)
     |> assign(:selected_cycles_ids, selected_cycles_ids)
     |> assign(:selected_cycles, selected_cycles)
-    |> assign_filter_type(current_user, current_filters, filter_types)
+    |> assign_filter_type(current_user, current_filters, filter_types, opts)
   end
 
-  defp assign_filter_type(socket, current_user, current_filters, [:classes | filter_types]) do
+  defp assign_filter_type(socket, current_user, current_filters, [:classes | filter_types], opts) do
     classes =
       Schools.list_user_classes(current_user)
 
@@ -135,24 +138,46 @@ defmodule LantternWeb.PersonalizationHelpers do
     |> assign(:classes, classes)
     |> assign(:selected_classes_ids, selected_classes_ids)
     |> assign(:selected_classes, selected_classes)
-    |> assign_filter_type(current_user, current_filters, filter_types)
+    |> assign_filter_type(current_user, current_filters, filter_types, opts)
   end
 
-  defp assign_filter_type(socket, current_user, current_filters, [_ | filter_types]),
-    do: assign_filter_type(socket, current_user, current_filters, filter_types)
+  defp assign_filter_type(
+         socket,
+         current_user,
+         current_filters,
+         [:linked_students_classes | filter_types],
+         [report_card_id: report_card_id] = opts
+       ) do
+    classes =
+      Reporting.list_report_card_linked_students_classes(report_card_id)
+
+    selected_classes_ids = Map.get(current_filters, :linked_students_classes_ids) || []
+    selected_classes = Enum.filter(classes, &(&1.id in selected_classes_ids))
+
+    socket
+    |> assign(:linked_students_classes, classes)
+    |> assign(:selected_linked_students_classes_ids, selected_classes_ids)
+    |> assign(:selected_linked_students_classes, selected_classes)
+    |> assign_filter_type(current_user, current_filters, filter_types, opts)
+  end
+
+  defp assign_filter_type(socket, current_user, current_filters, [_ | filter_types], opts),
+    do: assign_filter_type(socket, current_user, current_filters, filter_types, opts)
 
   @type_to_type_ids_key_map %{
     subjects: :subjects_ids,
     years: :years_ids,
     cycles: :cycles_ids,
-    classes: :classes_ids
+    classes: :classes_ids,
+    linked_students_classes: :linked_students_classes_ids
   }
 
   @type_to_selected_ids_key_map %{
     subjects: :selected_subjects_ids,
     years: :selected_years_ids,
     cycles: :selected_cycles_ids,
-    classes: :selected_classes_ids
+    classes: :selected_classes_ids,
+    linked_students_classes: :selected_linked_students_classes_ids
   }
 
   @doc """

--- a/lib/lanttern_web/live/pages/admin/rubric_live/form_component.ex
+++ b/lib/lanttern_web/live/pages/admin/rubric_live/form_component.ex
@@ -43,7 +43,7 @@ defmodule LantternWeb.Admin.RubricLive.FormComponent do
 
   attr :scale, :map, required: true
   attr :field, :map, required: true
-  attr :myself, :any, required: true
+  attr :myself, Phoenix.LiveComponent.CID, required: true
 
   defp descriptors_fields(%{scale: nil} = assigns) do
     ~H"""

--- a/lib/lanttern_web/live/pages/grading/grades_report_grid_setup_overlay_component.ex
+++ b/lib/lanttern_web/live/pages/grading/grades_report_grid_setup_overlay_component.ex
@@ -96,7 +96,7 @@ defmodule LantternWeb.ReportCardLive.GradesReportGridSetupOverlayComponent do
 
   attr :id, :string, required: true
   attr :grades_report_cycle, GradesReportCycle, required: true
-  attr :myself, :any, required: true
+  attr :myself, Phoenix.LiveComponent.CID, required: true
 
   def grades_report_cycle_form(assigns) do
     form =

--- a/lib/lanttern_web/live/pages/report_cards/id/grades_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/grades_component.ex
@@ -105,7 +105,7 @@ defmodule LantternWeb.ReportCardLive.GradesComponent do
   attr :grade_component, GradeComponent, required: true
   attr :index, :integer, required: true
   attr :is_last, :boolean, required: true
-  attr :myself, :any, required: true
+  attr :myself, Phoenix.LiveComponent.CID, required: true
 
   def grade_component_form(assigns) do
     form =

--- a/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
@@ -21,7 +21,7 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
     ~H"""
     <div class="pt-10 pb-20">
       <.responsive_container>
-        <div :if={@has_students_in_report_card} class="mb-10">
+        <div class="mb-10">
           <p class="font-display font-bold text-2xl">
             <%= gettext("Students linked to this report card") %>
           </p>
@@ -30,18 +30,26 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
             id="linked-students-classes-filter"
             filter_items={@linked_students_classes}
             selected_items_ids={@selected_linked_students_classes_ids}
-            class="mt-2"
+            class="mt-4"
             notify_component={@myself}
           />
-          <div phx-update="stream" id="other-students-and-report-cards">
-            <.student_and_report_card_row
-              :for={{dom_id, {student, student_report_card}} <- @streams.students_in_report_card}
-              id={dom_id}
-              report_card_id={@report_card.id}
-              student={student}
-              student_report_card={student_report_card}
-            />
-          </div>
+          <%= if @has_students_in_report_card do %>
+            <div phx-update="stream" id="other-students-and-report-cards">
+              <.student_and_report_card_row
+                :for={{dom_id, {student, student_report_card}} <- @streams.students_in_report_card}
+                id={dom_id}
+                report_card_id={@report_card.id}
+                student={student}
+                student_report_card={student_report_card}
+              />
+            </div>
+          <% else %>
+            <div class="p-10 mt-4 rounded shadow-xl bg-white">
+              <.empty_state>
+                <%= gettext("No students linked to this report card yet") %>
+              </.empty_state>
+            </div>
+          <% end %>
         </div>
         <%= if @selected_classes != [] do %>
           <p class="font-display font-bold text-2xl">
@@ -277,9 +285,6 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
       |> save_profile_filters(
         socket.assigns.current_user,
         [:linked_students_classes],
-        report_card_id: socket.assigns.report_card.id
-      )
-      |> assign_user_filters([:classes, :linked_students_classes], socket.assigns.current_user,
         report_card_id: socket.assigns.report_card.id
       )
       |> stream_students_report_cards(force: true)

--- a/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
@@ -1,11 +1,14 @@
 defmodule LantternWeb.ReportCardLive.StudentsComponent do
   use LantternWeb, :live_component
 
-  alias Lanttern.Personalization
+  alias Phoenix.LiveView.LiveStream
+
   alias Lanttern.Reporting
   alias Lanttern.Reporting.StudentReportCard
   alias Lanttern.Schools
   alias Lanttern.Schools.Student
+
+  import LantternWeb.PersonalizationHelpers, only: [assign_user_filters: 3]
 
   # shared components
   alias LantternWeb.Reporting.StudentReportCardFormComponent
@@ -15,46 +18,13 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
     ~H"""
     <div class="pt-10 pb-20">
       <.responsive_container>
-        <div class="flex items-end justify-between gap-6">
+        <div :if={@has_students_in_report_card} class="mb-10">
           <p class="font-display font-bold text-2xl">
-            <%= gettext("Viewing") %>
-            <button
-              type="button"
-              class="inline text-left underline hover:text-ltrn-subtle"
-              phx-click={JS.exec("data-show", to: "#classes-filter-overlay")}
-            >
-              <%= if length(@classes) > 0 do
-                @classes
-                |> Enum.map(& &1.name)
-                |> Enum.join(", ")
-              else
-                gettext("all classes")
-              end %>
-            </button>
-          </p>
-        </div>
-        <div phx-update="stream" id="students-and-report-cards">
-          <.student_and_report_card_row
-            :for={{dom_id, {student, student_report_card}} <- @streams.students_and_report_cards}
-            id={dom_id}
-            report_card_id={@report_card.id}
-            student={student}
-            student_report_card={student_report_card}
-            on_click={
-              JS.push("toggle_student_id", value: %{"student_id" => student.id}, target: @myself)
-              |> JS.toggle_class("outline outline-4 outline-ltrn-dark", to: "##{dom_id}")
-            }
-          />
-        </div>
-        <div :if={@has_other_students_and_report_cards} class="mt-10">
-          <p class="font-display font-bold text-xl text-ltrn-subtle">
-            <%= gettext("Other students linked to this report card") %>
+            <%= gettext("Students linked to this report card") %>
           </p>
           <div phx-update="stream" id="other-students-and-report-cards">
             <.student_and_report_card_row
-              :for={
-                {dom_id, {student, student_report_card}} <- @streams.other_students_and_report_cards
-              }
+              :for={{dom_id, {student, student_report_card}} <- @streams.students_in_report_card}
               id={dom_id}
               report_card_id={@report_card.id}
               student={student}
@@ -62,10 +32,43 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
             />
           </div>
         </div>
+        <%= if @selected_classes != [] do %>
+          <p class="font-display font-bold text-2xl">
+            <%= gettext("Link students from") %>
+            <button
+              type="button"
+              class="inline text-left underline hover:text-ltrn-subtle"
+              phx-click={JS.exec("data-show", to: "#classes-filter-modal")}
+            >
+              <%= @selected_classes
+              |> Enum.map(& &1.name)
+              |> Enum.join(", ") %>
+            </button>
+            <%= gettext("to this report card") %>
+          </p>
+        <% else %>
+          <p class="font-display font-bold text-2xl">
+            <button
+              type="button"
+              class="underline hover:text-ltrn-subtle"
+              phx-click={JS.exec("data-show", to: "#classes-filter-modal")}
+            >
+              <%= gettext("Select a class") %>
+            </button>
+            <%= gettext("to view students assessments") %>
+          </p>
+        <% end %>
+        <.other_students_list
+          has_selected_class={@selected_classes_ids != []}
+          has_other_students={@has_other_students}
+          students_stream={@streams.other_students}
+          report_card_id={@report_card.id}
+          myself={@myself}
+        />
       </.responsive_container>
       <.live_component
         module={LantternWeb.Personalization.FiltersOverlayComponent}
-        id="classes-filter-overlay"
+        id="classes-filter-modal"
         current_user={@current_user}
         title={gettext("Select classes")}
         filter_type={:classes}
@@ -142,6 +145,48 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
     """
   end
 
+  attr :has_selected_class, :boolean, required: true
+  attr :has_other_students, :boolean, required: true
+  attr :students_stream, LiveStream, required: true
+  attr :report_card_id, :integer, required: true
+  attr :myself, :any, required: true
+
+  def other_students_list(%{has_selected_class: false} = assigns) do
+    ~H"""
+    <div class="p-10 mt-4 rounded shadow-xl bg-white">
+      <.empty_state><%= gettext("No results") %></.empty_state>
+    </div>
+    """
+  end
+
+  def other_students_list(%{has_other_students: false} = assigns) do
+    ~H"""
+    <div class="p-10 mt-4 rounded shadow-xl bg-white">
+      <.empty_state>
+        <%= gettext("All students from selected classes are already linked to this report card") %>
+      </.empty_state>
+    </div>
+    """
+  end
+
+  def other_students_list(assigns) do
+    ~H"""
+    <div phx-update="stream" id="students-and-report-cards">
+      <.student_and_report_card_row
+        :for={{dom_id, student} <- @students_stream}
+        id={dom_id}
+        report_card_id={@report_card_id}
+        student={student}
+        student_report_card={nil}
+        on_click={
+          JS.push("toggle_student_id", value: %{"student_id" => student.id}, target: @myself)
+          |> JS.toggle_class("outline outline-4 outline-ltrn-dark", to: "##{dom_id}")
+        }
+      />
+    </div>
+    """
+  end
+
   attr :id, :string, required: true
   attr :report_card_id, :string, required: true
   attr :student, Student, required: true
@@ -204,11 +249,7 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
     socket =
       socket
       |> stream_configure(
-        :students_and_report_cards,
-        dom_id: fn {student, _} -> "student-#{student.id}" end
-      )
-      |> stream_configure(
-        :other_students_and_report_cards,
+        :students_in_report_card,
         dom_id: fn {student, _} -> "student-#{student.id}" end
       )
       |> assign(:selected_students_ids, [])
@@ -221,22 +262,7 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
     socket =
       socket
       |> assign(assigns)
-      |> assign_new(:classes, fn ->
-        case Personalization.get_profile_settings(assigns.current_user.current_profile_id) do
-          %{current_filters: %{classes_ids: classes_ids}} when is_list(classes_ids) ->
-            Schools.list_user_classes(
-              assigns.current_user,
-              classes_ids: classes_ids
-            )
-
-          _ ->
-            []
-        end
-      end)
-      |> assign_new(:classes_ids, fn %{classes: classes} ->
-        classes
-        |> Enum.map(& &1.id)
-      end)
+      |> assign_user_filters([:classes], assigns.current_user)
       |> stream_students_report_cards()
       |> assign_show_student_report_card_form(assigns)
 
@@ -250,37 +276,38 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
   defp stream_students_report_cards(socket, opts \\ [force: false])
 
   defp stream_students_report_cards(
-         %{assigns: %{streams: %{students_and_report_cards: _}}} = socket,
+         %{assigns: %{streams: %{students_in_report_card: _}}} = socket,
          force: false
        ),
        do: socket
 
   defp stream_students_report_cards(socket, _) do
-    students_and_report_cards =
-      Reporting.list_students_for_report_card(
-        socket.assigns.report_card.id,
-        classes_ids: socket.assigns.classes_ids
-      )
-
-    students_ids =
-      students_and_report_cards
-      |> Enum.map(fn {student, _} -> student.id end)
-
-    # list all students linked to this report card
-    # and remove the ones already present in students_and_report_cards list
-    other_students_and_report_cards =
+    students_in_report_card =
       Reporting.list_students_for_report_card(
         socket.assigns.report_card.id,
         only_with_report: true
       )
-      |> Enum.filter(fn {student, _} -> student.id not in students_ids end)
 
-    has_other_students_and_report_cards = length(other_students_and_report_cards) > 0
+    has_students_in_report_card = length(students_in_report_card) > 0
+
+    # list students for current classes filters,
+    # and remove the ones already in `students_in_report_card`
+
+    students_ids =
+      students_in_report_card
+      |> Enum.map(fn {student, _} -> student.id end)
+
+    other_students =
+      Schools.list_students(classes_ids: socket.assigns.selected_classes_ids)
+      |> Enum.filter(&(&1.id not in students_ids))
+
+    has_other_students = length(other_students) > 0
 
     socket
-    |> stream(:students_and_report_cards, students_and_report_cards, reset: true)
-    |> stream(:other_students_and_report_cards, other_students_and_report_cards, reset: true)
-    |> assign(:has_other_students_and_report_cards, has_other_students_and_report_cards)
+    |> stream(:students_in_report_card, students_in_report_card, reset: true)
+    |> assign(:has_students_in_report_card, has_students_in_report_card)
+    |> stream(:other_students, other_students, reset: true)
+    |> assign(:has_other_students, has_other_students)
   end
 
   defp assign_show_student_report_card_form(socket, %{

--- a/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
@@ -55,7 +55,7 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
             >
               <%= gettext("Select a class") %>
             </button>
-            <%= gettext("to view students assessments") %>
+            <%= gettext("to list students") %>
           </p>
         <% end %>
         <.other_students_list

--- a/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
@@ -8,7 +8,7 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
   alias Lanttern.Schools
   alias Lanttern.Schools.Student
 
-  import LantternWeb.PersonalizationHelpers, only: [assign_user_filters: 3]
+  import LantternWeb.PersonalizationHelpers, only: [assign_user_filters: 4]
 
   # shared components
   alias LantternWeb.Reporting.StudentReportCardFormComponent
@@ -72,6 +72,7 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
         current_user={@current_user}
         title={gettext("Select classes")}
         filter_type={:classes}
+        filter_opts={[report_card_id: @report_card.id]}
         navigate={~p"/report_cards/#{@report_card}"}
       />
       <.slide_over
@@ -262,7 +263,9 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
     socket =
       socket
       |> assign(assigns)
-      |> assign_user_filters([:classes], assigns.current_user)
+      |> assign_user_filters([:classes], assigns.current_user,
+        report_card_id: assigns.report_card.id
+      )
       |> stream_students_report_cards()
       |> assign_show_student_report_card_form(assigns)
 

--- a/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
@@ -22,6 +22,17 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
           <p class="font-display font-bold text-2xl">
             <%= gettext("Students linked to this report card") %>
           </p>
+          <div class="flex flex-wrap gap-2 mt-2">
+            <.badge_button theme="primary" icon_name="hero-check-mini">
+              <%= gettext("All classes") %>
+            </.badge_button>
+            <.badge_button
+              :for={class <- @linked_students_classes}
+              id={"linked-student-class-#{class.id}"}
+            >
+              <%= class.name %>
+            </.badge_button>
+          </div>
           <div phx-update="stream" id="other-students-and-report-cards">
             <.student_and_report_card_row
               :for={{dom_id, {student, student_report_card}} <- @streams.students_in_report_card}
@@ -266,6 +277,9 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
       |> assign_user_filters([:classes], assigns.current_user,
         report_card_id: assigns.report_card.id
       )
+      |> assign_new(:linked_students_classes, fn ->
+        Reporting.list_report_card_linked_students_classes(assigns.report_card.id)
+      end)
       |> stream_students_report_cards()
       |> assign_show_student_report_card_form(assigns)
 

--- a/lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex
@@ -169,8 +169,6 @@ defmodule LantternWeb.ReportCardLive.StudentsGradesComponent do
       |> assign_is_editing_student_grade_report_entry(assigns)
       |> assign_students_grades_grid()
 
-    IO.inspect(socket.assigns.current_grades_report_cycle, label: "current_grades_report_cycle")
-
     {:ok, socket}
   end
 

--- a/lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex
@@ -4,8 +4,6 @@ defmodule LantternWeb.ReportCardLive.StudentsGradesComponent do
   alias Lanttern.GradesReports
   alias Lanttern.Schools
 
-  import LantternWeb.PersonalizationHelpers
-
   # shared
   alias LantternWeb.GradesReports.StudentGradeReportEntryFormComponent
   import LantternWeb.ReportingComponents
@@ -14,41 +12,25 @@ defmodule LantternWeb.ReportCardLive.StudentsGradesComponent do
   @impl true
   def render(assigns) do
     ~H"""
-    <div class="py-10">
-      <%= if @selected_classes == [] do %>
+    <div>
+      <div :if={@grades_report} class="py-10">
         <div class="container mx-auto lg:max-w-5xl">
-          <p class="font-display font-bold text-2xl">
-            <%= gettext("Select a") %>
-            <button
-              type="button"
-              class="inline text-left underline hover:text-ltrn-subtle"
-              phx-click={JS.exec("data-show", to: "#students-grades-filters")}
-            >
-              <%= gettext("class") %>
-            </button>
-            <%= gettext("to view students grades") %>
+          <h5 class="font-display font-bold text-2xl">
+            <%= gettext("Students grades") %>
+          </h5>
+          <p class="mt-2">
+            <%= gettext("View grades reports for all students linked in the students tab.") %>
           </p>
         </div>
-      <% else %>
-        <div :if={@grades_report}>
-          <div class="container mx-auto lg:max-w-5xl">
-            <p class="font-display font-bold text-2xl">
-              <%= gettext("Viewing") %>
-              <button
-                type="button"
-                class="inline text-left underline hover:text-ltrn-subtle"
-                phx-click={JS.exec("data-show", to: "#students-grades-filters")}
-              >
-                <%= if length(@selected_classes) > 0 do
-                  @selected_classes
-                  |> Enum.map(& &1.name)
-                  |> Enum.join(", ")
-                else
-                  gettext("all classes")
-                end %>
-              </button>
-            </p>
+        <%= if @students == [] do %>
+          <div class="container mx-auto mt-4 lg:max-w-5xl">
+            <div class="p-10 rounded shadow-xl bg-white">
+              <.empty_state>
+                <%= gettext("Add students to report card to view grades") %>
+              </.empty_state>
+            </div>
           </div>
+        <% else %>
           <div class="p-6">
             <.students_grades_grid
               students={@students}
@@ -91,74 +73,74 @@ defmodule LantternWeb.ReportCardLive.StudentsGradesComponent do
               }
             />
           </div>
-        </div>
-      <% end %>
-      <.slide_over
-        :if={@is_editing_student_grade_report_entry}
-        id="student-grades-report-entry-overlay"
-        show={true}
-        on_cancel={JS.patch(~p"/report_cards/#{@report_card}?tab=grades")}
-      >
-        <:title><%= gettext("Edit student grade report entry") %></:title>
-        <.metadata class="mb-4" icon_name="hero-user">
-          <%= @student_grade_report_entry.student.name %>
-        </.metadata>
-        <.metadata class="mb-4" icon_name="hero-bookmark">
-          <%= @student_grade_report_entry.grades_report_subject.subject.name %>
-        </.metadata>
-        <.metadata class="mb-4" icon_name="hero-calendar">
-          <%= @student_grade_report_entry.grades_report_cycle.school_cycle.name %>
-        </.metadata>
+        <% end %>
+        <.slide_over
+          :if={@is_editing_student_grade_report_entry}
+          id="student-grades-report-entry-overlay"
+          show={true}
+          on_cancel={JS.patch(~p"/report_cards/#{@report_card}?tab=grades")}
+        >
+          <:title><%= gettext("Edit student grade report entry") %></:title>
+          <.metadata class="mb-4" icon_name="hero-user">
+            <%= @student_grade_report_entry.student.name %>
+          </.metadata>
+          <.metadata class="mb-4" icon_name="hero-bookmark">
+            <%= @student_grade_report_entry.grades_report_subject.subject.name %>
+          </.metadata>
+          <.metadata class="mb-4" icon_name="hero-calendar">
+            <%= @student_grade_report_entry.grades_report_cycle.school_cycle.name %>
+          </.metadata>
+          <.live_component
+            module={StudentGradeReportEntryFormComponent}
+            id={@student_grade_report_entry.id}
+            student_grade_report_entry={@student_grade_report_entry}
+            scale_id={@grades_report.scale_id}
+            navigate={~p"/report_cards/#{@report_card}?tab=grades"}
+            hide_submit
+          />
+          <div class="py-10">
+            <h6 class="font-display font-bold"><%= gettext("Grade composition") %></h6>
+            <p class="mt-4 mb-6 text-sm">
+              <%= gettext(
+                "Lanttern automatic grade calculation info based on configured grade composition"
+              ) %> (<%= Timex.local(@student_grade_report_entry.composition_datetime)
+              |> Timex.format!("{0D}/{0M}/{YYYY} {h24}:{m}") %>).
+            </p>
+            <.grade_composition_table student_grade_report_entry={@student_grade_report_entry} />
+          </div>
+          <:actions_left>
+            <.button
+              type="button"
+              theme="ghost"
+              phx-click="delete_student_grade_report_entry"
+              phx-target={@myself}
+              data-confirm={gettext("Are you sure?")}
+            >
+              <%= gettext("Delete") %>
+            </.button>
+          </:actions_left>
+          <:actions>
+            <.button
+              type="button"
+              theme="ghost"
+              phx-click={JS.exec("data-cancel", to: "#student-grades-report-entry-overlay")}
+            >
+              <%= gettext("Cancel") %>
+            </.button>
+            <.button type="submit" form="student-grade-report-entry-form">
+              <%= gettext("Save") %>
+            </.button>
+          </:actions>
+        </.slide_over>
         <.live_component
-          module={StudentGradeReportEntryFormComponent}
-          id={@student_grade_report_entry.id}
-          student_grade_report_entry={@student_grade_report_entry}
-          scale_id={@grades_report.scale_id}
+          module={LantternWeb.Personalization.FiltersOverlayComponent}
+          id="students-grades-filters"
+          current_user={@current_user}
+          title={gettext("Students grades filter")}
+          filter_type={:classes}
           navigate={~p"/report_cards/#{@report_card}?tab=grades"}
-          hide_submit
         />
-        <div class="py-10">
-          <h6 class="font-display font-bold"><%= gettext("Grade composition") %></h6>
-          <p class="mt-4 mb-6 text-sm">
-            <%= gettext(
-              "Lanttern automatic grade calculation info based on configured grade composition"
-            ) %> (<%= Timex.local(@student_grade_report_entry.composition_datetime)
-            |> Timex.format!("{0D}/{0M}/{YYYY} {h24}:{m}") %>).
-          </p>
-          <.grade_composition_table student_grade_report_entry={@student_grade_report_entry} />
-        </div>
-        <:actions_left>
-          <.button
-            type="button"
-            theme="ghost"
-            phx-click="delete_student_grade_report_entry"
-            phx-target={@myself}
-            data-confirm={gettext("Are you sure?")}
-          >
-            <%= gettext("Delete") %>
-          </.button>
-        </:actions_left>
-        <:actions>
-          <.button
-            type="button"
-            theme="ghost"
-            phx-click={JS.exec("data-cancel", to: "#student-grades-report-entry-overlay")}
-          >
-            <%= gettext("Cancel") %>
-          </.button>
-          <.button type="submit" form="student-grade-report-entry-form">
-            <%= gettext("Save") %>
-          </.button>
-        </:actions>
-      </.slide_over>
-      <.live_component
-        module={LantternWeb.Personalization.FiltersOverlayComponent}
-        id="students-grades-filters"
-        current_user={@current_user}
-        title={gettext("Students grades filter")}
-        filter_type={:classes}
-        navigate={~p"/report_cards/#{@report_card}?tab=grades"}
-      />
+      </div>
     </div>
     """
   end
@@ -185,8 +167,9 @@ defmodule LantternWeb.ReportCardLive.StudentsGradesComponent do
           |> Enum.find(&(&1.school_cycle_id == report_card.school_cycle_id))
       end)
       |> assign_is_editing_student_grade_report_entry(assigns)
-      |> assign_user_filters([:classes], assigns.current_user)
       |> assign_students_grades_grid()
+
+    IO.inspect(socket.assigns.current_grades_report_cycle, label: "current_grades_report_cycle")
 
     {:ok, socket}
   end
@@ -223,7 +206,7 @@ defmodule LantternWeb.ReportCardLive.StudentsGradesComponent do
 
   defp assign_students_grades_grid(socket) do
     students =
-      Schools.list_students(classes_ids: socket.assigns.selected_classes_ids)
+      Schools.list_students(report_card_id: socket.assigns.report_card.id)
 
     students_grades_map =
       case socket.assigns.grades_report do

--- a/lib/lanttern_web/live/pages/strands/id/moments_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/moments_component.ex
@@ -109,7 +109,7 @@ defmodule LantternWeb.StrandLive.MomentsComponent do
 
   attr :sortable_moments, :list, required: true
   attr :moments_count, :integer, required: true
-  attr :myself, :any, required: true
+  attr :myself, Phoenix.LiveComponent.CID, required: true
 
   def reorder_overlay(assigns) do
     ~H"""

--- a/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
@@ -196,7 +196,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
   attr :student, Student, required: true
   attr :entries, :list, required: true
   attr :scale_ov_map, :map, required: true
-  attr :myself, :any, required: true
+  attr :myself, Phoenix.LiveComponent.CID, required: true
 
   def student_entries(assigns) do
     ~H"""

--- a/lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex
@@ -290,7 +290,7 @@ defmodule LantternWeb.MomentLive.AssessmentComponent do
   attr :id, :string, required: true
   attr :student, Lanttern.Schools.Student, required: true
   attr :entries, :list, required: true
-  attr :myself, :any, required: true
+  attr :myself, Phoenix.LiveComponent.CID, required: true
 
   def student_and_entries(assigns) do
     ~H"""

--- a/lib/lanttern_web/live/shared/personalization/filters_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/personalization/filters_overlay_component.ex
@@ -39,7 +39,7 @@ defmodule LantternWeb.Personalization.FiltersOverlayComponent do
   end
 
   attr :type, :string, required: true
-  attr :myself, :any, required: true
+  attr :myself, Phoenix.LiveComponent.CID, required: true
   attr :items, :list, required: true
   attr :selected_ids, :list, required: true
 

--- a/lib/lanttern_web/live/shared/personalization/inline_filters_component.ex
+++ b/lib/lanttern_web/live/shared/personalization/inline_filters_component.ex
@@ -1,0 +1,142 @@
+defmodule LantternWeb.Personalization.InlineFiltersComponent do
+  @moduledoc """
+  Renders an inline filter component based on the list of items and selected ids
+  from `LantternWeb.PersonalizationHelpers.assign_user_filters/4`.
+
+  This component receives the inital state from the parent view/component,
+  but handles its own internal state (selected items).
+  """
+
+  use LantternWeb, :live_component
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class={["flex flex-wrap gap-2", @class]}>
+      <.badge_button
+        id={"#{@id}-all"}
+        phx-click={JS.push("toggle_all", target: @myself)}
+        {get_select_all_attrs(@selected_items_ids)}
+      >
+        <%= gettext("All") %>
+      </.badge_button>
+      <.badge_button
+        :for={item <- @filter_items}
+        id={"#{@id}-#{item.id}"}
+        phx-click={JS.push("toggle_filter", value: %{"id" => item.id}, target: @myself)}
+        {get_filter_attrs(item.id, @selected_items_ids)}
+      >
+        <%= item.name %>
+      </.badge_button>
+      <.badge_button :if={@has_changes} theme="dark" phx-click="apply_filters" phx-target={@myself}>
+        <%= gettext("Apply filters") %>
+      </.badge_button>
+    </div>
+    """
+  end
+
+  defp get_select_all_attrs(selected_items_ids) do
+    case selected_items_ids do
+      [] ->
+        %{
+          theme: "primary",
+          icon_name: "hero-check-mini"
+        }
+
+      _ ->
+        %{
+          theme: nil,
+          icon_name: nil
+        }
+    end
+  end
+
+  defp get_filter_attrs(item_id, selected_items_ids) do
+    case item_id in selected_items_ids do
+      true ->
+        %{
+          theme: "primary",
+          icon_name: "hero-check-mini"
+        }
+
+      _ ->
+        %{
+          theme: nil,
+          icon_name: nil
+        }
+    end
+  end
+
+  # lifecycle
+
+  @impl true
+  def mount(socket) do
+    socket =
+      socket
+      |> assign(:class, nil)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(:initial_selected_items_ids, assigns.selected_items_ids)
+      |> assign(:has_changes, false)
+
+    {:ok, socket}
+  end
+
+  # event handlers
+
+  @impl true
+  def handle_event("toggle_all", _params, socket) do
+    socket =
+      socket
+      |> assign(:selected_items_ids, [])
+      |> assign(:has_changes, check_if_has_changes(socket.assigns.initial_selected_items_ids, []))
+
+    {:noreply, socket}
+  end
+
+  def handle_event("toggle_filter", %{"id" => id}, socket) do
+    selected_items_ids =
+      case id in socket.assigns.selected_items_ids do
+        true ->
+          socket.assigns.selected_items_ids
+          |> Enum.filter(&(&1 != id))
+
+        false ->
+          [id | socket.assigns.selected_items_ids]
+      end
+
+    socket =
+      socket
+      |> assign(:selected_items_ids, selected_items_ids)
+      |> assign(
+        :has_changes,
+        check_if_has_changes(socket.assigns.initial_selected_items_ids, selected_items_ids)
+      )
+
+    {:noreply, socket}
+  end
+
+  def handle_event("apply_filters", _params, socket) do
+    notify(__MODULE__, {:apply, socket.assigns.selected_items_ids}, socket.assigns)
+
+    {:noreply, socket}
+  end
+
+  defp check_if_has_changes([], []), do: false
+  defp check_if_has_changes([], _current_selected_ids), do: true
+  defp check_if_has_changes(_initial_selected_ids, []), do: true
+
+  defp check_if_has_changes(initial_selected_ids, current_selected_ids) do
+    is_same_length = length(initial_selected_ids) == length(current_selected_ids)
+    has_same_items = Enum.all?(initial_selected_ids, &(&1 in current_selected_ids))
+
+    not is_same_length or not has_same_items
+  end
+end

--- a/lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex
+++ b/lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex
@@ -62,7 +62,7 @@ defmodule LantternWeb.Rubrics.RubricFormComponent do
 
   attr :scale, :map, required: true
   attr :field, :map, required: true
-  attr :myself, :any, required: true
+  attr :myself, Phoenix.LiveComponent.CID, required: true
 
   defp descriptors_fields(%{scale: nil} = assigns) do
     ~H"""

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2024.4.15-alpha.12",
+      version: "2024.4.24-alpha.13",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1213
-#: lib/lanttern_web/components/core_components.ex:1275
+#: lib/lanttern_web/components/core_components.ex:1215
+#: lib/lanttern_web/components/core_components.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -58,9 +58,9 @@ msgstr ""
 msgid "Strands"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:473
+#: lib/lanttern_web/components/core_components.ex:475
 #: lib/lanttern_web/components/overlay_components.ex:78
-#: lib/lanttern_web/components/overlay_components.ex:327
+#: lib/lanttern_web/components/overlay_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -106,8 +106,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:125
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:173
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:111
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:147
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:114
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:85
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:166
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:93
@@ -162,8 +162,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:128
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:176
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:150
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:88
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
@@ -313,17 +313,17 @@ msgstr ""
 msgid "or drag and drop here"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:512
+#: lib/lanttern_web/components/core_components.ex:514
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:503
+#: lib/lanttern_web/components/core_components.ex:505
 #, elixir-autogen, elixir-format
 msgid "Error!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:524
+#: lib/lanttern_web/components/core_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Hang in there while we get back on track"
 msgstr ""
@@ -333,22 +333,22 @@ msgstr ""
 msgid "Markdown supported"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:502
+#: lib/lanttern_web/components/core_components.ex:504
 #, elixir-autogen, elixir-format
 msgid "Success!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:507
+#: lib/lanttern_web/components/core_components.ex:509
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:519
+#: lib/lanttern_web/components/core_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:375
+#: lib/lanttern_web/components/core_components.ex:377
 #, elixir-autogen, elixir-format
 msgid "all %{type}"
 msgstr ""
@@ -385,8 +385,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:87
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:59
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:102
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:138
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:105
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:119
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:74
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:244
@@ -451,8 +451,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:85
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:112
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:100
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:136
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:103
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:117
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:29
@@ -495,7 +495,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/learning_context_components.ex:51
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:183
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:228
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:63
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:52
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:281
@@ -558,6 +558,7 @@ msgstr ""
 msgid "Save updated order"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:56
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
@@ -586,8 +587,6 @@ msgstr ""
 msgid "Understood. Delete anyway"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:20
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:36
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:20
 #, elixir-autogen, elixir-format
 msgid "Viewing"
@@ -760,7 +759,7 @@ msgstr ""
 msgid "Move assessment point up"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:462
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:470
 #, elixir-autogen, elixir-format
 msgid "This assessment point already have some entries. Deleting it will cause data loss."
 msgstr ""
@@ -852,7 +851,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1163
+#: lib/lanttern_web/components/core_components.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -885,10 +884,10 @@ msgstr ""
 #: lib/lanttern/learning_context.ex:443
 #: lib/lanttern/repo_helpers.ex:111
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:271
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:302
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:338
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:370
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:353
 #, elixir-autogen, elixir-format
 msgid "Something went wrong"
 msgstr ""
@@ -923,28 +922,28 @@ msgstr ""
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:425
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:408
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no assessment point entries)"
 msgid_plural "%{count} grades skipped (no assessment point entries)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:409
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:392
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:419
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:402
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:414
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:397
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1060,7 +1059,7 @@ msgstr ""
 msgid "Component"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:192
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:237
 #, elixir-autogen, elixir-format
 msgid "Create"
 msgstr ""
@@ -1085,7 +1084,7 @@ msgstr ""
 msgid "Create strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:303
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:330
 #, elixir-autogen, elixir-format
 msgid "Create student report card"
 msgstr ""
@@ -1191,12 +1190,12 @@ msgstr ""
 msgid "Edit strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:102
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:83
 #, elixir-autogen, elixir-format
 msgid "Edit student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:322
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:349
 #, elixir-autogen, elixir-format
 msgid "Edit student report card"
 msgstr ""
@@ -1236,12 +1235,12 @@ msgstr ""
 msgid "Error deleting strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:391
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:374
 #, elixir-autogen, elixir-format
 msgid "Error deleting student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:385
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:412
 #, elixir-autogen, elixir-format
 msgid "Error deleting student report card"
 msgstr ""
@@ -1282,12 +1281,12 @@ msgstr ""
 msgid "Final strand goals assessment for"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:366
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:349
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:121
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:102
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Grade composition"
@@ -1309,7 +1308,7 @@ msgstr ""
 msgid "Grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:263
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:246
 #, elixir-autogen, elixir-format
 msgid "Grades calculated succesfully"
 msgstr ""
@@ -1370,7 +1369,7 @@ msgstr ""
 msgid "Item"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:123
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:104
 #, elixir-autogen, elixir-format
 msgid "Lanttern automatic grade calculation info based on configured grade composition"
 msgstr ""
@@ -1425,7 +1424,7 @@ msgstr ""
 msgid "Move moment card up"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1153
+#: lib/lanttern_web/components/core_components.ex:1155
 #: lib/lanttern_web/live/pages/report_cards/id/grades_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1441,7 +1440,7 @@ msgstr ""
 msgid "No assesment points in this grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:361
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:344
 #, elixir-autogen, elixir-format
 msgid "No assessment point entries for this grade composition"
 msgstr ""
@@ -1522,14 +1521,14 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:271
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:302
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:338
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
 #, elixir-autogen, elixir-format
 msgid "Partial results"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:175
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:220
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
@@ -1618,11 +1617,6 @@ msgstr ""
 msgid "Save student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:21
-#, elixir-autogen, elixir-format
-msgid "Select a"
-msgstr ""
-
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:25
 #, elixir-autogen, elixir-format
 msgid "Select a level"
@@ -1703,7 +1697,7 @@ msgstr ""
 msgid "Student grade report entry created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:383
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:366
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry deleted"
 msgstr ""
@@ -1713,7 +1707,7 @@ msgstr ""
 msgid "Student grade report entry updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:294
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:277
 #, elixir-autogen, elixir-format
 msgid "Student grades calculated succesfully"
 msgstr ""
@@ -1724,7 +1718,7 @@ msgstr ""
 msgid "Student report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:377
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:404
 #, elixir-autogen, elixir-format
 msgid "Student report card deleted"
 msgstr ""
@@ -1734,7 +1728,7 @@ msgstr ""
 msgid "Students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:158
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:139
 #, elixir-autogen, elixir-format
 msgid "Students grades filter"
 msgstr ""
@@ -1749,7 +1743,7 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:330
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:313
 #, elixir-autogen, elixir-format
 msgid "Subject grades calculated succesfully"
 msgstr ""
@@ -1800,12 +1794,6 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:31
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:47
-#, elixir-autogen, elixir-format
-msgid "all classes"
-msgstr ""
-
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "all subjects"
@@ -1821,19 +1809,9 @@ msgstr ""
 msgid "and"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:27
-#, elixir-autogen, elixir-format
-msgid "class"
-msgstr ""
-
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "cycles"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:29
-#, elixir-autogen, elixir-format
-msgid "to view students grades"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:53
@@ -1856,7 +1834,7 @@ msgstr ""
 msgid "Not linked to strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:70
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:73
 #, elixir-autogen, elixir-format
 msgid "Select classes"
 msgstr ""
@@ -1938,21 +1916,21 @@ msgstr ""
 msgid "Report information"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:121
+#: lib/lanttern_web/helpers/assessments_helpers.ex:128
 #, elixir-autogen, elixir-format
 msgid "1 entry created"
 msgid_plural "%{count} entries created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:131
+#: lib/lanttern_web/helpers/assessments_helpers.ex:138
 #, elixir-autogen, elixir-format
 msgid "1 entry removed"
 msgid_plural "%{count} entries removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:126
+#: lib/lanttern_web/helpers/assessments_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "1 entry updated"
 msgid_plural "%{count} entries updated"
@@ -1965,54 +1943,54 @@ msgstr[1] ""
 msgid "Discard"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:70
+#: lib/lanttern_web/helpers/assessments_helpers.ex:74
 #, elixir-autogen, elixir-format
 msgid "Error creating assessment point entry"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:87
+#: lib/lanttern_web/helpers/assessments_helpers.ex:93
 #, elixir-autogen, elixir-format
 msgid "Error deleting assessment point entry"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:104
+#: lib/lanttern_web/helpers/assessments_helpers.ex:111
 #, elixir-autogen, elixir-format
 msgid "Error updating assessment point entry"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:47
+#: lib/lanttern_web/helpers/assessments_helpers.ex:49
 #, elixir-autogen, elixir-format
 msgid "Results so far"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:90
-#: lib/lanttern_web/helpers/assessments_helpers.ex:107
+#: lib/lanttern_web/helpers/assessments_helpers.ex:96
+#: lib/lanttern_web/helpers/assessments_helpers.ex:114
 #, elixir-autogen, elixir-format
 msgid "The entry does not exist anymore"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:456
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:483
 #, elixir-autogen, elixir-format
 msgid "1 report creation failed"
 msgid_plural "%{count} reports creation failed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:445
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:472
 #, elixir-autogen, elixir-format
 msgid "1 student report card created"
 msgid_plural "%{count} students report cards created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:120
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
 #, elixir-autogen, elixir-format
 msgid "1 student selected"
 msgid_plural "%{count} students selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:451
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "1 student skipped"
 msgid_plural "%{count} students skipped"
@@ -2029,12 +2007,12 @@ msgstr ""
 msgid "Assessment points explorer"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:135
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:138
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:138
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:141
 #, elixir-autogen, elixir-format
 msgid "Create for selected"
 msgstr ""
@@ -2044,13 +2022,8 @@ msgstr ""
 msgid "Hey!"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:51
-#, elixir-autogen, elixir-format
-msgid "Other students linked to this report card"
-msgstr ""
-
-#: lib/lanttern_web/components/core_components.ex:902
-#: lib/lanttern_web/components/core_components.ex:924
+#: lib/lanttern_web/components/core_components.ex:904
+#: lib/lanttern_web/components/core_components.ex:926
 #, elixir-autogen, elixir-format
 msgid "Selected"
 msgstr ""
@@ -2167,7 +2140,7 @@ msgstr ""
 msgid "Privacy policy and terms of service"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:185
+#: lib/lanttern_web/live/shared/menu_component.ex:186
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr ""
@@ -2175,4 +2148,49 @@ msgstr ""
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:17
 #, elixir-autogen, elixir-format
 msgid "terms of service"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:29
+#, elixir-autogen, elixir-format
+msgid "Add students to report card to view grades"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:166
+#, elixir-autogen, elixir-format
+msgid "All students from selected classes are already linked to this report card"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:37
+#, elixir-autogen, elixir-format
+msgid "Link students from"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:157
+#, elixir-autogen, elixir-format
+msgid "No results"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:19
+#, elixir-autogen, elixir-format
+msgid "Students grades"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:23
+#, elixir-autogen, elixir-format
+msgid "Students linked to this report card"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:22
+#, elixir-autogen, elixir-format
+msgid "View grades reports for all students linked in the students tab."
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
+#, elixir-autogen, elixir-format
+msgid "to list students"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:47
+#, elixir-autogen, elixir-format
+msgid "to this report card"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -92,6 +92,7 @@ msgid "All strands"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/personalization/filters_overlay_component.ex:32
+#: lib/lanttern_web/live/shared/personalization/inline_filters_component.ex:32
 #, elixir-autogen, elixir-format
 msgid "Apply filters"
 msgstr ""
@@ -106,7 +107,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:125
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:173
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:114
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:85
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:166
@@ -162,7 +163,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:128
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:176
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:129
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:88
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
@@ -385,7 +386,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:87
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:59
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:105
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:119
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:74
@@ -451,7 +452,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:85
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:112
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:103
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:115
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:117
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
@@ -495,7 +496,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/learning_context_components.ex:51
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:228
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:240
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:63
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:52
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:281
@@ -558,7 +559,7 @@ msgstr ""
 msgid "Save updated order"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:56
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:67
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
@@ -884,10 +885,10 @@ msgstr ""
 #: lib/lanttern/learning_context.ex:443
 #: lib/lanttern/repo_helpers.ex:111
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:353
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:351
 #, elixir-autogen, elixir-format
 msgid "Something went wrong"
 msgstr ""
@@ -922,28 +923,28 @@ msgstr ""
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:408
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:406
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no assessment point entries)"
 msgid_plural "%{count} grades skipped (no assessment point entries)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:392
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:390
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:402
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:400
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:397
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:395
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Component"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:237
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:249
 #, elixir-autogen, elixir-format
 msgid "Create"
 msgstr ""
@@ -1084,7 +1085,7 @@ msgstr ""
 msgid "Create strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:330
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:364
 #, elixir-autogen, elixir-format
 msgid "Create student report card"
 msgstr ""
@@ -1195,7 +1196,7 @@ msgstr ""
 msgid "Edit student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:349
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "Edit student report card"
 msgstr ""
@@ -1235,12 +1236,12 @@ msgstr ""
 msgid "Error deleting strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:374
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:372
 #, elixir-autogen, elixir-format
 msgid "Error deleting student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:412
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "Error deleting student report card"
 msgstr ""
@@ -1281,7 +1282,7 @@ msgstr ""
 msgid "Final strand goals assessment for"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:349
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:347
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
 msgstr ""
@@ -1308,7 +1309,7 @@ msgstr ""
 msgid "Grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:246
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:244
 #, elixir-autogen, elixir-format
 msgid "Grades calculated succesfully"
 msgstr ""
@@ -1440,7 +1441,7 @@ msgstr ""
 msgid "No assesment points in this grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:344
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:342
 #, elixir-autogen, elixir-format
 msgid "No assessment point entries for this grade composition"
 msgstr ""
@@ -1521,14 +1522,14 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
 #, elixir-autogen, elixir-format
 msgid "Partial results"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:220
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:232
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
@@ -1697,7 +1698,7 @@ msgstr ""
 msgid "Student grade report entry created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:366
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:364
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry deleted"
 msgstr ""
@@ -1707,7 +1708,7 @@ msgstr ""
 msgid "Student grade report entry updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:277
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:275
 #, elixir-autogen, elixir-format
 msgid "Student grades calculated succesfully"
 msgstr ""
@@ -1718,7 +1719,7 @@ msgstr ""
 msgid "Student report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:404
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "Student report card deleted"
 msgstr ""
@@ -1743,7 +1744,7 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:313
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:311
 #, elixir-autogen, elixir-format
 msgid "Subject grades calculated succesfully"
 msgstr ""
@@ -1834,7 +1835,7 @@ msgstr ""
 msgid "Not linked to strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:73
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:84
 #, elixir-autogen, elixir-format
 msgid "Select classes"
 msgstr ""
@@ -1969,28 +1970,28 @@ msgstr ""
 msgid "The entry does not exist anymore"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:483
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:517
 #, elixir-autogen, elixir-format
 msgid "1 report creation failed"
 msgid_plural "%{count} reports creation failed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:472
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:506
 #, elixir-autogen, elixir-format
 msgid "1 student report card created"
 msgid_plural "%{count} students report cards created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:135
 #, elixir-autogen, elixir-format
 msgid "1 student selected"
 msgid_plural "%{count} students selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:478
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:512
 #, elixir-autogen, elixir-format
 msgid "1 student skipped"
 msgid_plural "%{count} students skipped"
@@ -2007,12 +2008,12 @@ msgstr ""
 msgid "Assessment points explorer"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:138
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:150
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:141
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:153
 #, elixir-autogen, elixir-format
 msgid "Create for selected"
 msgstr ""
@@ -2155,17 +2156,17 @@ msgstr ""
 msgid "Add students to report card to view grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:166
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:178
 #, elixir-autogen, elixir-format
 msgid "All students from selected classes are already linked to this report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:37
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:48
 #, elixir-autogen, elixir-format
 msgid "Link students from"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:157
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:169
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr ""
@@ -2175,7 +2176,7 @@ msgstr ""
 msgid "Students grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:23
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:26
 #, elixir-autogen, elixir-format
 msgid "Students linked to this report card"
 msgstr ""
@@ -2185,12 +2186,22 @@ msgstr ""
 msgid "View grades reports for all students linked in the students tab."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:69
 #, elixir-autogen, elixir-format
 msgid "to list students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:47
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
 #, elixir-autogen, elixir-format
 msgid "to this report card"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/personalization/inline_filters_component.ex:21
+#, elixir-autogen, elixir-format
+msgid "All"
+msgstr ""
+
+#: lib/lanttern/personalization/profile_report_card_filter.ex:41
+#, elixir-autogen, elixir-format
+msgid "Filter value (class or linked students class) is required"
 msgstr ""

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -107,8 +107,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:125
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:173
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:126
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:134
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:140
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:85
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:166
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:93
@@ -163,8 +163,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:128
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:176
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:129
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:137
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:143
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:88
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
@@ -386,8 +386,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:87
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:59
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:119
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:125
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:74
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:244
@@ -452,8 +452,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:85
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:112
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:115
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:117
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:129
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:29
@@ -496,7 +496,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/learning_context_components.ex:51
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:240
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:248
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:63
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:52
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:281
@@ -559,7 +559,7 @@ msgstr ""
 msgid "Save updated order"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:67
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:75
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
@@ -885,10 +885,10 @@ msgstr ""
 #: lib/lanttern/learning_context.ex:443
 #: lib/lanttern/repo_helpers.ex:111
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:284
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:315
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:351
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "Something went wrong"
 msgstr ""
@@ -923,28 +923,28 @@ msgstr ""
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:406
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no assessment point entries)"
 msgid_plural "%{count} grades skipped (no assessment point entries)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:390
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:422
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:400
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:432
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:395
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1060,7 +1060,7 @@ msgstr ""
 msgid "Component"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:249
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:257
 #, elixir-autogen, elixir-format
 msgid "Create"
 msgstr ""
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "Create strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:364
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:369
 #, elixir-autogen, elixir-format
 msgid "Create student report card"
 msgstr ""
@@ -1191,12 +1191,12 @@ msgstr ""
 msgid "Edit strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:83
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:95
 #, elixir-autogen, elixir-format
 msgid "Edit student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:383
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:388
 #, elixir-autogen, elixir-format
 msgid "Edit student report card"
 msgstr ""
@@ -1236,12 +1236,12 @@ msgstr ""
 msgid "Error deleting strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:372
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:404
 #, elixir-autogen, elixir-format
 msgid "Error deleting student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:446
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:451
 #, elixir-autogen, elixir-format
 msgid "Error deleting student report card"
 msgstr ""
@@ -1282,12 +1282,12 @@ msgstr ""
 msgid "Final strand goals assessment for"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:347
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:379
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:102
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:114
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Grade composition"
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:244
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:276
 #, elixir-autogen, elixir-format
 msgid "Grades calculated succesfully"
 msgstr ""
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Item"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:104
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:116
 #, elixir-autogen, elixir-format
 msgid "Lanttern automatic grade calculation info based on configured grade composition"
 msgstr ""
@@ -1441,7 +1441,7 @@ msgstr ""
 msgid "No assesment points in this grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:342
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:374
 #, elixir-autogen, elixir-format
 msgid "No assessment point entries for this grade composition"
 msgstr ""
@@ -1522,14 +1522,14 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:284
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:315
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:351
 #, elixir-autogen, elixir-format
 msgid "Partial results"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:232
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:240
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
@@ -1698,7 +1698,7 @@ msgstr ""
 msgid "Student grade report entry created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:364
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:396
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry deleted"
 msgstr ""
@@ -1708,7 +1708,7 @@ msgstr ""
 msgid "Student grade report entry updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:275
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:307
 #, elixir-autogen, elixir-format
 msgid "Student grades calculated succesfully"
 msgstr ""
@@ -1719,7 +1719,7 @@ msgstr ""
 msgid "Student report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:438
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:443
 #, elixir-autogen, elixir-format
 msgid "Student report card deleted"
 msgstr ""
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "Students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:139
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:151
 #, elixir-autogen, elixir-format
 msgid "Students grades filter"
 msgstr ""
@@ -1744,7 +1744,7 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:311
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:343
 #, elixir-autogen, elixir-format
 msgid "Subject grades calculated succesfully"
 msgstr ""
@@ -1835,7 +1835,7 @@ msgstr ""
 msgid "Not linked to strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:84
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:92
 #, elixir-autogen, elixir-format
 msgid "Select classes"
 msgstr ""
@@ -1970,28 +1970,28 @@ msgstr ""
 msgid "The entry does not exist anymore"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:517
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:522
 #, elixir-autogen, elixir-format
 msgid "1 report creation failed"
 msgid_plural "%{count} reports creation failed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:506
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:511
 #, elixir-autogen, elixir-format
 msgid "1 student report card created"
 msgid_plural "%{count} students report cards created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:135
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:143
 #, elixir-autogen, elixir-format
 msgid "1 student selected"
 msgid_plural "%{count} students selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:512
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:517
 #, elixir-autogen, elixir-format
 msgid "1 student skipped"
 msgid_plural "%{count} students skipped"
@@ -2008,12 +2008,12 @@ msgstr ""
 msgid "Assessment points explorer"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:150
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:158
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:153
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:161
 #, elixir-autogen, elixir-format
 msgid "Create for selected"
 msgstr ""
@@ -2151,27 +2151,27 @@ msgstr ""
 msgid "terms of service"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:29
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Add students to report card to view grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:178
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:186
 #, elixir-autogen, elixir-format
 msgid "All students from selected classes are already linked to this report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:48
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:56
 #, elixir-autogen, elixir-format
 msgid "Link students from"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:169
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:19
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:23
 #, elixir-autogen, elixir-format
 msgid "Students grades"
 msgstr ""
@@ -2181,17 +2181,17 @@ msgstr ""
 msgid "Students linked to this report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:22
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:26
 #, elixir-autogen, elixir-format
 msgid "View grades reports for all students linked in the students tab."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:69
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:77
 #, elixir-autogen, elixir-format
 msgid "to list students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:66
 #, elixir-autogen, elixir-format
 msgid "to this report card"
 msgstr ""
@@ -2204,4 +2204,9 @@ msgstr ""
 #: lib/lanttern/personalization/profile_report_card_filter.ex:41
 #, elixir-autogen, elixir-format
 msgid "Filter value (class or linked students class) is required"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:49
+#, elixir-autogen, elixir-format
+msgid "No students linked to this report card yet"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,8 +11,8 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/lanttern_web/components/core_components.ex:1213
-#: lib/lanttern_web/components/core_components.ex:1275
+#: lib/lanttern_web/components/core_components.ex:1215
+#: lib/lanttern_web/components/core_components.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -58,9 +58,9 @@ msgstr ""
 msgid "Strands"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:473
+#: lib/lanttern_web/components/core_components.ex:475
 #: lib/lanttern_web/components/overlay_components.ex:78
-#: lib/lanttern_web/components/overlay_components.ex:327
+#: lib/lanttern_web/components/overlay_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr ""
@@ -106,8 +106,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:125
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:173
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:111
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:147
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:114
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:85
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:166
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:93
@@ -162,8 +162,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:128
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:176
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:150
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:88
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
@@ -313,17 +313,17 @@ msgstr ""
 msgid "or drag and drop here"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:512
+#: lib/lanttern_web/components/core_components.ex:514
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:503
+#: lib/lanttern_web/components/core_components.ex:505
 #, elixir-autogen, elixir-format
 msgid "Error!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:524
+#: lib/lanttern_web/components/core_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Hang in there while we get back on track"
 msgstr ""
@@ -333,22 +333,22 @@ msgstr ""
 msgid "Markdown supported"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:502
+#: lib/lanttern_web/components/core_components.ex:504
 #, elixir-autogen, elixir-format
 msgid "Success!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:507
+#: lib/lanttern_web/components/core_components.ex:509
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:519
+#: lib/lanttern_web/components/core_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:375
+#: lib/lanttern_web/components/core_components.ex:377
 #, elixir-autogen, elixir-format
 msgid "all %{type}"
 msgstr ""
@@ -385,8 +385,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:87
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:59
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:102
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:138
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:105
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:119
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:74
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:244
@@ -451,8 +451,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:85
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:112
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:100
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:136
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:103
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:117
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:29
@@ -495,7 +495,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/learning_context_components.ex:51
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:183
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:228
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:63
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:52
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:281
@@ -558,6 +558,7 @@ msgstr ""
 msgid "Save updated order"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:56
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
@@ -586,8 +587,6 @@ msgstr ""
 msgid "Understood. Delete anyway"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:20
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:36
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:20
 #, elixir-autogen, elixir-format
 msgid "Viewing"
@@ -760,7 +759,7 @@ msgstr ""
 msgid "Move assessment point up"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:462
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:470
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This assessment point already have some entries. Deleting it will cause data loss."
 msgstr ""
@@ -852,7 +851,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1163
+#: lib/lanttern_web/components/core_components.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -885,10 +884,10 @@ msgstr ""
 #: lib/lanttern/learning_context.ex:443
 #: lib/lanttern/repo_helpers.ex:111
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:271
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:302
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:338
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:370
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:353
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Something went wrong"
 msgstr ""
@@ -923,28 +922,28 @@ msgstr ""
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:425
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:408
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no assessment point entries)"
 msgid_plural "%{count} grades skipped (no assessment point entries)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:409
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:392
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:419
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:402
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:414
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:397
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1060,7 +1059,7 @@ msgstr ""
 msgid "Component"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:192
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:237
 #, elixir-autogen, elixir-format
 msgid "Create"
 msgstr ""
@@ -1085,7 +1084,7 @@ msgstr ""
 msgid "Create strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:303
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:330
 #, elixir-autogen, elixir-format
 msgid "Create student report card"
 msgstr ""
@@ -1191,12 +1190,12 @@ msgstr ""
 msgid "Edit strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:102
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:83
 #, elixir-autogen, elixir-format
 msgid "Edit student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:322
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:349
 #, elixir-autogen, elixir-format
 msgid "Edit student report card"
 msgstr ""
@@ -1236,12 +1235,12 @@ msgstr ""
 msgid "Error deleting strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:391
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:374
 #, elixir-autogen, elixir-format
 msgid "Error deleting student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:385
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:412
 #, elixir-autogen, elixir-format
 msgid "Error deleting student report card"
 msgstr ""
@@ -1282,12 +1281,12 @@ msgstr ""
 msgid "Final strand goals assessment for"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:366
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:349
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:121
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:102
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Grade composition"
@@ -1309,7 +1308,7 @@ msgstr ""
 msgid "Grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:263
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:246
 #, elixir-autogen, elixir-format
 msgid "Grades calculated succesfully"
 msgstr ""
@@ -1370,7 +1369,7 @@ msgstr ""
 msgid "Item"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:123
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:104
 #, elixir-autogen, elixir-format
 msgid "Lanttern automatic grade calculation info based on configured grade composition"
 msgstr ""
@@ -1425,7 +1424,7 @@ msgstr ""
 msgid "Move moment card up"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1153
+#: lib/lanttern_web/components/core_components.ex:1155
 #: lib/lanttern_web/live/pages/report_cards/id/grades_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1441,7 +1440,7 @@ msgstr ""
 msgid "No assesment points in this grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:361
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:344
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No assessment point entries for this grade composition"
 msgstr ""
@@ -1522,14 +1521,14 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:271
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:302
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:338
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
 #, elixir-autogen, elixir-format
 msgid "Partial results"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:175
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:220
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
@@ -1618,11 +1617,6 @@ msgstr ""
 msgid "Save student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:21
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Select a"
-msgstr ""
-
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:25
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a level"
@@ -1703,7 +1697,7 @@ msgstr ""
 msgid "Student grade report entry created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:383
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:366
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry deleted"
 msgstr ""
@@ -1713,7 +1707,7 @@ msgstr ""
 msgid "Student grade report entry updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:294
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:277
 #, elixir-autogen, elixir-format
 msgid "Student grades calculated succesfully"
 msgstr ""
@@ -1724,7 +1718,7 @@ msgstr ""
 msgid "Student report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:377
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:404
 #, elixir-autogen, elixir-format
 msgid "Student report card deleted"
 msgstr ""
@@ -1734,7 +1728,7 @@ msgstr ""
 msgid "Students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:158
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:139
 #, elixir-autogen, elixir-format
 msgid "Students grades filter"
 msgstr ""
@@ -1749,7 +1743,7 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:330
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:313
 #, elixir-autogen, elixir-format
 msgid "Subject grades calculated succesfully"
 msgstr ""
@@ -1800,12 +1794,6 @@ msgstr ""
 msgid "Year"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:31
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:47
-#, elixir-autogen, elixir-format
-msgid "all classes"
-msgstr ""
-
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:25
 #, elixir-autogen, elixir-format, fuzzy
 msgid "all subjects"
@@ -1821,19 +1809,9 @@ msgstr ""
 msgid "and"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:27
-#, elixir-autogen, elixir-format
-msgid "class"
-msgstr ""
-
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "cycles"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:29
-#, elixir-autogen, elixir-format, fuzzy
-msgid "to view students grades"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:53
@@ -1856,7 +1834,7 @@ msgstr ""
 msgid "Not linked to strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:70
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:73
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select classes"
 msgstr ""
@@ -1938,21 +1916,21 @@ msgstr ""
 msgid "Report information"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:121
+#: lib/lanttern_web/helpers/assessments_helpers.ex:128
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 entry created"
 msgid_plural "%{count} entries created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:131
+#: lib/lanttern_web/helpers/assessments_helpers.ex:138
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 entry removed"
 msgid_plural "%{count} entries removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:126
+#: lib/lanttern_web/helpers/assessments_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "1 entry updated"
 msgid_plural "%{count} entries updated"
@@ -1965,54 +1943,54 @@ msgstr[1] ""
 msgid "Discard"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:70
+#: lib/lanttern_web/helpers/assessments_helpers.ex:74
 #, elixir-autogen, elixir-format
 msgid "Error creating assessment point entry"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:87
+#: lib/lanttern_web/helpers/assessments_helpers.ex:93
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error deleting assessment point entry"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:104
+#: lib/lanttern_web/helpers/assessments_helpers.ex:111
 #, elixir-autogen, elixir-format
 msgid "Error updating assessment point entry"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:47
+#: lib/lanttern_web/helpers/assessments_helpers.ex:49
 #, elixir-autogen, elixir-format
 msgid "Results so far"
 msgstr ""
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:90
-#: lib/lanttern_web/helpers/assessments_helpers.ex:107
+#: lib/lanttern_web/helpers/assessments_helpers.ex:96
+#: lib/lanttern_web/helpers/assessments_helpers.ex:114
 #, elixir-autogen, elixir-format
 msgid "The entry does not exist anymore"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:456
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:483
 #, elixir-autogen, elixir-format
 msgid "1 report creation failed"
 msgid_plural "%{count} reports creation failed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:445
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:472
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 student report card created"
 msgid_plural "%{count} students report cards created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:120
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
 #, elixir-autogen, elixir-format
 msgid "1 student selected"
 msgid_plural "%{count} students selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:451
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "1 student skipped"
 msgid_plural "%{count} students skipped"
@@ -2029,12 +2007,12 @@ msgstr ""
 msgid "Assessment points explorer"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:135
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:138
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:138
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:141
 #, elixir-autogen, elixir-format
 msgid "Create for selected"
 msgstr ""
@@ -2044,13 +2022,8 @@ msgstr ""
 msgid "Hey!"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:51
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Other students linked to this report card"
-msgstr ""
-
-#: lib/lanttern_web/components/core_components.ex:902
-#: lib/lanttern_web/components/core_components.ex:924
+#: lib/lanttern_web/components/core_components.ex:904
+#: lib/lanttern_web/components/core_components.ex:926
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Selected"
 msgstr ""
@@ -2167,7 +2140,7 @@ msgstr ""
 msgid "Privacy policy and terms of service"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:185
+#: lib/lanttern_web/live/shared/menu_component.ex:186
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr ""
@@ -2175,4 +2148,49 @@ msgstr ""
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:17
 #, elixir-autogen, elixir-format
 msgid "terms of service"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:29
+#, elixir-autogen, elixir-format
+msgid "Add students to report card to view grades"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:166
+#, elixir-autogen, elixir-format
+msgid "All students from selected classes are already linked to this report card"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:37
+#, elixir-autogen, elixir-format
+msgid "Link students from"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:157
+#, elixir-autogen, elixir-format
+msgid "No results"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:19
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Students grades"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:23
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Students linked to this report card"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:22
+#, elixir-autogen, elixir-format
+msgid "View grades reports for all students linked in the students tab."
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
+#, elixir-autogen, elixir-format
+msgid "to list students"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:47
+#, elixir-autogen, elixir-format, fuzzy
+msgid "to this report card"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -92,6 +92,7 @@ msgid "All strands"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/personalization/filters_overlay_component.ex:32
+#: lib/lanttern_web/live/shared/personalization/inline_filters_component.ex:32
 #, elixir-autogen, elixir-format
 msgid "Apply filters"
 msgstr ""
@@ -106,7 +107,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:125
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:173
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:114
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:85
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:166
@@ -162,7 +163,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:128
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:176
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:129
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:88
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
@@ -385,7 +386,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:87
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:59
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:105
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:119
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:74
@@ -451,7 +452,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:85
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:112
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:103
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:115
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:117
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
@@ -495,7 +496,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/learning_context_components.ex:51
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:228
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:240
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:63
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:52
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:281
@@ -558,7 +559,7 @@ msgstr ""
 msgid "Save updated order"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:56
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:67
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
@@ -884,10 +885,10 @@ msgstr ""
 #: lib/lanttern/learning_context.ex:443
 #: lib/lanttern/repo_helpers.ex:111
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:353
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:351
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Something went wrong"
 msgstr ""
@@ -922,28 +923,28 @@ msgstr ""
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:408
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:406
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no assessment point entries)"
 msgid_plural "%{count} grades skipped (no assessment point entries)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:392
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:390
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:402
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:400
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:397
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:395
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Component"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:237
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:249
 #, elixir-autogen, elixir-format
 msgid "Create"
 msgstr ""
@@ -1084,7 +1085,7 @@ msgstr ""
 msgid "Create strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:330
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:364
 #, elixir-autogen, elixir-format
 msgid "Create student report card"
 msgstr ""
@@ -1195,7 +1196,7 @@ msgstr ""
 msgid "Edit student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:349
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "Edit student report card"
 msgstr ""
@@ -1235,12 +1236,12 @@ msgstr ""
 msgid "Error deleting strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:374
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:372
 #, elixir-autogen, elixir-format
 msgid "Error deleting student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:412
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "Error deleting student report card"
 msgstr ""
@@ -1281,7 +1282,7 @@ msgstr ""
 msgid "Final strand goals assessment for"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:349
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:347
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
 msgstr ""
@@ -1308,7 +1309,7 @@ msgstr ""
 msgid "Grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:246
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:244
 #, elixir-autogen, elixir-format
 msgid "Grades calculated succesfully"
 msgstr ""
@@ -1440,7 +1441,7 @@ msgstr ""
 msgid "No assesment points in this grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:344
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:342
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No assessment point entries for this grade composition"
 msgstr ""
@@ -1521,14 +1522,14 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
 #, elixir-autogen, elixir-format
 msgid "Partial results"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:220
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:232
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
@@ -1697,7 +1698,7 @@ msgstr ""
 msgid "Student grade report entry created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:366
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:364
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry deleted"
 msgstr ""
@@ -1707,7 +1708,7 @@ msgstr ""
 msgid "Student grade report entry updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:277
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:275
 #, elixir-autogen, elixir-format
 msgid "Student grades calculated succesfully"
 msgstr ""
@@ -1718,7 +1719,7 @@ msgstr ""
 msgid "Student report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:404
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "Student report card deleted"
 msgstr ""
@@ -1743,7 +1744,7 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:313
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:311
 #, elixir-autogen, elixir-format
 msgid "Subject grades calculated succesfully"
 msgstr ""
@@ -1834,7 +1835,7 @@ msgstr ""
 msgid "Not linked to strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:73
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:84
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select classes"
 msgstr ""
@@ -1969,28 +1970,28 @@ msgstr ""
 msgid "The entry does not exist anymore"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:483
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:517
 #, elixir-autogen, elixir-format
 msgid "1 report creation failed"
 msgid_plural "%{count} reports creation failed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:472
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:506
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 student report card created"
 msgid_plural "%{count} students report cards created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:135
 #, elixir-autogen, elixir-format
 msgid "1 student selected"
 msgid_plural "%{count} students selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:478
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:512
 #, elixir-autogen, elixir-format
 msgid "1 student skipped"
 msgid_plural "%{count} students skipped"
@@ -2007,12 +2008,12 @@ msgstr ""
 msgid "Assessment points explorer"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:138
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:150
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:141
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:153
 #, elixir-autogen, elixir-format
 msgid "Create for selected"
 msgstr ""
@@ -2155,17 +2156,17 @@ msgstr ""
 msgid "Add students to report card to view grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:166
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:178
 #, elixir-autogen, elixir-format
 msgid "All students from selected classes are already linked to this report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:37
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:48
 #, elixir-autogen, elixir-format
 msgid "Link students from"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:157
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:169
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr ""
@@ -2175,7 +2176,7 @@ msgstr ""
 msgid "Students grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:23
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:26
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Students linked to this report card"
 msgstr ""
@@ -2185,12 +2186,22 @@ msgstr ""
 msgid "View grades reports for all students linked in the students tab."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:69
 #, elixir-autogen, elixir-format
 msgid "to list students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:47
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
 #, elixir-autogen, elixir-format, fuzzy
 msgid "to this report card"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/personalization/inline_filters_component.ex:21
+#, elixir-autogen, elixir-format
+msgid "All"
+msgstr ""
+
+#: lib/lanttern/personalization/profile_report_card_filter.ex:41
+#, elixir-autogen, elixir-format
+msgid "Filter value (class or linked students class) is required"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -107,8 +107,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:125
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:173
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:126
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:134
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:140
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:85
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:166
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:93
@@ -163,8 +163,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:128
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:176
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:129
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:137
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:143
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:88
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
@@ -386,8 +386,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:87
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:59
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:119
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:125
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:74
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:244
@@ -452,8 +452,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:85
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:112
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:115
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:117
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:129
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:29
@@ -496,7 +496,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/learning_context_components.ex:51
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:240
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:248
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:63
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:52
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:281
@@ -559,7 +559,7 @@ msgstr ""
 msgid "Save updated order"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:67
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:75
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
@@ -885,10 +885,10 @@ msgstr ""
 #: lib/lanttern/learning_context.ex:443
 #: lib/lanttern/repo_helpers.ex:111
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:284
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:315
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:351
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:383
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Something went wrong"
 msgstr ""
@@ -923,28 +923,28 @@ msgstr ""
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:406
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no assessment point entries)"
 msgid_plural "%{count} grades skipped (no assessment point entries)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:390
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:422
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:400
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:432
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:395
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1060,7 +1060,7 @@ msgstr ""
 msgid "Component"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:249
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:257
 #, elixir-autogen, elixir-format
 msgid "Create"
 msgstr ""
@@ -1085,7 +1085,7 @@ msgstr ""
 msgid "Create strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:364
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:369
 #, elixir-autogen, elixir-format
 msgid "Create student report card"
 msgstr ""
@@ -1191,12 +1191,12 @@ msgstr ""
 msgid "Edit strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:83
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:95
 #, elixir-autogen, elixir-format
 msgid "Edit student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:383
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:388
 #, elixir-autogen, elixir-format
 msgid "Edit student report card"
 msgstr ""
@@ -1236,12 +1236,12 @@ msgstr ""
 msgid "Error deleting strand report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:372
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:404
 #, elixir-autogen, elixir-format
 msgid "Error deleting student grade report entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:446
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:451
 #, elixir-autogen, elixir-format
 msgid "Error deleting student report card"
 msgstr ""
@@ -1282,12 +1282,12 @@ msgstr ""
 msgid "Final strand goals assessment for"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:347
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:379
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:102
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:114
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Grade composition"
@@ -1309,7 +1309,7 @@ msgstr ""
 msgid "Grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:244
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:276
 #, elixir-autogen, elixir-format
 msgid "Grades calculated succesfully"
 msgstr ""
@@ -1370,7 +1370,7 @@ msgstr ""
 msgid "Item"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:104
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:116
 #, elixir-autogen, elixir-format
 msgid "Lanttern automatic grade calculation info based on configured grade composition"
 msgstr ""
@@ -1441,7 +1441,7 @@ msgstr ""
 msgid "No assesment points in this grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:342
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:374
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No assessment point entries for this grade composition"
 msgstr ""
@@ -1522,14 +1522,14 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:284
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:315
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:351
 #, elixir-autogen, elixir-format
 msgid "Partial results"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:232
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:240
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
@@ -1698,7 +1698,7 @@ msgstr ""
 msgid "Student grade report entry created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:364
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:396
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry deleted"
 msgstr ""
@@ -1708,7 +1708,7 @@ msgstr ""
 msgid "Student grade report entry updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:275
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:307
 #, elixir-autogen, elixir-format
 msgid "Student grades calculated succesfully"
 msgstr ""
@@ -1719,7 +1719,7 @@ msgstr ""
 msgid "Student report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:438
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:443
 #, elixir-autogen, elixir-format
 msgid "Student report card deleted"
 msgstr ""
@@ -1729,7 +1729,7 @@ msgstr ""
 msgid "Students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:139
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:151
 #, elixir-autogen, elixir-format
 msgid "Students grades filter"
 msgstr ""
@@ -1744,7 +1744,7 @@ msgstr ""
 msgid "Subject"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:311
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:343
 #, elixir-autogen, elixir-format
 msgid "Subject grades calculated succesfully"
 msgstr ""
@@ -1835,7 +1835,7 @@ msgstr ""
 msgid "Not linked to strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:84
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:92
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select classes"
 msgstr ""
@@ -1970,28 +1970,28 @@ msgstr ""
 msgid "The entry does not exist anymore"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:517
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:522
 #, elixir-autogen, elixir-format
 msgid "1 report creation failed"
 msgid_plural "%{count} reports creation failed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:506
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:511
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 student report card created"
 msgid_plural "%{count} students report cards created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:135
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:143
 #, elixir-autogen, elixir-format
 msgid "1 student selected"
 msgid_plural "%{count} students selected"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:512
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:517
 #, elixir-autogen, elixir-format
 msgid "1 student skipped"
 msgid_plural "%{count} students skipped"
@@ -2008,12 +2008,12 @@ msgstr ""
 msgid "Assessment points explorer"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:150
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:158
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:153
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:161
 #, elixir-autogen, elixir-format
 msgid "Create for selected"
 msgstr ""
@@ -2151,27 +2151,27 @@ msgstr ""
 msgid "terms of service"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:29
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Add students to report card to view grades"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:178
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:186
 #, elixir-autogen, elixir-format
 msgid "All students from selected classes are already linked to this report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:48
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:56
 #, elixir-autogen, elixir-format
 msgid "Link students from"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:169
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:19
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:23
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Students grades"
 msgstr ""
@@ -2181,17 +2181,17 @@ msgstr ""
 msgid "Students linked to this report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:22
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:26
 #, elixir-autogen, elixir-format
 msgid "View grades reports for all students linked in the students tab."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:69
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:77
 #, elixir-autogen, elixir-format
 msgid "to list students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:66
 #, elixir-autogen, elixir-format, fuzzy
 msgid "to this report card"
 msgstr ""
@@ -2204,4 +2204,9 @@ msgstr ""
 #: lib/lanttern/personalization/profile_report_card_filter.ex:41
 #, elixir-autogen, elixir-format
 msgid "Filter value (class or linked students class) is required"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:49
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No students linked to this report card yet"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -107,8 +107,8 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:125
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:173
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:126
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:134
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:140
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:85
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:166
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:93
@@ -163,8 +163,8 @@ msgstr "Nenhuma trilha criadas para os anos e componentes selecionados"
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:128
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:176
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:129
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:137
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:143
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:88
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
@@ -386,8 +386,8 @@ msgstr "Não foi possível encontrar a trilha"
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:87
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:59
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:119
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:125
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:74
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:244
@@ -452,8 +452,8 @@ msgstr "Adicione suas anotações..."
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:85
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:112
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:115
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:117
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:129
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:29
@@ -496,7 +496,7 @@ msgstr "Diferenciação para %{name}"
 
 #: lib/lanttern_web/components/learning_context_components.ex:51
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:240
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:248
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:63
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:52
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:281
@@ -559,7 +559,7 @@ msgstr "Rubrica"
 msgid "Save updated order"
 msgstr "Salvar ordem atualizada"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:67
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:75
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
@@ -885,10 +885,10 @@ msgstr "Salvar momento"
 #: lib/lanttern/learning_context.ex:443
 #: lib/lanttern/repo_helpers.ex:111
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:284
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:315
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:351
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "Something went wrong"
 msgstr "Algo deu errado"
@@ -923,28 +923,28 @@ msgstr "Você ainda não poussui anotações para este momento"
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr "Você já deve possuir registros para este ponto de avaliação. Alterar a escala quando registros já existem não é permitido, pois acarretaria perda de dados."
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:406
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no assessment point entries)"
 msgid_plural "%{count} grades skipped (no assessment point entries)"
 msgstr[0] "1 cálculo de nota ignorado (sem registros de ponto de avaliação)"
 msgstr[1] "%{count} cálculos de nota ignorados (sem registros de ponto de avaliação)"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:390
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:422
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] "1 nota criada"
 msgstr[1] "%{count} notas criadas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:400
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:432
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] "1 nota removida"
 msgstr[1] "%{count} notas removidas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:395
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1060,7 +1060,7 @@ msgstr "Comp"
 msgid "Component"
 msgstr "Componente"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:249
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:257
 #, elixir-autogen, elixir-format
 msgid "Create"
 msgstr "Criar"
@@ -1085,7 +1085,7 @@ msgstr "Criar novo report card"
 msgid "Create strand report"
 msgstr "Criar novo relatório de trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:364
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:369
 #, elixir-autogen, elixir-format
 msgid "Create student report card"
 msgstr "Criar report card de estudante"
@@ -1191,12 +1191,12 @@ msgstr "Editar report card"
 msgid "Edit strand report"
 msgstr "Editar relatório da trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:83
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:95
 #, elixir-autogen, elixir-format
 msgid "Edit student grade report entry"
 msgstr "Editar registro de relatório de nota de estudante"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:383
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:388
 #, elixir-autogen, elixir-format
 msgid "Edit student report card"
 msgstr "Editar report card de estudante"
@@ -1236,12 +1236,12 @@ msgstr "Erro ao deletar report card"
 msgid "Error deleting strand report"
 msgstr "Erro ao deletar relatório da trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:372
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:404
 #, elixir-autogen, elixir-format
 msgid "Error deleting student grade report entry"
 msgstr "Erro ao deletar registro de relatório de nota de estudante"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:446
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:451
 #, elixir-autogen, elixir-format
 msgid "Error deleting student report card"
 msgstr "Erro ao deletar report card de estudante"
@@ -1282,12 +1282,12 @@ msgstr "Nota final"
 msgid "Final strand goals assessment for"
 msgstr "Avaliação final do objetivo da trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:347
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:379
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
 msgstr "Nota calculada com sucesso"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:102
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:114
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Grade composition"
@@ -1309,7 +1309,7 @@ msgstr "Relatório de nota deletada"
 msgid "Grades"
 msgstr "Notas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:244
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:276
 #, elixir-autogen, elixir-format
 msgid "Grades calculated succesfully"
 msgstr "Notas calculadas com sucesso"
@@ -1370,7 +1370,7 @@ msgstr "Info"
 msgid "Item"
 msgstr "Item"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:104
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:116
 #, elixir-autogen, elixir-format
 msgid "Lanttern automatic grade calculation info based on configured grade composition"
 msgstr "Informações do cálculo automático da nota do Lanttern baseado na configuração de composição da nota"
@@ -1441,7 +1441,7 @@ msgstr "Novo report card"
 msgid "No assesment points in this grade composition"
 msgstr "Nenhum ponto de avaliação para esta composição de nota"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:342
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:374
 #, elixir-autogen, elixir-format
 msgid "No assessment point entries for this grade composition"
 msgstr "Nenhum ponto de avaliação para esta composição de nota"
@@ -1522,14 +1522,14 @@ msgstr "Abrir em uma nova aba"
 msgid "Overview"
 msgstr "Visão geral"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:284
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:315
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:351
 #, elixir-autogen, elixir-format
 msgid "Partial results"
 msgstr "Resultados parciais"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:232
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:240
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Prévia"
@@ -1698,7 +1698,7 @@ msgstr "Estudante já vinculado ao report card"
 msgid "Student grade report entry created successfully"
 msgstr "Registro de relatório de nota de estudante criado com sucesso"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:364
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:396
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry deleted"
 msgstr "Registro de relatório de nota de estudante deletado"
@@ -1708,7 +1708,7 @@ msgstr "Registro de relatório de nota de estudante deletado"
 msgid "Student grade report entry updated successfully"
 msgstr "Registro de relatório de nota de estudante atualizado com sucesso"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:275
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:307
 #, elixir-autogen, elixir-format
 msgid "Student grades calculated succesfully"
 msgstr "Notas do estudantes calculadas com sucesso"
@@ -1719,7 +1719,7 @@ msgstr "Notas do estudantes calculadas com sucesso"
 msgid "Student report card"
 msgstr "Report card de estudante"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:438
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:443
 #, elixir-autogen, elixir-format
 msgid "Student report card deleted"
 msgstr "Report card de estudante deletado"
@@ -1729,7 +1729,7 @@ msgstr "Report card de estudante deletado"
 msgid "Students"
 msgstr "Estudantes"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:139
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:151
 #, elixir-autogen, elixir-format
 msgid "Students grades filter"
 msgstr "Filtro de notas de estudantes"
@@ -1744,7 +1744,7 @@ msgstr "Sub ciclo"
 msgid "Subject"
 msgstr "Disciplina"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:311
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:343
 #, elixir-autogen, elixir-format
 msgid "Subject grades calculated succesfully"
 msgstr "Notas da disciplina calculadas com sucesso"
@@ -1835,7 +1835,7 @@ msgstr "Nome obrigatótio"
 msgid "Not linked to strand"
 msgstr "Não vinculado à trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:84
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:92
 #, elixir-autogen, elixir-format
 msgid "Select classes"
 msgstr "Selecione as turmas"
@@ -1970,28 +1970,28 @@ msgstr "Resultados até aqui"
 msgid "The entry does not exist anymore"
 msgstr "O registro não existe mais"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:517
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:522
 #, elixir-autogen, elixir-format
 msgid "1 report creation failed"
 msgid_plural "%{count} reports creation failed"
 msgstr[0] "1 criação de report falhou"
 msgstr[1] "%{count} criações de reports falharam"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:506
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:511
 #, elixir-autogen, elixir-format
 msgid "1 student report card created"
 msgid_plural "%{count} students report cards created"
 msgstr[0] "1 report card de estudante criado"
 msgstr[1] "%{count} report cards de estudantes criados"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:135
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:143
 #, elixir-autogen, elixir-format
 msgid "1 student selected"
 msgid_plural "%{count} students selected"
 msgstr[0] "1 estudante selecionado"
 msgstr[1] "%{count} estudantes selecionados"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:512
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:517
 #, elixir-autogen, elixir-format
 msgid "1 student skipped"
 msgid_plural "%{count} students skipped"
@@ -2008,12 +2008,12 @@ msgstr "Ponto de avaliação"
 msgid "Assessment points explorer"
 msgstr "Explorador de pontos de avaliação"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:150
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:158
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr "Limpar seleção"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:153
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:161
 #, elixir-autogen, elixir-format
 msgid "Create for selected"
 msgstr "Criar para selecionados"
@@ -2151,27 +2151,27 @@ msgstr "Termos de uso"
 msgid "terms of service"
 msgstr "termos de uso"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:29
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Add students to report card to view grades"
 msgstr "Adicione estudantes ao report card para ver as notas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:178
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:186
 #, elixir-autogen, elixir-format
 msgid "All students from selected classes are already linked to this report card"
 msgstr "Todos estudantes das turmas selecionadas já estão vinculados ao report card"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:48
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:56
 #, elixir-autogen, elixir-format
 msgid "Link students from"
 msgstr "Vincular estudantes de"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:169
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr "Nenhum resultado"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:19
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:23
 #, elixir-autogen, elixir-format
 msgid "Students grades"
 msgstr "Notas de estudantes"
@@ -2181,17 +2181,17 @@ msgstr "Notas de estudantes"
 msgid "Students linked to this report card"
 msgstr "Estudantes vinculados a este report card"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:22
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:26
 #, elixir-autogen, elixir-format
 msgid "View grades reports for all students linked in the students tab."
 msgstr "Visualizar relatório de notas de todos estudantes vinculados na aba estudantes."
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:69
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:77
 #, elixir-autogen, elixir-format
 msgid "to list students"
 msgstr "para listar estudantes"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:66
 #, elixir-autogen, elixir-format
 msgid "to this report card"
 msgstr "a este report card"
@@ -2205,3 +2205,8 @@ msgstr "Tudo"
 #, elixir-autogen, elixir-format
 msgid "Filter value (class or linked students class) is required"
 msgstr "Valor do filtro (turma ou turma dos estudantes vinculados) obrigatório"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:49
+#, elixir-autogen, elixir-format
+msgid "No students linked to this report card yet"
+msgstr "Nenhum estudante vinculado a este report card ainda"

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -11,8 +11,8 @@ msgstr ""
 "Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n>1);\n"
 
-#: lib/lanttern_web/components/core_components.ex:1213
-#: lib/lanttern_web/components/core_components.ex:1275
+#: lib/lanttern_web/components/core_components.ex:1215
+#: lib/lanttern_web/components/core_components.ex:1277
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Ações"
@@ -58,9 +58,9 @@ msgstr "Escola"
 msgid "Strands"
 msgstr "Trilhas"
 
-#: lib/lanttern_web/components/core_components.ex:473
+#: lib/lanttern_web/components/core_components.ex:475
 #: lib/lanttern_web/components/overlay_components.ex:78
-#: lib/lanttern_web/components/overlay_components.ex:327
+#: lib/lanttern_web/components/overlay_components.ex:330
 #, elixir-autogen, elixir-format
 msgid "close"
 msgstr "fechar"
@@ -106,8 +106,8 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:125
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:173
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:111
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:147
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:114
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:85
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:166
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:93
@@ -162,8 +162,8 @@ msgstr "Nenhuma trilha criadas para os anos e componentes selecionados"
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:128
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:176
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:150
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:88
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
@@ -313,17 +313,17 @@ msgstr "cancelar"
 msgid "or drag and drop here"
 msgstr "ou arraste e solte aqui"
 
-#: lib/lanttern_web/components/core_components.ex:512
+#: lib/lanttern_web/components/core_components.ex:514
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr "Tentando reconectar"
 
-#: lib/lanttern_web/components/core_components.ex:503
+#: lib/lanttern_web/components/core_components.ex:505
 #, elixir-autogen, elixir-format
 msgid "Error!"
 msgstr "Erro!"
 
-#: lib/lanttern_web/components/core_components.ex:524
+#: lib/lanttern_web/components/core_components.ex:526
 #, elixir-autogen, elixir-format
 msgid "Hang in there while we get back on track"
 msgstr "Aguente firme enquanto nos reconectamos"
@@ -333,22 +333,22 @@ msgstr "Aguente firme enquanto nos reconectamos"
 msgid "Markdown supported"
 msgstr "Suporta Markdown"
 
-#: lib/lanttern_web/components/core_components.ex:502
+#: lib/lanttern_web/components/core_components.ex:504
 #, elixir-autogen, elixir-format
 msgid "Success!"
 msgstr "Sucesso!"
 
-#: lib/lanttern_web/components/core_components.ex:507
+#: lib/lanttern_web/components/core_components.ex:509
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr "Não conseguimos nos conectar"
 
-#: lib/lanttern_web/components/core_components.ex:519
+#: lib/lanttern_web/components/core_components.ex:521
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr "Algo deu errado!"
 
-#: lib/lanttern_web/components/core_components.ex:375
+#: lib/lanttern_web/components/core_components.ex:377
 #, elixir-autogen, elixir-format
 msgid "all %{type}"
 msgstr "todos %{type}"
@@ -385,8 +385,8 @@ msgstr "Não foi possível encontrar a trilha"
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:87
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:59
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:102
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:138
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:105
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:119
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:74
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:244
@@ -451,8 +451,8 @@ msgstr "Adicione suas anotações..."
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:85
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:112
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:100
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:136
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:103
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:117
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:29
@@ -495,7 +495,7 @@ msgstr "Diferenciação para %{name}"
 
 #: lib/lanttern_web/components/learning_context_components.ex:51
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:183
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:228
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:63
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:52
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:281
@@ -558,6 +558,7 @@ msgstr "Rubrica"
 msgid "Save updated order"
 msgstr "Salvar ordem atualizada"
 
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:56
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
@@ -586,8 +587,6 @@ msgstr "Por baixo dos panos, objetivos no Lanttern são definidos por pontos de 
 msgid "Understood. Delete anyway"
 msgstr "Compreendo. Deletar mesmo assim"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:20
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:36
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:20
 #, elixir-autogen, elixir-format
 msgid "Viewing"
@@ -760,7 +759,7 @@ msgstr "Mover ponto de avaliação para baixo"
 msgid "Move assessment point up"
 msgstr "Mover ponto de avaliação para cima"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:462
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:470
 #, elixir-autogen, elixir-format
 msgid "This assessment point already have some entries. Deleting it will cause data loss."
 msgstr "Este ponto de avaliação já possui alguns registros. Deletá-lo irá causar perda de dados."
@@ -852,7 +851,7 @@ msgstr "Momento atualizado com sucesso"
 msgid "Moments"
 msgstr "Momentos"
 
-#: lib/lanttern_web/components/core_components.ex:1163
+#: lib/lanttern_web/components/core_components.ex:1165
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr "Mover momento para baixo"
@@ -885,10 +884,10 @@ msgstr "Salvar momento"
 #: lib/lanttern/learning_context.ex:443
 #: lib/lanttern/repo_helpers.ex:111
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:271
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:302
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:338
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:370
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:353
 #, elixir-autogen, elixir-format
 msgid "Something went wrong"
 msgstr "Algo deu errado"
@@ -923,28 +922,28 @@ msgstr "Você ainda não poussui anotações para este momento"
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr "Você já deve possuir registros para este ponto de avaliação. Alterar a escala quando registros já existem não é permitido, pois acarretaria perda de dados."
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:425
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:408
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no assessment point entries)"
 msgid_plural "%{count} grades skipped (no assessment point entries)"
 msgstr[0] "1 cálculo de nota ignorado (sem registros de ponto de avaliação)"
 msgstr[1] "%{count} cálculos de nota ignorados (sem registros de ponto de avaliação)"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:409
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:392
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] "1 nota criada"
 msgstr[1] "%{count} notas criadas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:419
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:402
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] "1 nota removida"
 msgstr[1] "%{count} notas removidas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:414
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:397
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1060,7 +1059,7 @@ msgstr "Comp"
 msgid "Component"
 msgstr "Componente"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:192
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:237
 #, elixir-autogen, elixir-format
 msgid "Create"
 msgstr "Criar"
@@ -1085,7 +1084,7 @@ msgstr "Criar novo report card"
 msgid "Create strand report"
 msgstr "Criar novo relatório de trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:303
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:330
 #, elixir-autogen, elixir-format
 msgid "Create student report card"
 msgstr "Criar report card de estudante"
@@ -1191,12 +1190,12 @@ msgstr "Editar report card"
 msgid "Edit strand report"
 msgstr "Editar relatório da trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:102
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:83
 #, elixir-autogen, elixir-format
 msgid "Edit student grade report entry"
 msgstr "Editar registro de relatório de nota de estudante"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:322
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:349
 #, elixir-autogen, elixir-format
 msgid "Edit student report card"
 msgstr "Editar report card de estudante"
@@ -1236,12 +1235,12 @@ msgstr "Erro ao deletar report card"
 msgid "Error deleting strand report"
 msgstr "Erro ao deletar relatório da trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:391
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:374
 #, elixir-autogen, elixir-format
 msgid "Error deleting student grade report entry"
 msgstr "Erro ao deletar registro de relatório de nota de estudante"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:385
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:412
 #, elixir-autogen, elixir-format
 msgid "Error deleting student report card"
 msgstr "Erro ao deletar report card de estudante"
@@ -1282,12 +1281,12 @@ msgstr "Nota final"
 msgid "Final strand goals assessment for"
 msgstr "Avaliação final do objetivo da trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:366
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:349
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
 msgstr "Nota calculada com sucesso"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:121
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:102
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
 #, elixir-autogen, elixir-format
 msgid "Grade composition"
@@ -1309,7 +1308,7 @@ msgstr "Relatório de nota deletada"
 msgid "Grades"
 msgstr "Notas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:263
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:246
 #, elixir-autogen, elixir-format
 msgid "Grades calculated succesfully"
 msgstr "Notas calculadas com sucesso"
@@ -1370,7 +1369,7 @@ msgstr "Info"
 msgid "Item"
 msgstr "Item"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:123
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:104
 #, elixir-autogen, elixir-format
 msgid "Lanttern automatic grade calculation info based on configured grade composition"
 msgstr "Informações do cálculo automático da nota do Lanttern baseado na configuração de composição da nota"
@@ -1425,7 +1424,7 @@ msgstr "Mover card de momento para baixo"
 msgid "Move moment card up"
 msgstr "Mover card de momento para cima"
 
-#: lib/lanttern_web/components/core_components.ex:1153
+#: lib/lanttern_web/components/core_components.ex:1155
 #: lib/lanttern_web/live/pages/report_cards/id/grades_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1441,7 +1440,7 @@ msgstr "Novo report card"
 msgid "No assesment points in this grade composition"
 msgstr "Nenhum ponto de avaliação para esta composição de nota"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:361
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:344
 #, elixir-autogen, elixir-format
 msgid "No assessment point entries for this grade composition"
 msgstr "Nenhum ponto de avaliação para esta composição de nota"
@@ -1522,14 +1521,14 @@ msgstr "Abrir em uma nova aba"
 msgid "Overview"
 msgstr "Visão geral"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:271
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:302
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:338
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
 #, elixir-autogen, elixir-format
 msgid "Partial results"
 msgstr "Resultados parciais"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:175
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:220
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Prévia"
@@ -1618,11 +1617,6 @@ msgstr "Salvar card de momento"
 msgid "Save student grade report entry"
 msgstr "Salvar registro de relatório de nota de estudante"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:21
-#, elixir-autogen, elixir-format
-msgid "Select a"
-msgstr "Selecione uma"
-
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:25
 #, elixir-autogen, elixir-format
 msgid "Select a level"
@@ -1703,7 +1697,7 @@ msgstr "Estudante já vinculado ao report card"
 msgid "Student grade report entry created successfully"
 msgstr "Registro de relatório de nota de estudante criado com sucesso"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:383
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:366
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry deleted"
 msgstr "Registro de relatório de nota de estudante deletado"
@@ -1713,7 +1707,7 @@ msgstr "Registro de relatório de nota de estudante deletado"
 msgid "Student grade report entry updated successfully"
 msgstr "Registro de relatório de nota de estudante atualizado com sucesso"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:294
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:277
 #, elixir-autogen, elixir-format
 msgid "Student grades calculated succesfully"
 msgstr "Notas do estudantes calculadas com sucesso"
@@ -1724,7 +1718,7 @@ msgstr "Notas do estudantes calculadas com sucesso"
 msgid "Student report card"
 msgstr "Report card de estudante"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:377
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:404
 #, elixir-autogen, elixir-format
 msgid "Student report card deleted"
 msgstr "Report card de estudante deletado"
@@ -1734,7 +1728,7 @@ msgstr "Report card de estudante deletado"
 msgid "Students"
 msgstr "Estudantes"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:158
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:139
 #, elixir-autogen, elixir-format
 msgid "Students grades filter"
 msgstr "Filtro de notas de estudantes"
@@ -1749,7 +1743,7 @@ msgstr "Sub ciclo"
 msgid "Subject"
 msgstr "Disciplina"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:330
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:313
 #, elixir-autogen, elixir-format
 msgid "Subject grades calculated succesfully"
 msgstr "Notas da disciplina calculadas com sucesso"
@@ -1800,12 +1794,6 @@ msgstr "Qual trilha você quer vincular a este relatório?"
 msgid "Year"
 msgstr "Ano"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:31
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:47
-#, elixir-autogen, elixir-format
-msgid "all classes"
-msgstr "todas as turmas"
-
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:25
 #, elixir-autogen, elixir-format
 msgid "all subjects"
@@ -1821,20 +1809,10 @@ msgstr "todos os anos"
 msgid "and"
 msgstr "e"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:27
-#, elixir-autogen, elixir-format
-msgid "class"
-msgstr "turma"
-
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:7
 #, elixir-autogen, elixir-format
 msgid "cycles"
 msgstr "ciclos"
-
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:29
-#, elixir-autogen, elixir-format
-msgid "to view students grades"
-msgstr "para visualizar as notas dos estudantes"
 
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:53
 #, elixir-autogen, elixir-format
@@ -1856,7 +1834,7 @@ msgstr "Nome obrigatótio"
 msgid "Not linked to strand"
 msgstr "Não vinculado à trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:70
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:73
 #, elixir-autogen, elixir-format
 msgid "Select classes"
 msgstr "Selecione as turmas"
@@ -1938,21 +1916,21 @@ msgstr "Informações do relatório"
 msgid "Report information"
 msgstr "Informações do relatório"
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:121
+#: lib/lanttern_web/helpers/assessments_helpers.ex:128
 #, elixir-autogen, elixir-format
 msgid "1 entry created"
 msgid_plural "%{count} entries created"
 msgstr[0] "1 registro criado"
 msgstr[1] "%{count} registros criados"
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:131
+#: lib/lanttern_web/helpers/assessments_helpers.ex:138
 #, elixir-autogen, elixir-format
 msgid "1 entry removed"
 msgid_plural "%{count} entries removed"
 msgstr[0] "1 registro removido"
 msgstr[1] "%{count} registros removidos"
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:126
+#: lib/lanttern_web/helpers/assessments_helpers.ex:133
 #, elixir-autogen, elixir-format
 msgid "1 entry updated"
 msgid_plural "%{count} entries updated"
@@ -1965,54 +1943,54 @@ msgstr[1] "%{count} registros atualizados"
 msgid "Discard"
 msgstr "Descartar"
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:70
+#: lib/lanttern_web/helpers/assessments_helpers.ex:74
 #, elixir-autogen, elixir-format
 msgid "Error creating assessment point entry"
 msgstr "Erro ao criar registro de ponto de avaliação"
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:87
+#: lib/lanttern_web/helpers/assessments_helpers.ex:93
 #, elixir-autogen, elixir-format
 msgid "Error deleting assessment point entry"
 msgstr "Erro ao deletar registro de ponto de avaliação"
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:104
+#: lib/lanttern_web/helpers/assessments_helpers.ex:111
 #, elixir-autogen, elixir-format
 msgid "Error updating assessment point entry"
 msgstr "Erro ao atualizar registro de ponto de avaliação"
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:47
+#: lib/lanttern_web/helpers/assessments_helpers.ex:49
 #, elixir-autogen, elixir-format
 msgid "Results so far"
 msgstr "Resultados até aqui"
 
-#: lib/lanttern_web/helpers/assessments_helpers.ex:90
-#: lib/lanttern_web/helpers/assessments_helpers.ex:107
+#: lib/lanttern_web/helpers/assessments_helpers.ex:96
+#: lib/lanttern_web/helpers/assessments_helpers.ex:114
 #, elixir-autogen, elixir-format
 msgid "The entry does not exist anymore"
 msgstr "O registro não existe mais"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:456
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:483
 #, elixir-autogen, elixir-format
 msgid "1 report creation failed"
 msgid_plural "%{count} reports creation failed"
 msgstr[0] "1 criação de report falhou"
 msgstr[1] "%{count} criações de reports falharam"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:445
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:472
 #, elixir-autogen, elixir-format
 msgid "1 student report card created"
 msgid_plural "%{count} students report cards created"
 msgstr[0] "1 report card de estudante criado"
 msgstr[1] "%{count} report cards de estudantes criados"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:120
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
 #, elixir-autogen, elixir-format
 msgid "1 student selected"
 msgid_plural "%{count} students selected"
 msgstr[0] "1 estudante selecionado"
 msgstr[1] "%{count} estudantes selecionados"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:451
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:478
 #, elixir-autogen, elixir-format
 msgid "1 student skipped"
 msgid_plural "%{count} students skipped"
@@ -2029,12 +2007,12 @@ msgstr "Ponto de avaliação"
 msgid "Assessment points explorer"
 msgstr "Explorador de pontos de avaliação"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:135
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:138
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr "Limpar seleção"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:138
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:141
 #, elixir-autogen, elixir-format
 msgid "Create for selected"
 msgstr "Criar para selecionados"
@@ -2044,13 +2022,8 @@ msgstr "Criar para selecionados"
 msgid "Hey!"
 msgstr "Olá!"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:51
-#, elixir-autogen, elixir-format
-msgid "Other students linked to this report card"
-msgstr "Outros estudantes vinculados a este report card"
-
-#: lib/lanttern_web/components/core_components.ex:902
-#: lib/lanttern_web/components/core_components.ex:924
+#: lib/lanttern_web/components/core_components.ex:904
+#: lib/lanttern_web/components/core_components.ex:926
 #, elixir-autogen, elixir-format
 msgid "Selected"
 msgstr "Selecionado"
@@ -2167,7 +2140,7 @@ msgstr "Ao utilizar o Lanttern, você confirma ter lido e estar de acordo com no
 msgid "Privacy policy and terms of service"
 msgstr "Política de privacidade e termos de uso"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:185
+#: lib/lanttern_web/live/shared/menu_component.ex:186
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr "Termos de uso"
@@ -2176,3 +2149,48 @@ msgstr "Termos de uso"
 #, elixir-autogen, elixir-format
 msgid "terms of service"
 msgstr "termos de uso"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:29
+#, elixir-autogen, elixir-format
+msgid "Add students to report card to view grades"
+msgstr "Adicione estudantes ao report card para ver as notas"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:166
+#, elixir-autogen, elixir-format
+msgid "All students from selected classes are already linked to this report card"
+msgstr "Todos estudantes das turmas selecionadas já estão vinculados ao report card"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:37
+#, elixir-autogen, elixir-format
+msgid "Link students from"
+msgstr "Vincular estudantes de"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:157
+#, elixir-autogen, elixir-format
+msgid "No results"
+msgstr "Nenhum resultado"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:19
+#, elixir-autogen, elixir-format
+msgid "Students grades"
+msgstr "Notas de estudantes"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:23
+#, elixir-autogen, elixir-format
+msgid "Students linked to this report card"
+msgstr "Estudantes vinculados a este report card"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:22
+#, elixir-autogen, elixir-format
+msgid "View grades reports for all students linked in the students tab."
+msgstr "Visualizar relatório de notas de todos estudantes vinculados na aba estudantes."
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
+#, elixir-autogen, elixir-format
+msgid "to list students"
+msgstr "para listar estudantes"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:47
+#, elixir-autogen, elixir-format
+msgid "to this report card"
+msgstr "a este report card"

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -92,6 +92,7 @@ msgid "All strands"
 msgstr "Todas as trilhas"
 
 #: lib/lanttern_web/live/shared/personalization/filters_overlay_component.ex:32
+#: lib/lanttern_web/live/shared/personalization/inline_filters_component.ex:32
 #, elixir-autogen, elixir-format
 msgid "Apply filters"
 msgstr "Aplicar filtros"
@@ -106,7 +107,7 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:125
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:173
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:114
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:85
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:166
@@ -162,7 +163,7 @@ msgstr "Nenhuma trilha criadas para os anos e componentes selecionados"
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:128
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:126
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:176
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:129
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:131
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:88
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
@@ -385,7 +386,7 @@ msgstr "Não foi possível encontrar a trilha"
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:87
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:59
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:114
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:105
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:117
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:119
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:74
@@ -451,7 +452,7 @@ msgstr "Adicione suas anotações..."
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:85
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:112
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:103
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:115
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:117
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
@@ -495,7 +496,7 @@ msgstr "Diferenciação para %{name}"
 
 #: lib/lanttern_web/components/learning_context_components.ex:51
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:228
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:240
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:63
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:52
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:281
@@ -558,7 +559,7 @@ msgstr "Rubrica"
 msgid "Save updated order"
 msgstr "Salvar ordem atualizada"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:56
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:67
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
@@ -884,10 +885,10 @@ msgstr "Salvar momento"
 #: lib/lanttern/learning_context.ex:443
 #: lib/lanttern/repo_helpers.ex:111
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:353
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:351
 #, elixir-autogen, elixir-format
 msgid "Something went wrong"
 msgstr "Algo deu errado"
@@ -922,28 +923,28 @@ msgstr "Você ainda não poussui anotações para este momento"
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr "Você já deve possuir registros para este ponto de avaliação. Alterar a escala quando registros já existem não é permitido, pois acarretaria perda de dados."
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:408
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:406
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no assessment point entries)"
 msgid_plural "%{count} grades skipped (no assessment point entries)"
 msgstr[0] "1 cálculo de nota ignorado (sem registros de ponto de avaliação)"
 msgstr[1] "%{count} cálculos de nota ignorados (sem registros de ponto de avaliação)"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:392
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:390
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] "1 nota criada"
 msgstr[1] "%{count} notas criadas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:402
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:400
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] "1 nota removida"
 msgstr[1] "%{count} notas removidas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:397
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:395
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1059,7 +1060,7 @@ msgstr "Comp"
 msgid "Component"
 msgstr "Componente"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:237
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:249
 #, elixir-autogen, elixir-format
 msgid "Create"
 msgstr "Criar"
@@ -1084,7 +1085,7 @@ msgstr "Criar novo report card"
 msgid "Create strand report"
 msgstr "Criar novo relatório de trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:330
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:364
 #, elixir-autogen, elixir-format
 msgid "Create student report card"
 msgstr "Criar report card de estudante"
@@ -1195,7 +1196,7 @@ msgstr "Editar relatório da trilha"
 msgid "Edit student grade report entry"
 msgstr "Editar registro de relatório de nota de estudante"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:349
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:383
 #, elixir-autogen, elixir-format
 msgid "Edit student report card"
 msgstr "Editar report card de estudante"
@@ -1235,12 +1236,12 @@ msgstr "Erro ao deletar report card"
 msgid "Error deleting strand report"
 msgstr "Erro ao deletar relatório da trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:374
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:372
 #, elixir-autogen, elixir-format
 msgid "Error deleting student grade report entry"
 msgstr "Erro ao deletar registro de relatório de nota de estudante"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:412
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:446
 #, elixir-autogen, elixir-format
 msgid "Error deleting student report card"
 msgstr "Erro ao deletar report card de estudante"
@@ -1281,7 +1282,7 @@ msgstr "Nota final"
 msgid "Final strand goals assessment for"
 msgstr "Avaliação final do objetivo da trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:349
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:347
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
 msgstr "Nota calculada com sucesso"
@@ -1308,7 +1309,7 @@ msgstr "Relatório de nota deletada"
 msgid "Grades"
 msgstr "Notas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:246
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:244
 #, elixir-autogen, elixir-format
 msgid "Grades calculated succesfully"
 msgstr "Notas calculadas com sucesso"
@@ -1440,7 +1441,7 @@ msgstr "Novo report card"
 msgid "No assesment points in this grade composition"
 msgstr "Nenhum ponto de avaliação para esta composição de nota"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:344
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:342
 #, elixir-autogen, elixir-format
 msgid "No assessment point entries for this grade composition"
 msgstr "Nenhum ponto de avaliação para esta composição de nota"
@@ -1521,14 +1522,14 @@ msgstr "Abrir em uma nova aba"
 msgid "Overview"
 msgstr "Visão geral"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:254
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:285
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:321
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:252
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:319
 #, elixir-autogen, elixir-format
 msgid "Partial results"
 msgstr "Resultados parciais"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:220
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:232
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Prévia"
@@ -1697,7 +1698,7 @@ msgstr "Estudante já vinculado ao report card"
 msgid "Student grade report entry created successfully"
 msgstr "Registro de relatório de nota de estudante criado com sucesso"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:366
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:364
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry deleted"
 msgstr "Registro de relatório de nota de estudante deletado"
@@ -1707,7 +1708,7 @@ msgstr "Registro de relatório de nota de estudante deletado"
 msgid "Student grade report entry updated successfully"
 msgstr "Registro de relatório de nota de estudante atualizado com sucesso"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:277
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:275
 #, elixir-autogen, elixir-format
 msgid "Student grades calculated succesfully"
 msgstr "Notas do estudantes calculadas com sucesso"
@@ -1718,7 +1719,7 @@ msgstr "Notas do estudantes calculadas com sucesso"
 msgid "Student report card"
 msgstr "Report card de estudante"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:404
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "Student report card deleted"
 msgstr "Report card de estudante deletado"
@@ -1743,7 +1744,7 @@ msgstr "Sub ciclo"
 msgid "Subject"
 msgstr "Disciplina"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:313
+#: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:311
 #, elixir-autogen, elixir-format
 msgid "Subject grades calculated succesfully"
 msgstr "Notas da disciplina calculadas com sucesso"
@@ -1834,7 +1835,7 @@ msgstr "Nome obrigatótio"
 msgid "Not linked to strand"
 msgstr "Não vinculado à trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:73
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:84
 #, elixir-autogen, elixir-format
 msgid "Select classes"
 msgstr "Selecione as turmas"
@@ -1969,28 +1970,28 @@ msgstr "Resultados até aqui"
 msgid "The entry does not exist anymore"
 msgstr "O registro não existe mais"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:483
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:517
 #, elixir-autogen, elixir-format
 msgid "1 report creation failed"
 msgid_plural "%{count} reports creation failed"
 msgstr[0] "1 criação de report falhou"
 msgstr[1] "%{count} criações de reports falharam"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:472
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:506
 #, elixir-autogen, elixir-format
 msgid "1 student report card created"
 msgid_plural "%{count} students report cards created"
 msgstr[0] "1 report card de estudante criado"
 msgstr[1] "%{count} report cards de estudantes criados"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:135
 #, elixir-autogen, elixir-format
 msgid "1 student selected"
 msgid_plural "%{count} students selected"
 msgstr[0] "1 estudante selecionado"
 msgstr[1] "%{count} estudantes selecionados"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:478
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:512
 #, elixir-autogen, elixir-format
 msgid "1 student skipped"
 msgid_plural "%{count} students skipped"
@@ -2007,12 +2008,12 @@ msgstr "Ponto de avaliação"
 msgid "Assessment points explorer"
 msgstr "Explorador de pontos de avaliação"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:138
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:150
 #, elixir-autogen, elixir-format
 msgid "Clear selection"
 msgstr "Limpar seleção"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:141
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:153
 #, elixir-autogen, elixir-format
 msgid "Create for selected"
 msgstr "Criar para selecionados"
@@ -2155,17 +2156,17 @@ msgstr "termos de uso"
 msgid "Add students to report card to view grades"
 msgstr "Adicione estudantes ao report card para ver as notas"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:166
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:178
 #, elixir-autogen, elixir-format
 msgid "All students from selected classes are already linked to this report card"
 msgstr "Todos estudantes das turmas selecionadas já estão vinculados ao report card"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:37
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:48
 #, elixir-autogen, elixir-format
 msgid "Link students from"
 msgstr "Vincular estudantes de"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:157
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:169
 #, elixir-autogen, elixir-format
 msgid "No results"
 msgstr "Nenhum resultado"
@@ -2175,7 +2176,7 @@ msgstr "Nenhum resultado"
 msgid "Students grades"
 msgstr "Notas de estudantes"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:23
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:26
 #, elixir-autogen, elixir-format
 msgid "Students linked to this report card"
 msgstr "Estudantes vinculados a este report card"
@@ -2185,12 +2186,22 @@ msgstr "Estudantes vinculados a este report card"
 msgid "View grades reports for all students linked in the students tab."
 msgstr "Visualizar relatório de notas de todos estudantes vinculados na aba estudantes."
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:69
 #, elixir-autogen, elixir-format
 msgid "to list students"
 msgstr "para listar estudantes"
 
-#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:47
+#: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:58
 #, elixir-autogen, elixir-format
 msgid "to this report card"
 msgstr "a este report card"
+
+#: lib/lanttern_web/live/shared/personalization/inline_filters_component.ex:21
+#, elixir-autogen, elixir-format
+msgid "All"
+msgstr "Tudo"
+
+#: lib/lanttern/personalization/profile_report_card_filter.ex:41
+#, elixir-autogen, elixir-format
+msgid "Filter value (class or linked students class) is required"
+msgstr "Valor do filtro (turma ou turma dos estudantes vinculados) obrigatório"

--- a/priv/repo/migrations/20240423125853_create_profile_report_card_filter.exs
+++ b/priv/repo/migrations/20240423125853_create_profile_report_card_filter.exs
@@ -1,0 +1,17 @@
+defmodule Lanttern.Repo.Migrations.CreateProfileReportCardFilter do
+  use Ecto.Migration
+
+  def change do
+    create table(:profile_report_card_filters) do
+      add :profile_id, references(:profiles, on_delete: :delete_all), null: false
+      add :report_card_id, references(:report_cards, on_delete: :delete_all), null: false
+      add :class_id, references(:classes, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:profile_report_card_filters, [:profile_id])
+    create index(:profile_report_card_filters, [:report_card_id])
+    create unique_index(:profile_report_card_filters, [:class_id, :profile_id, :report_card_id])
+  end
+end

--- a/priv/repo/migrations/20240424122329_add_linked_students_class_id_to_profile_report_card_filters.exs
+++ b/priv/repo/migrations/20240424122329_add_linked_students_class_id_to_profile_report_card_filters.exs
@@ -1,0 +1,35 @@
+defmodule Lanttern.Repo.Migrations.AddLinkedStudentsClassIdToProfileReportCardFilters do
+  use Ecto.Migration
+
+  # MIGRATION PLAN
+  # 1. remove not null constraint from class_id
+  # 2. add column linked_students_class_id (references classes)
+  # 4. add unique constraint to prevent duplicate linked_students_class_id per report/profile
+  # 4. add check constraint: class_id is not null and linked_students_class_id is null (or vice-versa)
+
+  def change do
+    execute "ALTER TABLE profile_report_card_filters ALTER COLUMN class_id DROP NOT NULL",
+            "ALTER TABLE profile_report_card_filters ALTER COLUMN class_id SET NOT NULL"
+
+    alter table(:profile_report_card_filters) do
+      add :linked_students_class_id, references(:classes, on_delete: :delete_all)
+    end
+
+    create unique_index(:profile_report_card_filters, [
+             :linked_students_class_id,
+             :profile_id,
+             :report_card_id
+           ])
+
+    check_constraint = """
+    (class_id IS NOT NULL AND linked_students_class_id IS NULL)
+    OR (class_id IS NULL AND linked_students_class_id IS NOT NULL)
+    """
+
+    create constraint(
+             :profile_report_card_filters,
+             :required_filter_value,
+             check: check_constraint
+           )
+  end
+end

--- a/test/lanttern/personalization_test.exs
+++ b/test/lanttern/personalization_test.exs
@@ -621,4 +621,93 @@ defmodule Lanttern.PersonalizationTest do
                Personalization.change_profile_strand_filter(profile_strand_filter)
     end
   end
+
+  describe "profile_report_card_filters" do
+    alias Lanttern.Personalization.ProfileReportCardFilter
+
+    import Lanttern.PersonalizationFixtures
+
+    @invalid_attrs %{profile_id: nil}
+
+    test "list_profile_report_card_filters/0 returns all profile_report_card_filters" do
+      profile_report_card_filters = profile_report_card_filters_fixture()
+      assert Personalization.list_profile_report_card_filters() == [profile_report_card_filters]
+    end
+
+    test "get_profile_report_card_filters!/1 returns the profile_report_card_filters with given id" do
+      profile_report_card_filters = profile_report_card_filters_fixture()
+
+      assert Personalization.get_profile_report_card_filters!(profile_report_card_filters.id) ==
+               profile_report_card_filters
+    end
+
+    test "create_profile_report_card_filters/1 with valid data creates a profile_report_card_filters" do
+      profile = Lanttern.IdentityFixtures.teacher_profile_fixture()
+      report_card = Lanttern.ReportingFixtures.report_card_fixture()
+      class = Lanttern.SchoolsFixtures.class_fixture()
+
+      valid_attrs = %{
+        profile_id: profile.id,
+        report_card_id: report_card.id,
+        class_id: class.id
+      }
+
+      assert {:ok, %ProfileReportCardFilter{} = profile_report_card_filters} =
+               Personalization.create_profile_report_card_filters(valid_attrs)
+
+      assert profile_report_card_filters.profile_id == profile.id
+      assert profile_report_card_filters.report_card_id == report_card.id
+      assert profile_report_card_filters.class_id == class.id
+    end
+
+    test "create_profile_report_card_filters/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} =
+               Personalization.create_profile_report_card_filters(@invalid_attrs)
+    end
+
+    test "update_profile_report_card_filters/2 with valid data updates the profile_report_card_filters" do
+      profile_report_card_filters = profile_report_card_filters_fixture()
+      class = Lanttern.SchoolsFixtures.class_fixture()
+      update_attrs = %{class_id: class.id}
+
+      assert {:ok, %ProfileReportCardFilter{} = profile_report_card_filters} =
+               Personalization.update_profile_report_card_filters(
+                 profile_report_card_filters,
+                 update_attrs
+               )
+
+      assert profile_report_card_filters.class_id == class.id
+    end
+
+    test "update_profile_report_card_filters/2 with invalid data returns error changeset" do
+      profile_report_card_filters = profile_report_card_filters_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               Personalization.update_profile_report_card_filters(
+                 profile_report_card_filters,
+                 @invalid_attrs
+               )
+
+      assert profile_report_card_filters ==
+               Personalization.get_profile_report_card_filters!(profile_report_card_filters.id)
+    end
+
+    test "delete_profile_report_card_filters/1 deletes the profile_report_card_filters" do
+      profile_report_card_filters = profile_report_card_filters_fixture()
+
+      assert {:ok, %ProfileReportCardFilter{}} =
+               Personalization.delete_profile_report_card_filters(profile_report_card_filters)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Personalization.get_profile_report_card_filters!(profile_report_card_filters.id)
+      end
+    end
+
+    test "change_profile_report_card_filters/1 returns a profile_report_card_filters changeset" do
+      profile_report_card_filters = profile_report_card_filters_fixture()
+
+      assert %Ecto.Changeset{} =
+               Personalization.change_profile_report_card_filters(profile_report_card_filters)
+    end
+  end
 end

--- a/test/lanttern/personalization_test.exs
+++ b/test/lanttern/personalization_test.exs
@@ -622,26 +622,98 @@ defmodule Lanttern.PersonalizationTest do
     end
   end
 
-  describe "profile_report_card_filters" do
+  describe "profile_report_card_filter" do
     alias Lanttern.Personalization.ProfileReportCardFilter
 
     import Lanttern.PersonalizationFixtures
+    alias Lanttern.IdentityFixtures
+    alias Lanttern.ReportingFixtures
+    alias Lanttern.SchoolsFixtures
 
     @invalid_attrs %{profile_id: nil}
 
-    test "list_profile_report_card_filters/0 returns all profile_report_card_filters" do
-      profile_report_card_filters = profile_report_card_filters_fixture()
-      assert Personalization.list_profile_report_card_filters() == [profile_report_card_filters]
+    test "list_profile_report_card_filter/0 returns all profile_report_card_filter" do
+      profile_report_card_filter = profile_report_card_filter_fixture()
+      assert Personalization.list_profile_report_card_filter() == [profile_report_card_filter]
     end
 
-    test "get_profile_report_card_filters!/1 returns the profile_report_card_filters with given id" do
-      profile_report_card_filters = profile_report_card_filters_fixture()
+    test "list_profile_report_card_filter_classes_ids/2 returns all classes ids filtered by profile in the report card context" do
+      report_card = ReportingFixtures.report_card_fixture()
+      class_1 = SchoolsFixtures.class_fixture()
+      class_2 = SchoolsFixtures.class_fixture()
+      profile = IdentityFixtures.teacher_profile_fixture()
 
-      assert Personalization.get_profile_report_card_filters!(profile_report_card_filters.id) ==
-               profile_report_card_filters
+      profile_report_card_filter_fixture(%{
+        profile_id: profile.id,
+        report_card_id: report_card.id,
+        class_id: class_1.id
+      })
+
+      profile_report_card_filter_fixture(%{
+        profile_id: profile.id,
+        report_card_id: report_card.id,
+        class_id: class_2.id
+      })
+
+      # extra fixtures to test filter
+      profile_report_card_filter_fixture()
+
+      assert expected =
+               Personalization.list_profile_report_card_filter_classes_ids(
+                 profile.id,
+                 report_card.id
+               )
+
+      assert length(expected) == 2
+      assert class_1.id in expected
+      assert class_2.id in expected
     end
 
-    test "create_profile_report_card_filters/1 with valid data creates a profile_report_card_filters" do
+    test "get_profile_report_card_filter!/1 returns the profile_report_card_filter with given id" do
+      profile_report_card_filter = profile_report_card_filter_fixture()
+
+      assert Personalization.get_profile_report_card_filter!(profile_report_card_filter.id) ==
+               profile_report_card_filter
+    end
+
+    test "set_profile_report_card_filters/3 sets current filters in profile report card filters" do
+      current_profile = IdentityFixtures.teacher_profile_fixture()
+      report_card = ReportingFixtures.report_card_fixture()
+      class_1 = SchoolsFixtures.class_fixture()
+      class_2 = SchoolsFixtures.class_fixture()
+
+      assert {:ok, results} =
+               Personalization.set_profile_report_card_filters(
+                 %{current_profile: current_profile},
+                 report_card.id,
+                 %{classes_ids: [class_1.id, class_2.id]}
+               )
+
+      for {_, profile_report_card_filter} <- results do
+        assert profile_report_card_filter.profile_id == current_profile.id
+        assert profile_report_card_filter.report_card_id == report_card.id
+        assert profile_report_card_filter.class_id in [class_1.id, class_2.id]
+      end
+
+      # repeat with a new class to test filter "update"
+      class_3 = SchoolsFixtures.class_fixture()
+      class_3_id = class_3.id
+
+      assert {:ok, _results} =
+               Personalization.set_profile_report_card_filters(
+                 %{current_profile: current_profile},
+                 report_card.id,
+                 %{classes_ids: [class_3_id]}
+               )
+
+      assert [class_3_id] ==
+               Personalization.list_profile_report_card_filter_classes_ids(
+                 current_profile.id,
+                 report_card.id
+               )
+    end
+
+    test "create_profile_report_card_filter/1 with valid data creates a profile_report_card_filter" do
       profile = Lanttern.IdentityFixtures.teacher_profile_fixture()
       report_card = Lanttern.ReportingFixtures.report_card_fixture()
       class = Lanttern.SchoolsFixtures.class_fixture()
@@ -652,62 +724,62 @@ defmodule Lanttern.PersonalizationTest do
         class_id: class.id
       }
 
-      assert {:ok, %ProfileReportCardFilter{} = profile_report_card_filters} =
-               Personalization.create_profile_report_card_filters(valid_attrs)
+      assert {:ok, %ProfileReportCardFilter{} = profile_report_card_filter} =
+               Personalization.create_profile_report_card_filter(valid_attrs)
 
-      assert profile_report_card_filters.profile_id == profile.id
-      assert profile_report_card_filters.report_card_id == report_card.id
-      assert profile_report_card_filters.class_id == class.id
+      assert profile_report_card_filter.profile_id == profile.id
+      assert profile_report_card_filter.report_card_id == report_card.id
+      assert profile_report_card_filter.class_id == class.id
     end
 
-    test "create_profile_report_card_filters/1 with invalid data returns error changeset" do
+    test "create_profile_report_card_filter/1 with invalid data returns error changeset" do
       assert {:error, %Ecto.Changeset{}} =
-               Personalization.create_profile_report_card_filters(@invalid_attrs)
+               Personalization.create_profile_report_card_filter(@invalid_attrs)
     end
 
-    test "update_profile_report_card_filters/2 with valid data updates the profile_report_card_filters" do
-      profile_report_card_filters = profile_report_card_filters_fixture()
+    test "update_profile_report_card_filter/2 with valid data updates the profile_report_card_filter" do
+      profile_report_card_filter = profile_report_card_filter_fixture()
       class = Lanttern.SchoolsFixtures.class_fixture()
       update_attrs = %{class_id: class.id}
 
-      assert {:ok, %ProfileReportCardFilter{} = profile_report_card_filters} =
-               Personalization.update_profile_report_card_filters(
-                 profile_report_card_filters,
+      assert {:ok, %ProfileReportCardFilter{} = profile_report_card_filter} =
+               Personalization.update_profile_report_card_filter(
+                 profile_report_card_filter,
                  update_attrs
                )
 
-      assert profile_report_card_filters.class_id == class.id
+      assert profile_report_card_filter.class_id == class.id
     end
 
-    test "update_profile_report_card_filters/2 with invalid data returns error changeset" do
-      profile_report_card_filters = profile_report_card_filters_fixture()
+    test "update_profile_report_card_filter/2 with invalid data returns error changeset" do
+      profile_report_card_filter = profile_report_card_filter_fixture()
 
       assert {:error, %Ecto.Changeset{}} =
-               Personalization.update_profile_report_card_filters(
-                 profile_report_card_filters,
+               Personalization.update_profile_report_card_filter(
+                 profile_report_card_filter,
                  @invalid_attrs
                )
 
-      assert profile_report_card_filters ==
-               Personalization.get_profile_report_card_filters!(profile_report_card_filters.id)
+      assert profile_report_card_filter ==
+               Personalization.get_profile_report_card_filter!(profile_report_card_filter.id)
     end
 
-    test "delete_profile_report_card_filters/1 deletes the profile_report_card_filters" do
-      profile_report_card_filters = profile_report_card_filters_fixture()
+    test "delete_profile_report_card_filter/1 deletes the profile_report_card_filter" do
+      profile_report_card_filter = profile_report_card_filter_fixture()
 
       assert {:ok, %ProfileReportCardFilter{}} =
-               Personalization.delete_profile_report_card_filters(profile_report_card_filters)
+               Personalization.delete_profile_report_card_filter(profile_report_card_filter)
 
       assert_raise Ecto.NoResultsError, fn ->
-        Personalization.get_profile_report_card_filters!(profile_report_card_filters.id)
+        Personalization.get_profile_report_card_filter!(profile_report_card_filter.id)
       end
     end
 
-    test "change_profile_report_card_filters/1 returns a profile_report_card_filters changeset" do
-      profile_report_card_filters = profile_report_card_filters_fixture()
+    test "change_profile_report_card_filter/1 returns a profile_report_card_filter changeset" do
+      profile_report_card_filter = profile_report_card_filter_fixture()
 
       assert %Ecto.Changeset{} =
-               Personalization.change_profile_report_card_filters(profile_report_card_filters)
+               Personalization.change_profile_report_card_filter(profile_report_card_filter)
     end
   end
 end

--- a/test/lanttern/reporting_test.exs
+++ b/test/lanttern/reporting_test.exs
@@ -882,5 +882,44 @@ defmodule Lanttern.ReportingTest do
       assert expected_grade_component_2.assessment_point.curriculum_item.curriculum_component.id ==
                cur_component.id
     end
+
+    test "list_report_card_linked_students_classes/1 returns all report classes from students linked to the report card" do
+      report_card = report_card_fixture()
+
+      year_1 = Lanttern.TaxonomyFixtures.year_fixture()
+      year_2 = Lanttern.TaxonomyFixtures.year_fixture()
+      year_3 = Lanttern.TaxonomyFixtures.year_fixture()
+
+      class_1 = Lanttern.SchoolsFixtures.class_fixture(%{name: "AAA", years_ids: [year_1.id]})
+
+      class_2 =
+        Lanttern.SchoolsFixtures.class_fixture(%{name: "BBB", years_ids: [year_2.id, year_3.id]})
+
+      student_1 = Lanttern.SchoolsFixtures.student_fixture(%{classes_ids: [class_1.id]})
+      student_2 = Lanttern.SchoolsFixtures.student_fixture(%{classes_ids: [class_2.id]})
+      # student in same class to test distinct results
+      student_3 =
+        Lanttern.SchoolsFixtures.student_fixture(%{classes_ids: [class_1.id, class_2.id]})
+
+      student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_1.id})
+      student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_2.id})
+      student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_3.id})
+
+      # other fixtures for filtering test
+      other_report_card = report_card_fixture()
+      other_class = Lanttern.SchoolsFixtures.class_fixture()
+      other_student = Lanttern.SchoolsFixtures.student_fixture(%{classes_ids: [other_class.id]})
+
+      student_report_card_fixture(%{
+        report_card_id: other_report_card.id,
+        student_id: other_student.id
+      })
+
+      assert [expected_class_1, expected_class_2] =
+               Reporting.list_report_card_linked_students_classes(report_card.id)
+
+      assert expected_class_1.id == class_1.id
+      assert expected_class_2.id == class_2.id
+    end
   end
 end

--- a/test/lanttern/reporting_test.exs
+++ b/test/lanttern/reporting_test.exs
@@ -343,7 +343,7 @@ defmodule Lanttern.ReportingTest do
              ]
     end
 
-    test "list_students_for_report_card/2 returns all students with class and linked report cards" do
+    test "list_students_with_report_card/2 returns all students with class and linked report cards" do
       school = SchoolsFixtures.school_fixture()
       class_a = SchoolsFixtures.class_fixture(%{name: "AAA", school_id: school.id})
 
@@ -370,6 +370,7 @@ defmodule Lanttern.ReportingTest do
           classes_ids: [class_j.id]
         })
 
+      # without report card
       student_j_k =
         SchoolsFixtures.student_fixture(%{
           name: "KKK",
@@ -397,7 +398,7 @@ defmodule Lanttern.ReportingTest do
       student_j_j_report_card =
         student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_j_j.id})
 
-      student_z_z_report_card =
+      _student_z_z_report_card =
         student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_z_z.id})
 
       # other fixtures for filter testing
@@ -412,10 +413,9 @@ defmodule Lanttern.ReportingTest do
       assert [
                {expected_student_a_a, expected_student_a_a_report_card},
                {expected_student_a_b, expected_student_a_b_report_card},
-               {expected_student_j_j, expected_student_j_j_report_card},
-               {expected_student_j_k, nil}
+               {expected_student_j_j, expected_student_j_j_report_card}
              ] =
-               Reporting.list_students_for_report_card(report_card.id,
+               Reporting.list_students_with_report_card(report_card.id,
                  classes_ids: [class_a.id, class_j.id]
                )
 
@@ -434,33 +434,14 @@ defmodule Lanttern.ReportingTest do
       assert expected_class_j_j.id == class_j.id
       assert expected_student_j_j_report_card.id == student_j_j_report_card.id
 
-      assert expected_student_j_k.id == student_j_k.id
-      assert [expected_class_j_k] = expected_student_j_k.classes
-      assert expected_class_j_k.id == class_j.id
+      # use same setup and test without report card
 
-      # test only_with_report opt
-
-      assert [
-               {expected_student_a_a, expected_student_a_a_report_card},
-               {expected_student_a_b, expected_student_a_b_report_card},
-               {expected_student_j_j, expected_student_j_j_report_card},
-               {expected_student_z_z, expected_student_z_z_report_card}
-             ] =
-               Reporting.list_students_for_report_card(report_card.id,
-                 only_with_report: true
+      assert [expected_student_j_k] =
+               Reporting.list_students_without_report_card(report_card.id,
+                 classes_ids: [class_a.id, class_j.id]
                )
 
-      assert expected_student_a_a.id == student_a_a.id
-      assert expected_student_a_a_report_card.id == student_a_a_report_card.id
-
-      assert expected_student_a_b.id == student_a_b.id
-      assert expected_student_a_b_report_card.id == student_a_b_report_card.id
-
-      assert expected_student_j_j.id == student_j_j.id
-      assert expected_student_j_j_report_card.id == student_j_j_report_card.id
-
-      assert expected_student_z_z.id == student_z_z.id
-      assert expected_student_z_z_report_card.id == student_z_z_report_card.id
+      assert expected_student_j_k.id == student_j_k.id
     end
 
     test "get_student_report_card!/2 returns the student_report_card with given id" do

--- a/test/lanttern/schools_test.exs
+++ b/test/lanttern/schools_test.exs
@@ -423,6 +423,44 @@ defmodule Lanttern.SchoolsTest do
       assert !expected_2.has_diff_rubric
     end
 
+    test "list_students/1 with report card filter returns all students linked to given report card" do
+      class = class_fixture()
+
+      student_a = student_fixture(%{name: "AAA", classes_ids: [class.id]})
+      student_b = student_fixture(%{name: "BBB", classes_ids: [class.id]})
+
+      report_card = Lanttern.ReportingFixtures.report_card_fixture()
+
+      Lanttern.Reporting.create_student_report_card(%{
+        student_id: student_a.id,
+        report_card_id: report_card.id
+      })
+
+      Lanttern.Reporting.create_student_report_card(%{
+        student_id: student_b.id,
+        report_card_id: report_card.id
+      })
+
+      # other rubrics for testing
+      other_student = student_fixture(%{classes_ids: [class.id]})
+      other_report_card = Lanttern.ReportingFixtures.report_card_fixture()
+
+      Lanttern.Reporting.create_student_report_card(%{
+        student_id: other_student.id,
+        report_card_id: other_report_card.id
+      })
+
+      # assert
+      [expected_a, expected_b] =
+        Schools.list_students(report_card_id: report_card.id)
+
+      assert expected_a.id == student_a.id
+      assert expected_a.classes == [class]
+
+      assert expected_b.id == student_b.id
+      assert expected_b.classes == [class]
+    end
+
     test "get_student/2 returns the student with given id" do
       student = student_fixture()
       assert Schools.get_student(student.id) == student

--- a/test/lanttern_web/live/pages/report_cards/id/report_card_live_test.exs
+++ b/test/lanttern_web/live/pages/report_cards/id/report_card_live_test.exs
@@ -3,6 +3,7 @@ defmodule LantternWeb.ReportCardLiveTest do
 
   import Lanttern.ReportingFixtures
 
+  alias Lanttern.Personalization
   alias Lanttern.LearningContextFixtures
   alias Lanttern.SchoolsFixtures
   alias Lanttern.TaxonomyFixtures
@@ -22,7 +23,7 @@ defmodule LantternWeb.ReportCardLiveTest do
       {:ok, _view, _html} = live(conn)
     end
 
-    test "list students and students report cards", %{conn: conn} do
+    test "list students and students report cards", %{conn: conn, user: user} do
       cycle_2024 =
         SchoolsFixtures.cycle_fixture(%{
           start_at: ~D[2024-01-01],
@@ -33,11 +34,17 @@ defmodule LantternWeb.ReportCardLiveTest do
       report_card =
         report_card_fixture(%{school_cycle_id: cycle_2024.id, name: "Some report card name abc"})
 
-      student_a = SchoolsFixtures.student_fixture(%{name: "Student AAA"})
-      _student_b = SchoolsFixtures.student_fixture(%{name: "Student BBB"})
+      class = SchoolsFixtures.class_fixture()
+      student_a = SchoolsFixtures.student_fixture(%{name: "Student AAA", classes_ids: [class.id]})
+
+      _student_b =
+        SchoolsFixtures.student_fixture(%{name: "Student BBB", classes_ids: [class.id]})
 
       student_a_report_card =
         student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_a.id})
+
+      # select profile class filter to display student B
+      Personalization.set_profile_current_filters(user, %{classes_ids: [class.id]})
 
       {:ok, view, _html} = live(conn, "#{@live_view_path_base}/#{report_card.id}")
 

--- a/test/lanttern_web/live/pages/report_cards/id/report_card_live_test.exs
+++ b/test/lanttern_web/live/pages/report_cards/id/report_card_live_test.exs
@@ -44,7 +44,11 @@ defmodule LantternWeb.ReportCardLiveTest do
         student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_a.id})
 
       # select profile class filter to display student B
-      Personalization.set_profile_current_filters(user, %{classes_ids: [class.id]})
+      Personalization.set_profile_report_card_filters(
+        user,
+        report_card.id,
+        %{classes_ids: [class.id]}
+      )
 
       {:ok, view, _html} = live(conn, "#{@live_view_path_base}/#{report_card.id}")
 

--- a/test/support/fixtures/personalization_fixtures.ex
+++ b/test/support/fixtures/personalization_fixtures.ex
@@ -86,18 +86,18 @@ defmodule Lanttern.PersonalizationFixtures do
   end
 
   @doc """
-  Generate a profile_report_card_filters.
+  Generate a profile_report_card_filter.
   """
-  def profile_report_card_filters_fixture(attrs \\ %{}) do
-    {:ok, profile_report_card_filters} =
+  def profile_report_card_filter_fixture(attrs \\ %{}) do
+    {:ok, profile_report_card_filter} =
       attrs
       |> Enum.into(%{
         profile_id: Lanttern.IdentityFixtures.maybe_gen_profile_id(attrs),
         report_card_id: Lanttern.ReportingFixtures.maybe_gen_report_card_id(attrs),
         class_id: Lanttern.SchoolsFixtures.maybe_gen_class_id(attrs)
       })
-      |> Lanttern.Personalization.create_profile_report_card_filters()
+      |> Lanttern.Personalization.create_profile_report_card_filter()
 
-    profile_report_card_filters
+    profile_report_card_filter
   end
 end

--- a/test/support/fixtures/personalization_fixtures.ex
+++ b/test/support/fixtures/personalization_fixtures.ex
@@ -4,8 +4,6 @@ defmodule Lanttern.PersonalizationFixtures do
   entities via the `Lanttern.Personalization` context.
   """
 
-  import Lanttern.IdentityFixtures
-
   @doc """
   Generate a note.
   """
@@ -13,7 +11,7 @@ defmodule Lanttern.PersonalizationFixtures do
     {:ok, note} =
       attrs
       |> Enum.into(%{
-        author_id: maybe_gen_author_id(attrs),
+        author_id: Lanttern.IdentityFixtures.maybe_gen_profile_id(attrs),
         description: "some description"
       })
       |> Lanttern.Personalization.create_note()
@@ -87,11 +85,19 @@ defmodule Lanttern.PersonalizationFixtures do
     profile_strand_filter
   end
 
-  # helpers
+  @doc """
+  Generate a profile_report_card_filters.
+  """
+  def profile_report_card_filters_fixture(attrs \\ %{}) do
+    {:ok, profile_report_card_filters} =
+      attrs
+      |> Enum.into(%{
+        profile_id: Lanttern.IdentityFixtures.maybe_gen_profile_id(attrs),
+        report_card_id: Lanttern.ReportingFixtures.maybe_gen_report_card_id(attrs),
+        class_id: Lanttern.SchoolsFixtures.maybe_gen_class_id(attrs)
+      })
+      |> Lanttern.Personalization.create_profile_report_card_filters()
 
-  defp maybe_gen_author_id(%{author_id: author_id} = _attrs),
-    do: author_id
-
-  defp maybe_gen_author_id(_attrs),
-    do: teacher_profile_fixture().id
+    profile_report_card_filters
+  end
 end


### PR DESCRIPTION
We adjusted how the students are listed in report card context, to keep the list of students linked to the report card more stable, which closes #121.

Now, when you link students to a report card, we'll create a list of "students linked to the report card" — this list is always displayed, and you can even filter by class within the scope of the linked students (using an UI pattern that we should implement in other contexts soon). The list of students displayed in "grades" tab follows this "students linked to the report card" list, preventing the user from viewing grades of students that are not related to the current report card.