### PR TITLE
chore: better upload file name handling

### DIFF
--- a/lib/lanttern/supabase_helpers.ex
+++ b/lib/lanttern/supabase_helpers.ex
@@ -12,16 +12,21 @@ defmodule Lanttern.SupabaseHelpers do
 
   - handles the client
   - puts the bucket name into a `Supabase.Storage.Bucket` struct
-  - URI encodes the path
+  - adds UUID + Slugify + URI encodes the path
   - parses opts to a `Supabase.Storage.ObjectOptions` struct
   """
   def upload_object(bucket_name, path, file, opts \\ %{}) do
     client = client()
 
+    path =
+      "#{Ecto.UUID.generate()}-#{path}"
+      |> Slug.slugify(lowercase: false, ignore: "._")
+      |> URI.encode()
+
     Supabase.Storage.upload_object(
       client,
       Supabase.Storage.Bucket.parse!(%{name: bucket_name}),
-      URI.encode(path),
+      path,
       file,
       Supabase.Storage.ObjectOptions.parse!(opts)
     )

--- a/lib/lanttern_web/live/shared/attachments/attachment_area_component.ex
+++ b/lib/lanttern_web/live/shared/attachments/attachment_area_component.ex
@@ -162,7 +162,7 @@ defmodule LantternWeb.Attachments.AttachmentAreaComponent do
           <%= gettext("File upload") %>
         </p>
         <p class="mt-2 font-bold">
-          <%= Slug.slugify(entry.client_name, lowercase: false, ignore: "._") %>
+          <%= entry.client_name %>
         </p>
         <.error_block :if={@invalid_upload_msg} class="mt-4">
           <%= @invalid_upload_msg %>
@@ -415,11 +415,9 @@ defmodule LantternWeb.Attachments.AttachmentAreaComponent do
   def handle_event("upload", _, socket) do
     [consumed_upload_res] =
       consume_uploaded_entries(socket, :attachment_file, fn %{path: file_path}, entry ->
-        attachment_name = Slug.slugify(entry.client_name, lowercase: false, ignore: "._")
-
         SupabaseHelpers.upload_object(
           "attachments",
-          "#{Ecto.UUID.generate()}-#{attachment_name}",
+          entry.client_name,
           file_path,
           %{content_type: entry.client_type}
         )
@@ -428,7 +426,7 @@ defmodule LantternWeb.Attachments.AttachmentAreaComponent do
             attachment_url =
               "#{SupabaseHelpers.config().base_url}/storage/v1/object/public/#{URI.encode(object["Key"])}"
 
-            {:ok, {:ok, {attachment_url, attachment_name}}}
+            {:ok, {:ok, {attachment_url, entry.client_name}}}
 
           {:error, message} ->
             {:ok, {:error, message}}

--- a/lib/lanttern_web/live/shared/learning_context/strand_form_component.ex
+++ b/lib/lanttern_web/live/shared/learning_context/strand_form_component.ex
@@ -161,7 +161,7 @@ defmodule LantternWeb.LearningContext.StrandFormComponent do
         {:ok, object} =
           SupabaseHelpers.upload_object(
             "covers",
-            "#{Ecto.UUID.generate()}-#{entry.client_name}",
+            entry.client_name,
             file_path,
             %{content_type: entry.client_type}
           )

--- a/lib/lanttern_web/live/shared/reporting/report_card_form_component.ex
+++ b/lib/lanttern_web/live/shared/reporting/report_card_form_component.ex
@@ -154,7 +154,7 @@ defmodule LantternWeb.Reporting.ReportCardFormComponent do
         {:ok, object} =
           SupabaseHelpers.upload_object(
             "covers",
-            "#{Ecto.UUID.generate()}-#{entry.client_name}",
+            entry.client_name,
             file_path,
             %{content_type: entry.client_type}
           )

--- a/lib/lanttern_web/live/shared/reporting/strand_report_form_component.ex
+++ b/lib/lanttern_web/live/shared/reporting/strand_report_form_component.ex
@@ -125,7 +125,7 @@ defmodule LantternWeb.Reporting.StrandReportFormComponent do
         {:ok, object} =
           SupabaseHelpers.upload_object(
             "covers",
-            "#{Ecto.UUID.generate()}-#{entry.client_name}",
+            entry.client_name,
             file_path,
             %{content_type: entry.client_type}
           )

--- a/lib/lanttern_web/live/shared/reporting/student_report_card_form_component.ex
+++ b/lib/lanttern_web/live/shared/reporting/student_report_card_form_component.ex
@@ -109,7 +109,7 @@ defmodule LantternWeb.Reporting.StudentReportCardFormComponent do
         {:ok, object} =
           SupabaseHelpers.upload_object(
             "covers",
-            "#{Ecto.UUID.generate()}-#{entry.client_name}",
+            entry.client_name,
             file_path,
             %{content_type: entry.client_type}
           )

--- a/lib/lanttern_web/router.ex
+++ b/lib/lanttern_web/router.ex
@@ -13,7 +13,7 @@ defmodule LantternWeb.Router do
 
     plug :put_secure_browser_headers, %{
       "content-security-policy" =>
-        "default-src 'self'; script-src-elem 'self' https://accounts.google.com; frame-src 'self' https://accounts.google.com; connect-src 'self' https://accounts.google.com; img-src * data: 'self'; style-src 'self' https://fonts.googleapis.com https://accounts.google.com 'unsafe-inline'; font-src *"
+        "default-src 'self'; script-src-elem 'self' https://accounts.google.com; frame-src 'self' https://accounts.google.com; connect-src 'self' https://accounts.google.com; img-src * data: blob: 'self'; style-src 'self' https://fonts.googleapis.com https://accounts.google.com 'unsafe-inline'; font-src *"
     }
 
     plug :fetch_current_user


### PR DESCRIPTION
enhanced `SupabaseHelpers.upload_object/4` path handling. now, the functions prepends an UUID and slugify the path (in addition to the previously implemented URI encoding), avoiding file upload issues as described in #119

- added `blob:` to img-src CSP
- resolves #119 