### PR TITLE
Fixed student strand report notes tab

### DIFF
--- a/lib/lanttern_web/live/pages/student notes/student_notes_live.ex
+++ b/lib/lanttern_web/live/pages/student notes/student_notes_live.ex
@@ -143,18 +143,10 @@ defmodule LantternWeb.StudentNotesLive do
   end
 
   def handle_info({NoteComponent, {:saved, note}}, socket) do
-    socket =
-      socket
-      |> assign(:note, note)
-
-    {:noreply, socket}
+    {:noreply, assign(socket, :note, note)}
   end
 
   def handle_info({NoteComponent, {:deleted, _}}, socket) do
-    socket =
-      socket
-      |> assign(:note, nil)
-
-    {:noreply, socket}
+    {:noreply, assign(socket, :note, nil)}
   end
 end

--- a/lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_notes_component.ex
+++ b/lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_notes_component.ex
@@ -30,13 +30,15 @@ defmodule LantternWeb.StudentStrandReportLive.StudentNotesComponent do
           }
           empty_add_note_msg={gettext("Add a strand note")}
           allow_editing={@is_student}
+          notify_component={@myself}
         />
         <.live_component
+          :if={@note}
           module={AttachmentAreaComponent}
           id="student-strand-note-attachemnts"
           class="mt-10"
           current_user={@current_user}
-          note_id={@note && @note.id}
+          note_id={@note.id}
           title={gettext("Note's attachments")}
           allow_editing={@is_student}
         />
@@ -53,6 +55,14 @@ defmodule LantternWeb.StudentStrandReportLive.StudentNotesComponent do
   end
 
   @impl true
+  def update(%{action: {NoteComponent, {:saved, note}}}, socket) do
+    {:ok, assign(socket, :note, note)}
+  end
+
+  def update(%{action: {NoteComponent, {:deleted, _note}}}, socket) do
+    {:ok, assign(socket, :note, nil)}
+  end
+
   def update(assigns, socket) do
     %{student_id: student_id, strand_id: strand_id} = assigns
 

--- a/lib/lanttern_web/live/shared/attachments/attachment_area_component.ex
+++ b/lib/lanttern_web/live/shared/attachments/attachment_area_component.ex
@@ -282,7 +282,13 @@ defmodule LantternWeb.Attachments.AttachmentAreaComponent do
   end
 
   defp stream_attachments(socket) do
-    attachments = Notes.list_note_attachments(socket.assigns.note_id)
+    attachments =
+      if socket.assigns.note_id do
+        Notes.list_note_attachments(socket.assigns.note_id)
+      else
+        []
+      end
+
     attachments_ids = Enum.map(attachments, & &1.id)
 
     socket

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2024.5.27-alpha.16",
+      version: "2024.5.28-alpha.17",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
There were a crash caused by a `Notes.list_note_attachments/1` being called with `nil`.