### PR TITLE
added support to register student self-assessment

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -15,12 +15,6 @@ module.exports = {
         ltrn: {
           primary: colors.cyan["400"],
           secondary: colors.rose["500"],
-          diff: {
-            dark: colors.purple["800"],
-            highlight: colors.purple["600"],
-            light: colors.purple["200"],
-            lightest: colors.purple["100"],
-          },
           dark: colors.slate["700"],
           subtle: colors.slate["400"],
           light: colors.slate["300"],
@@ -34,8 +28,28 @@ module.exports = {
             yellow: colors.yellow["100"],
             lime: colors.lime["100"],
           },
-          alert: colors.red["500"],
-          "alert-lighter": colors.red["100"]
+          diff: {
+            dark: colors.violet["800"],
+            accent: colors.violet["600"],
+            lighter: colors.violet["200"],
+            lightest: colors.violet["50"],
+          },
+          std: {
+            dark: colors.yellow["700"],
+            accent: colors.yellow["400"],
+            lighter: colors.yellow["200"],
+            lightest: colors.yellow["50"],
+          },
+          tt: {
+            dark: colors.lime["800"],
+            accent: colors.lime["500"],
+            lighter: colors.lime["200"],
+            lightest: colors.lime["50"],
+          },
+          alert: {
+            accent: colors.red["500"],
+            lighter: colors.red["100"]
+          }
         },
       },
       fontFamily: {

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -34,13 +34,13 @@ module.exports = {
             lighter: colors.violet["200"],
             lightest: colors.violet["50"],
           },
-          std: {
+          student: {
             dark: colors.yellow["700"],
             accent: colors.yellow["400"],
             lighter: colors.yellow["200"],
             lightest: colors.yellow["50"],
           },
-          tt: {
+          teacher: {
             dark: colors.lime["800"],
             accent: colors.lime["500"],
             lighter: colors.lime["200"],

--- a/lib/lanttern/assessments/assessment_point_entry.ex
+++ b/lib/lanttern/assessments/assessment_point_entry.ex
@@ -34,7 +34,9 @@ defmodule Lanttern.Assessments.AssessmentPointEntry do
           id: pos_integer(),
           observation: String.t(),
           report_note: String.t(),
+          student_report_note: String.t(),
           score: float(),
+          student_score: float(),
           scale_type: String.t(),
           assessment_point: AssessmentPoint.t(),
           assessment_point_id: pos_integer(),
@@ -44,6 +46,8 @@ defmodule Lanttern.Assessments.AssessmentPointEntry do
           scale_id: pos_integer(),
           ordinal_value: OrdinalValue.t(),
           ordinal_value_id: pos_integer(),
+          student_ordinal_value: OrdinalValue.t(),
+          student_ordinal_value_id: pos_integer(),
           differentiation_rubric: Rubric.t(),
           differentiation_rubric_id: pos_integer(),
           feedback: Feedback.t(),
@@ -54,13 +58,16 @@ defmodule Lanttern.Assessments.AssessmentPointEntry do
   schema "assessment_point_entries" do
     field :observation, :string
     field :report_note, :string
+    field :student_report_note, :string
     field :score, :float
+    field :student_score, :float
     field :scale_type, :string
 
     belongs_to :assessment_point, AssessmentPoint
     belongs_to :student, Student
     belongs_to :scale, Scale
     belongs_to :ordinal_value, OrdinalValue
+    belongs_to :student_ordinal_value, OrdinalValue
     belongs_to :differentiation_rubric, Rubric
 
     # warning: don't use `Repo.preload/3` with this association.
@@ -108,12 +115,15 @@ defmodule Lanttern.Assessments.AssessmentPointEntry do
     |> cast(attrs, [
       :observation,
       :report_note,
+      :student_report_note,
       :score,
+      :student_score,
       :assessment_point_id,
       :student_id,
       :scale_id,
       :scale_type,
       :ordinal_value_id,
+      :student_ordinal_value_id,
       :differentiation_rubric_id
     ])
     |> validate_required([:assessment_point_id, :student_id, :scale_id, :scale_type])

--- a/lib/lanttern/assessments_log/assessment_point_entry_log.ex
+++ b/lib/lanttern/assessments_log/assessment_point_entry_log.ex
@@ -13,13 +13,16 @@ defmodule Lanttern.AssessmentsLog.AssessmentPointEntryLog do
     field :operation, :string
     field :observation, :string
     field :score, :float
+    field :student_score, :float
     field :assessment_point_id, :integer
     field :student_id, :integer
     field :ordinal_value_id, :integer
+    field :student_ordinal_value_id, :integer
     field :scale_id, :integer
     field :scale_type, :string
     field :differentiation_rubric_id, :integer
     field :report_note, :string
+    field :student_report_note, :string
 
     timestamps(updated_at: false)
   end
@@ -33,13 +36,16 @@ defmodule Lanttern.AssessmentsLog.AssessmentPointEntryLog do
       :operation,
       :observation,
       :score,
+      :student_score,
       :assessment_point_id,
       :student_id,
       :ordinal_value_id,
+      :student_ordinal_value_id,
       :scale_id,
       :scale_type,
       :differentiation_rubric_id,
-      :report_note
+      :report_note,
+      :student_report_note
     ])
     |> validate_required([
       :assessment_point_entry_id,

--- a/lib/lanttern/personalization/profile_settings.ex
+++ b/lib/lanttern/personalization/profile_settings.ex
@@ -6,6 +6,8 @@ defmodule Lanttern.Personalization.ProfileSettings do
   use Ecto.Schema
   import Ecto.Changeset
 
+  import LantternWeb.Gettext
+
   alias Lanttern.Identity.Profile
 
   @type t :: %__MODULE__{
@@ -21,7 +23,8 @@ defmodule Lanttern.Personalization.ProfileSettings do
           classes_ids: [pos_integer()],
           subjects_ids: [pos_integer()],
           years_ids: [pos_integer()],
-          cycles_ids: [pos_integer()]
+          cycles_ids: [pos_integer()],
+          assessment_view: String.t()
         }
 
   schema "profile_settings" do
@@ -32,6 +35,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
       field :subjects_ids, {:array, :id}
       field :years_ids, {:array, :id}
       field :cycles_ids, {:array, :id}
+      field :assessment_view, :string
     end
 
     timestamps()
@@ -47,6 +51,11 @@ defmodule Lanttern.Personalization.ProfileSettings do
 
   defp current_filters_changeset(current_filters, attrs) do
     current_filters
-    |> cast(attrs, [:classes_ids, :subjects_ids, :years_ids, :cycles_ids])
+    |> cast(attrs, [:classes_ids, :subjects_ids, :years_ids, :cycles_ids, :assessment_view])
+    |> validate_change(:assessment_view, fn :assessment_view, view ->
+      if view in ["teacher", "student", "compare"],
+        do: [],
+        else: [assessment_view: gettext("Invalid assessment view")]
+    end)
   end
 end

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -87,7 +87,9 @@ defmodule LantternWeb.CoreComponents do
     "secondary" => "bg-ltrn-secondary text-white",
     "cyan" => "bg-ltrn-mesh-cyan text-ltrn-dark",
     "dark" => "bg-ltrn-dark text-ltrn-lighter",
-    "diff" => "bg-ltrn-diff-lightest text-ltrn-diff-highlight"
+    "diff" => "bg-ltrn-diff-lighter text-ltrn-diff-dark",
+    "student" => "bg-ltrn-std-lighter text-ltrn-std-dark",
+    "teacher" => "bg-ltrn-tt-lighter text-ltrn-tt-dark"
   }
 
   @badge_themes_hover %{
@@ -95,7 +97,10 @@ defmodule LantternWeb.CoreComponents do
     "primary" => "hover:bg-ltrn-primary/50",
     "secondary" => "hover:bg-ltrn-secondary/50",
     "cyan" => "hover:bg-ltrn-mesh-cyan/50",
-    "dark" => "hover:bg-ltrn-dark/50"
+    "dark" => "hover:bg-ltrn-dark/50",
+    "diff" => "hover:bg-ltrn-diff-lightest",
+    "student" => "hover:bg-ltrn-std-lightest",
+    "teacher" => "hover:bg-ltrn-tt-lightest"
   }
 
   defp badge_theme(theme, with_hover \\ false) do
@@ -288,7 +293,7 @@ defmodule LantternWeb.CoreComponents do
       "disabled:text-ltrn-subtle disabled:bg-ltrn-mesh-cyan disabled:shadow-none"
     ],
     "diff_light" => [
-      "bg-ltrn-diff-lightest hover:bg-ltrn-diff-light text-ltrn-diff-dark",
+      "bg-ltrn-diff-lightest hover:bg-ltrn-diff-lighter text-ltrn-diff-dark",
       "disabled:opacity-40"
     ],
     "white" => "text-ltrn-dark bg-white hover:bg-ltrn-lightest shadow-sm",
@@ -994,7 +999,7 @@ defmodule LantternWeb.CoreComponents do
     "subtle" => "text-ltrn-subtle bg-ltrn-lighter",
     "cyan" => "text-ltrn-dark bg-ltrn-mesh-primary",
     "rose" => "text-ltrn-dark bg-ltrn-mesh-rose",
-    "diff" => "text-ltrn-diff-lightest bg-ltrn-diff-highlight"
+    "diff" => "text-ltrn-diff-lightest bg-ltrn-diff-accent"
   }
 
   defp profile_icon_theme(theme, false),
@@ -1166,7 +1171,7 @@ defmodule LantternWeb.CoreComponents do
 
   @toggle_themes %{
     "default" => "focus:ring-ltrn-primary",
-    "diff" => "focus:ring-ltrn-diff-highlight"
+    "diff" => "focus:ring-ltrn-diff-accent"
   }
 
   defp toggle_theme(theme),
@@ -1174,7 +1179,7 @@ defmodule LantternWeb.CoreComponents do
 
   @toggle_enabled_themes %{
     "default" => "bg-ltrn-primary",
-    "diff" => "bg-ltrn-diff-highlight"
+    "diff" => "bg-ltrn-diff-accent"
   }
 
   defp toggle_enabled_theme(theme),

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -88,8 +88,8 @@ defmodule LantternWeb.CoreComponents do
     "cyan" => "bg-ltrn-mesh-cyan text-ltrn-dark",
     "dark" => "bg-ltrn-dark text-ltrn-lighter",
     "diff" => "bg-ltrn-diff-lighter text-ltrn-diff-dark",
-    "student" => "bg-ltrn-std-lighter text-ltrn-std-dark",
-    "teacher" => "bg-ltrn-tt-lighter text-ltrn-tt-dark"
+    "student" => "bg-ltrn-student-lighter text-ltrn-student-dark",
+    "teacher" => "bg-ltrn-teacher-lighter text-ltrn-teacher-dark"
   }
 
   @badge_themes_hover %{
@@ -99,8 +99,8 @@ defmodule LantternWeb.CoreComponents do
     "cyan" => "hover:bg-ltrn-mesh-cyan/50",
     "dark" => "hover:bg-ltrn-dark/50",
     "diff" => "hover:bg-ltrn-diff-lightest",
-    "student" => "hover:bg-ltrn-std-lightest",
-    "teacher" => "hover:bg-ltrn-tt-lightest"
+    "student" => "hover:bg-ltrn-student-lightest",
+    "teacher" => "hover:bg-ltrn-teacher-lightest"
   }
 
   defp badge_theme(theme, with_hover \\ false) do
@@ -297,11 +297,11 @@ defmodule LantternWeb.CoreComponents do
       "disabled:opacity-40"
     ],
     "teacher" => [
-      "bg-ltrn-tt-accent text-ltrn-tt-dark hover:opacity-80",
+      "bg-ltrn-teacher-accent text-ltrn-teacher-dark hover:opacity-80",
       "disabled:opacity-40"
     ],
     "student" => [
-      "bg-ltrn-std-accent text-ltrn-std-dark hover:opacity-80",
+      "bg-ltrn-student-accent text-ltrn-student-dark hover:opacity-80",
       "disabled:opacity-40"
     ],
     "white" => "text-ltrn-dark bg-white hover:bg-ltrn-lightest shadow-sm",

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -296,6 +296,14 @@ defmodule LantternWeb.CoreComponents do
       "bg-ltrn-diff-lightest hover:bg-ltrn-diff-lighter text-ltrn-diff-dark",
       "disabled:opacity-40"
     ],
+    "teacher" => [
+      "bg-ltrn-tt-accent text-ltrn-tt-dark hover:opacity-80",
+      "disabled:opacity-40"
+    ],
+    "student" => [
+      "bg-ltrn-std-accent text-ltrn-std-dark hover:opacity-80",
+      "disabled:opacity-40"
+    ],
     "white" => "text-ltrn-dark bg-white hover:bg-ltrn-lightest shadow-sm",
     "ghost" => [
       "text-ltrn-subtle bg-white/10 hover:bg-slate-100",

--- a/lib/lanttern_web/components/form_components.ex
+++ b/lib/lanttern_web/components/form_components.ex
@@ -550,7 +550,7 @@ defmodule LantternWeb.FormComponents do
     ~H"""
     <div
       class={[
-        "flex items-center gap-4 p-4 rounded-sm text-sm text-ltrn-alert bg-ltrn-alert-lighter",
+        "flex items-center gap-4 p-4 rounded-sm text-sm text-ltrn-alert-accent bg-ltrn-alert-lighter",
         @class
       ]}
       {@rest}

--- a/lib/lanttern_web/components/navigation_components.ex
+++ b/lib/lanttern_web/components/navigation_components.ex
@@ -106,7 +106,7 @@ defmodule LantternWeb.NavigationComponents do
   @person_tab_themes %{
     "default" => "text-ltrn-subtle bg-ltrn-lighter",
     "cyan" => "text-ltrn-dark bg-ltrn-mesh-cyan",
-    "diff" => "text-ltrn-diff-highlight bg-ltrn-diff-lightest"
+    "diff" => "text-ltrn-diff-accent bg-ltrn-diff-lightest"
   }
 
   defp person_tab_theme(theme),

--- a/lib/lanttern_web/components/overlay_components.ex
+++ b/lib/lanttern_web/components/overlay_components.ex
@@ -449,7 +449,7 @@ defmodule LantternWeb.OverlayComponents do
 
   @menu_button_item_themes %{
     "default" => "text-ltrn-dark",
-    "alert" => "text-ltrn-alert"
+    "alert" => "text-ltrn-alert-accent"
   }
 
   defp menu_button_item_theme_classes(theme),

--- a/lib/lanttern_web/components/reporting_components.ex
+++ b/lib/lanttern_web/components/reporting_components.ex
@@ -218,7 +218,7 @@ defmodule LantternWeb.ReportingComponents do
       ]}
     >
       <.responsive_container>
-        <div class="flex items-center justify-center w-10 h-10 rounded-full mb-6 text-ltrn-diff-lightest bg-ltrn-diff-highlight">
+        <div class="flex items-center justify-center w-10 h-10 rounded-full mb-6 text-ltrn-diff-lightest bg-ltrn-diff-accent">
           <.icon name="hero-document-text" />
         </div>
         <.markdown text={@footnote} size="sm" />

--- a/lib/lanttern_web/helpers/assessments_helpers.ex
+++ b/lib/lanttern_web/helpers/assessments_helpers.ex
@@ -26,11 +26,11 @@ defmodule LantternWeb.AssessmentsHelpers do
   Logs all entries.
   """
   @type changes_map() :: %{
-          optional(binary) => {type :: atom(), entry_id :: pos_integer(), params :: map()}
+          optional(String.t()) => {type :: atom(), entry_id :: pos_integer(), params :: map()}
         }
 
   @spec save_entry_editor_component_changes(changes_map(), profile_id :: pos_integer() | nil) ::
-          {:ok | :error, results_message :: binary()}
+          {:ok | :error, results_message :: String.t()}
   def save_entry_editor_component_changes(changes_map, profile_id \\ nil) do
     changes =
       changes_map

--- a/lib/lanttern_web/helpers/filters_helpers.ex
+++ b/lib/lanttern_web/helpers/filters_helpers.ex
@@ -55,6 +55,10 @@ defmodule LantternWeb.FiltersHelpers do
   - `:selected_linked_students_classes_ids`
   - `:selected_linked_students_classes`
 
+  ### `:assessment_view`' assigns
+
+  - `:current_assessment_view`
+
   ## Examples
 
       iex> assign_user_filters(socket, [:subjects], user)
@@ -166,6 +170,21 @@ defmodule LantternWeb.FiltersHelpers do
     |> assign_filter_type(current_user, current_filters, filter_types, opts)
   end
 
+  defp assign_filter_type(
+         socket,
+         current_user,
+         current_filters,
+         [:assessment_view | filter_types],
+         opts
+       ) do
+    current_assessment_view =
+      Map.get(current_filters, :assessment_view) || "teacher"
+
+    socket
+    |> assign(:current_assessment_view, current_assessment_view)
+    |> assign_filter_type(current_user, current_filters, filter_types, opts)
+  end
+
   defp assign_filter_type(socket, current_user, current_filters, [_ | filter_types], opts),
     do: assign_filter_type(socket, current_user, current_filters, filter_types, opts)
 
@@ -270,6 +289,7 @@ defmodule LantternWeb.FiltersHelpers do
   - `:subjects`
   - `:years`
   - `:cycles`
+  - `:linked_students_classes`
 
   ## Examples
 

--- a/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
@@ -98,7 +98,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
           class={[
             "relative w-full max-h-[calc(100vh-4rem)] border mt-6 rounded shadow-xl #{@view_bg} overflow-x-auto",
             if(@current_assessment_view == "student",
-              do: "border-ltrn-std-accent",
+              do: "border-ltrn-student-accent",
               else: "border-transparent"
             )
           ]}
@@ -129,7 +129,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
             <div
               id="grid-student-entries"
               phx-update="stream"
-              class="grid grid-cols-subgrid pb-4 pr-4"
+              class="grid grid-cols-subgrid pb-4"
               style={"grid-column: span #{@assessment_points_count + 1} / span #{@assessment_points_count + 1}"}
             >
               <.student_entries
@@ -226,10 +226,10 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
         <%= @assessment_point.curriculum_item.name %>
       </p>
       <div :if={@assessment_view == "compare"} class="flex gap-1 w-full">
-        <div class="flex-1 pb-1 border-b-2 border-ltrn-tt-accent text-xs text-center text-ltrn-tt-dark">
+        <div class="flex-1 pb-1 border-b-2 border-ltrn-teacher-accent text-xs text-center text-ltrn-teacher-dark">
           <%= gettext("Teacher") %>
         </div>
-        <div class="flex-1 pb-1 border-b-2 border-ltrn-std-accent text-xs text-center text-ltrn-std-dark">
+        <div class="flex-1 pb-1 border-b-2 border-ltrn-student-accent text-xs text-center text-ltrn-student-dark">
           <%= gettext("Student") %>
         </div>
       </div>
@@ -356,7 +356,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
   defp assign_view_bg(socket) do
     view_bg =
       case socket.assigns.current_assessment_view do
-        "student" -> "bg-ltrn-std-lightest"
+        "student" -> "bg-ltrn-student-lightest"
         _ -> "bg-white"
       end
 

--- a/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
@@ -4,6 +4,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
   alias Lanttern.Assessments
   alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.Filters
+  alias Lanttern.Identity.User
   alias Lanttern.Reporting
   alias Lanttern.Schools.Student
 
@@ -138,6 +139,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
                 myself={@myself}
                 current_assessment_view={@current_assessment_view}
                 view_bg={@view_bg}
+                current_user={@current_user}
               />
             </div>
           </div>
@@ -231,6 +233,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
   attr :myself, Phoenix.LiveComponent.CID, required: true
   attr :current_assessment_view, :string, required: true
   attr :view_bg, :string, required: true
+  attr :current_user, User, required: true
 
   def student_entries(assigns) do
     ~H"""
@@ -256,6 +259,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
           wrapper_class="w-full h-full"
           notify_component={@myself}
           assessment_view={@current_assessment_view}
+          current_user={@current_user}
         >
           <:marking_input class="w-full h-full" />
         </.live_component>

--- a/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
@@ -12,6 +12,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
   import LantternWeb.FiltersHelpers, only: [assign_user_filters: 4, assign_user_filters: 3]
 
   # shared components
+  alias LantternWeb.Assessments.EntryCompareComponent
   alias LantternWeb.Assessments.EntryEditorComponent
   import LantternWeb.ReportingComponents
 
@@ -121,6 +122,7 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
                   :for={{dom_id, assessment_point} <- @streams.assessment_points}
                   id={dom_id}
                   assessment_point={assessment_point}
+                  assessment_view={@current_assessment_view}
                 />
               </div>
             </div>
@@ -207,11 +209,12 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
 
   attr :id, :string, required: true
   attr :assessment_point, AssessmentPoint, required: true
+  attr :assessment_view, :string, required: true
 
   def assessment_point(assigns) do
     ~H"""
-    <div id={@id} class="max-w-80 pt-6 px-2 pb-2 text-sm">
-      <div class="flex items-center gap-2 mb-2">
+    <div id={@id} class="flex flex-col gap-2 max-w-80 pt-6 px-2 pb-2 text-sm">
+      <div class="flex items-center gap-2">
         <.badge>
           <%= @assessment_point.curriculum_item.curriculum_component.name %>
         </.badge>
@@ -219,9 +222,17 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
           <%= gettext("Diff") %>
         </.badge>
       </div>
-      <p class="line-clamp-3" title={@assessment_point.curriculum_item.name}>
+      <p class="flex-1 line-clamp-3" title={@assessment_point.curriculum_item.name}>
         <%= @assessment_point.curriculum_item.name %>
       </p>
+      <div :if={@assessment_view == "compare"} class="flex gap-1 w-full">
+        <div class="flex-1 pb-1 border-b-2 border-ltrn-tt-accent text-xs text-center text-ltrn-tt-dark">
+          <%= gettext("Teacher") %>
+        </div>
+        <div class="flex-1 pb-1 border-b-2 border-ltrn-std-accent text-xs text-center text-ltrn-std-dark">
+          <%= gettext("Student") %>
+        </div>
+      </div>
     </div>
     """
   end
@@ -248,21 +259,32 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
           extra_info={@student.classes |> Enum.map(& &1.name) |> Enum.join(", ")}
         />
       </div>
-      <div :for={{entry, assessment_point} <- @entries} class="p-2">
-        <.live_component
-          module={EntryEditorComponent}
-          id={"student-#{@student.id}-entry-for-#{assessment_point.id}"}
-          student={@student}
-          assessment_point={assessment_point}
-          entry={entry}
-          class="w-full h-full"
-          wrapper_class="w-full h-full"
-          notify_component={@myself}
-          assessment_view={@current_assessment_view}
-          current_user={@current_user}
-        >
-          <:marking_input class="w-full h-full" />
-        </.live_component>
+      <div :for={{entry, assessment_point} <- @entries} class="max-w-80 p-2">
+        <%= if @current_assessment_view == "compare" do %>
+          <.live_component
+            module={EntryCompareComponent}
+            id={"student-#{@student.id}-entry-for-#{assessment_point.id}"}
+            class="w-full h-full"
+            student={@student}
+            scale={assessment_point.scale}
+            entry={entry}
+          />
+        <% else %>
+          <.live_component
+            module={EntryEditorComponent}
+            id={"student-#{@student.id}-entry-for-#{assessment_point.id}"}
+            student={@student}
+            assessment_point={assessment_point}
+            entry={entry}
+            class="w-full h-full"
+            wrapper_class="w-full h-full"
+            notify_component={@myself}
+            assessment_view={@current_assessment_view}
+            current_user={@current_user}
+          >
+            <:marking_input class="w-full h-full" />
+          </.live_component>
+        <% end %>
       </div>
     </div>
     """

--- a/lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex
@@ -96,7 +96,7 @@ defmodule LantternWeb.StrandLive.StrandRubricsComponent do
               class={[
                 "p-6 rounded mt-6 bg-white shadow-lg",
                 if(@students_diff_rubrics_map[student.id][assessment_point.id],
-                  do: "border border-ltrn-diff-highlight"
+                  do: "border border-ltrn-diff-accent"
                 )
               ]}
             >

--- a/lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex
@@ -1,4 +1,5 @@
 defmodule LantternWeb.MomentLive.AssessmentComponent do
+  alias Lanttern.Identity.User
   use LantternWeb, :live_component
 
   alias Lanttern.Assessments
@@ -112,6 +113,7 @@ defmodule LantternWeb.MomentLive.AssessmentComponent do
               entries={entries}
               id={dom_id}
               myself={@myself}
+              current_user={@current_user}
             />
           </div>
         </div>
@@ -291,6 +293,7 @@ defmodule LantternWeb.MomentLive.AssessmentComponent do
   attr :student, Lanttern.Schools.Student, required: true
   attr :entries, :list, required: true
   attr :myself, Phoenix.LiveComponent.CID, required: true
+  attr :current_user, User, required: true
 
   def student_and_entries(assigns) do
     ~H"""
@@ -311,6 +314,7 @@ defmodule LantternWeb.MomentLive.AssessmentComponent do
             class="w-full h-full"
             wrapper_class="w-full h-full"
             notify_component={@myself}
+            current_user={@current_user}
           >
             <:marking_input class="w-full h-full" />
           </.live_component>

--- a/lib/lanttern_web/live/shared/assessments/entry_compare_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_compare_component.ex
@@ -1,0 +1,137 @@
+defmodule LantternWeb.Assessments.EntryCompareComponent do
+  @moduledoc """
+  Displays teacher assessment and student self-assessment
+  side by side.
+
+  Expected external assigns:
+
+      attr :entry, Lanttern.Assessments.AssessmentPointEntry, required: true
+      attr :scale, Lanttern.Grading.Scale, required: true
+
+  """
+  use LantternWeb, :live_component
+
+  alias Lanttern.Grading.OrdinalValue
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class={["grid grid-cols-2 gap-1", @class]}>
+      <.entry_view entry_value={@teacher_value} entry_style={@teacher_style} scale_type={@scale.type} />
+      <.entry_view entry_value={@student_value} entry_style={@student_style} scale_type={@scale.type} />
+    </div>
+    """
+  end
+
+  attr :scale_type, :string, required: true
+  attr :entry_style, :string, default: nil
+  attr :entry_value, :any, default: nil
+
+  def entry_view(%{entry_value: nil} = assigns) do
+    ~H"""
+    <div class="flex items-center justify-center p-2 rounded-sm font-mono text-sm text-ltrn-subtle bg-ltrn-lighter">
+      —
+    </div>
+    """
+  end
+
+  def entry_view(%{scale_type: "ordinal"} = assigns) do
+    ~H"""
+    <div
+      class="flex items-center justify-center p-2 rounded-sm font-mono text-sm bg-white"
+      style={@entry_style}
+    >
+      <span class="truncate">
+        <%= @entry_value %>
+      </span>
+    </div>
+    """
+  end
+
+  def entry_view(%{scale_type: "numeric"} = assigns) do
+    ~H"""
+    <div
+      class="flex items-center justify-center p-2 border border-ltrn-light rounded-sm font-mono text-sm bg-white"
+      style={@entry_style}
+    >
+      <%= @entry_value %>
+    </div>
+    """
+  end
+
+  # lifecycle
+
+  @impl true
+  def mount(socket) do
+    socket =
+      socket
+      |> assign(:class, nil)
+      |> assign(:viewing_note, nil)
+      |> assign(:teacher_style, nil)
+      |> assign(:teacher_value, nil)
+      |> assign(:student_style, nil)
+      |> assign(:student_value, nil)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign_styles_and_values()
+
+    {:ok, socket}
+  end
+
+  # helpers
+
+  defp assign_styles_and_values(%{assigns: %{entry: %{scale_type: "ordinal"}}} = socket) do
+    %{
+      entry: %{
+        ordinal_value_id: ordinal_value_id,
+        student_ordinal_value_id: student_ordinal_value_id
+      },
+      scale: %{ordinal_values: ordinal_values}
+    } = socket.assigns
+
+    {teacher_style, teacher_value} =
+      ordinal_values
+      |> Enum.find(&(&1.id == ordinal_value_id))
+      |> case do
+        nil -> {nil, nil}
+        ov -> {get_colors_style(ov), ov.name}
+      end
+
+    {student_style, student_value} =
+      ordinal_values
+      |> Enum.find(&(&1.id == student_ordinal_value_id))
+      |> case do
+        nil -> {nil, nil}
+        ov -> {get_colors_style(ov), ov.name}
+      end
+
+    socket
+    |> assign(:teacher_style, teacher_style)
+    |> assign(:teacher_value, teacher_value)
+    |> assign(:student_style, student_style)
+    |> assign(:student_value, student_value)
+  end
+
+  defp assign_styles_and_values(%{assigns: %{entry: %{scale_type: "numeric"}}} = socket) do
+    entry = socket.assigns.entry
+
+    socket
+    |> assign(:teacher_value, entry.score)
+    |> assign(:student_value, entry.student_score)
+  end
+
+  defp assign_styles_and_values(socket), do: socket
+
+  defp get_colors_style(%OrdinalValue{} = ordinal_value) do
+    "background-color: #{ordinal_value.bg_color}; color: #{ordinal_value.text_color}"
+  end
+
+  defp get_colors_style(_), do: ""
+end

--- a/lib/lanttern_web/live/shared/assessments/entry_editor_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_editor_component.ex
@@ -20,6 +20,7 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
   alias Lanttern.Grading.OrdinalValue
   alias Lanttern.Grading.Scale
 
+  @impl true
   def render(assigns) do
     ~H"""
     <div class={["flex items-center", @wrapper_class]}>
@@ -149,6 +150,21 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
 
   # lifecycle
 
+  @impl true
+  def mount(socket) do
+    socket =
+      socket
+      |> assign(:class, nil)
+      |> assign(:wrapper_class, nil)
+      |> assign(:has_changes, false)
+      |> assign(:is_editing_note, false)
+      |> assign(:assessment_view, "teacher")
+      |> assign(:marking_input, [])
+
+    {:ok, socket}
+  end
+
+  @impl true
   def update(assigns, socket) do
     %{
       student: student,
@@ -168,12 +184,6 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
       |> assign(assigns)
       |> assign(:entry, entry)
       |> assign(:form, form)
-      |> assign(:assessment_view, Map.get(assigns, :assessment_view, "teacher"))
-      |> assign(:wrapper_class, Map.get(assigns, :wrapper_class, ""))
-      |> assign(:class, Map.get(assigns, :class, ""))
-      |> assign(:marking_input, Map.get(assigns, :marking_input, []))
-      |> assign(:has_changes, false)
-      |> assign(:is_editing_note, false)
       |> assign_ordinal_value_options()
       |> assign_entry_value()
       |> assign_entry_note()
@@ -184,6 +194,7 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
 
   # event handlers
 
+  @impl true
   def handle_event("change", %{"assessment_point_entry" => params}, socket) do
     %{
       entry: %{scale_type: scale_type} = entry,
@@ -257,14 +268,17 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
     {:noreply, socket}
   end
 
+  @impl true
   def handle_event("edit_note", _, socket) do
     {:noreply, assign(socket, :is_editing_note, true)}
   end
 
+  @impl true
   def handle_event("cancel_edit_note", _, socket) do
     {:noreply, assign(socket, :is_editing_note, false)}
   end
 
+  @impl true
   def handle_event("save_note", %{"assessment_point_entry" => params}, socket) do
     opts = [log_profile_id: socket.assigns.current_user.current_profile_id]
 

--- a/lib/lanttern_web/live/shared/assessments/entry_editor_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_editor_component.ex
@@ -45,7 +45,7 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
       <.icon_button
         type="button"
         name="hero-pencil-square-mini"
-        theme={if @entry_note && @entry_value, do: "diff_light", else: "ghost"}
+        theme={@note_button_theme}
         rounded
         sr_text={gettext("Add entry note")}
         size="sm"
@@ -266,8 +266,10 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
   end
 
   def handle_event("save_note", %{"assessment_point_entry" => params}, socket) do
+    opts = [log_profile_id: socket.assigns.current_user.current_profile_id]
+
     socket =
-      case Assessments.update_assessment_point_entry(socket.assigns.entry, params) do
+      case Assessments.update_assessment_point_entry(socket.assigns.entry, params, opts) do
         {:ok, entry} ->
           form =
             entry
@@ -329,6 +331,7 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
   defp assign_entry_note(socket) do
     %{
       entry: entry,
+      entry_value: entry_value,
       assessment_view: assessment_view
     } = socket.assigns
 
@@ -338,7 +341,16 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
         _ -> entry.report_note
       end
 
-    assign(socket, :entry_note, entry_note)
+    note_button_theme =
+      cond do
+        entry_note && entry_value && assessment_view == "student" -> "student"
+        entry_note && entry_value -> "teacher"
+        true -> "ghost"
+      end
+
+    socket
+    |> assign(:entry_note, entry_note)
+    |> assign(:note_button_theme, note_button_theme)
   end
 
   defp assign_ov_style_and_name(socket) do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2024.5.29-alpha.19",
+      version: "2024.6.10-alpha.20",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,8 +11,8 @@
 msgid ""
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1271
-#: lib/lanttern_web/components/core_components.ex:1333
+#: lib/lanttern_web/components/core_components.ex:1284
+#: lib/lanttern_web/components/core_components.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -58,7 +58,7 @@ msgstr ""
 msgid "Strands"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:515
+#: lib/lanttern_web/components/core_components.ex:528
 #: lib/lanttern_web/components/overlay_components.ex:78
 #: lib/lanttern_web/components/overlay_components.ex:330
 #, elixir-autogen, elixir-format
@@ -115,8 +115,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:138
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:136
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:199
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:177
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:236
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:179
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:238
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:128
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:130
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:91
@@ -170,12 +170,12 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:141
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:165
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:201
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:139
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:206
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:180
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:239
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:255
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:182
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:241
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:257
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:131
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:133
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:94
@@ -317,17 +317,17 @@ msgstr ""
 msgid "or drag and drop here"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:554
+#: lib/lanttern_web/components/core_components.ex:567
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:545
+#: lib/lanttern_web/components/core_components.ex:558
 #, elixir-autogen, elixir-format
 msgid "Error!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:566
+#: lib/lanttern_web/components/core_components.ex:579
 #, elixir-autogen, elixir-format
 msgid "Hang in there while we get back on track"
 msgstr ""
@@ -337,22 +337,22 @@ msgstr ""
 msgid "Markdown supported"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:544
+#: lib/lanttern_web/components/core_components.ex:557
 #, elixir-autogen, elixir-format
 msgid "Success!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:549
+#: lib/lanttern_web/components/core_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:561
+#: lib/lanttern_web/components/core_components.ex:574
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:419
+#: lib/lanttern_web/components/core_components.ex:432
 #, elixir-autogen, elixir-format
 msgid "all %{type}"
 msgstr ""
@@ -395,7 +395,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:68
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:190
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:168
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:170
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:119
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:70
 #, elixir-autogen, elixir-format
@@ -461,12 +461,12 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:160
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:196
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:71
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:188
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:144
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:166
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:250
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:146
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:168
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:252
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:117
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:73
 #: lib/lanttern_web/live/shared/notes/note_component.ex:50
@@ -475,7 +475,7 @@ msgid "Are you sure?"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:53
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:73
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:74
 #, elixir-autogen, elixir-format
 msgid "Current assessment points"
 msgstr ""
@@ -537,7 +537,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:30
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:28
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:53
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:54
 #, elixir-autogen, elixir-format
 msgid "Reorder"
 msgstr ""
@@ -556,8 +556,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:83
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:67
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:45
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:42
 #, elixir-autogen, elixir-format
 msgid "Select a class"
 msgstr ""
@@ -578,7 +578,7 @@ msgid "Under the hood, goals in Lanttern are defined by assessment points linked
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:136
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:147
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:149
 #, elixir-autogen, elixir-format
 msgid "Understood. Delete anyway"
 msgstr ""
@@ -600,7 +600,7 @@ msgid "collapse"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:145
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:156
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:158
 #, elixir-autogen, elixir-format
 msgid "dismiss"
 msgstr ""
@@ -611,7 +611,7 @@ msgid "expand"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:40
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:44
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "to view students assessments"
 msgstr ""
@@ -724,42 +724,42 @@ msgstr ""
 msgid "Markdown supported in descriptors"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:23
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:24
 #, elixir-autogen, elixir-format
 msgid "Assessing"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:125
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:127
 #, elixir-autogen, elixir-format
 msgid "Assessment Point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:194
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:196
 #, elixir-autogen, elixir-format
 msgid "Assessment Points Order"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:60
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "Create assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:218
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:220
 #, elixir-autogen, elixir-format
 msgid "Move assessment point down"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:207
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:209
 #, elixir-autogen, elixir-format
 msgid "Move assessment point up"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:470
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:474
 #, elixir-autogen, elixir-format
 msgid "This assessment point already have some entries. Deleting it will cause data loss."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:43
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:44
 #, elixir-autogen, elixir-format
 msgid "to assess students"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1221
+#: lib/lanttern_web/components/core_components.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -851,7 +851,7 @@ msgstr ""
 msgid "New moment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:66
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "No assessment points for this moment yet"
 msgstr ""
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Add to grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:123
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:159
 #, elixir-autogen, elixir-format
 msgid "Add to report card"
 msgstr ""
@@ -1111,10 +1111,10 @@ msgstr ""
 msgid "Cycle already added to this grade report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:185
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:222
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:280
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:282
 #, elixir-autogen, elixir-format
 msgid "Diff"
 msgstr ""
@@ -1257,7 +1257,7 @@ msgstr ""
 msgid "Final grade"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:24
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "Final strand goals assessment for"
 msgstr ""
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Link strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:127
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:163
 #, elixir-autogen, elixir-format
 msgid "List of report cards linked to this strand."
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Move moment card up"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1211
+#: lib/lanttern_web/components/core_components.ex:1224
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "No cycles linked to this grades report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:50
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "No goals for this strand yet"
 msgstr ""
@@ -1547,7 +1547,7 @@ msgid "Report card id"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:29
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:116
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:152
 #: lib/lanttern_web/live/shared/menu_component.ex:52
 #, elixir-autogen, elixir-format
 msgid "Report cards"
@@ -1654,7 +1654,7 @@ msgstr ""
 msgid "Strand report deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:57
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:83
 #, elixir-autogen, elixir-format
 msgid "Strands goals"
 msgstr ""
@@ -1817,8 +1817,8 @@ msgid "Select classes"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:109
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:148
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:188
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:184
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:190
 #, elixir-autogen, elixir-format
 msgid "Select classes for assessment"
 msgstr ""
@@ -1913,8 +1913,8 @@ msgid_plural "%{count} entries updated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:162
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:252
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:198
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:254
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
@@ -1993,8 +1993,8 @@ msgstr ""
 msgid "Hey!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:959
-#: lib/lanttern_web/components/core_components.ex:981
+#: lib/lanttern_web/components/core_components.ex:972
+#: lib/lanttern_web/components/core_components.ex:994
 #, elixir-autogen, elixir-format
 msgid "Selected"
 msgstr ""
@@ -2014,35 +2014,35 @@ msgstr ""
 msgid "Strands reports"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:49
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Add entry note"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:63
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "Entry report note"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:69
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:75
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Save note"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:155
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:245
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:191
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:247
 #, elixir-autogen, elixir-format
 msgid "1 change"
 msgid_plural "%{count} changes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:141
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "No report cards linked to this strand"
 msgstr ""
@@ -2497,4 +2497,31 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:107
 #, elixir-autogen, elixir-format
 msgid "Attachments"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:71
+#, elixir-autogen, elixir-format
+msgid "Compare"
+msgstr ""
+
+#: lib/lanttern/personalization/profile_settings.ex:58
+#, elixir-autogen, elixir-format
+msgid "Invalid assessment view"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:65
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:233
+#, elixir-autogen, elixir-format
+msgid "Student"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:59
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:230
+#, elixir-autogen, elixir-format
+msgid "Teacher"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:53
+#, elixir-autogen, elixir-format
+msgid "View"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,8 +11,8 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/lanttern_web/components/core_components.ex:1271
-#: lib/lanttern_web/components/core_components.ex:1333
+#: lib/lanttern_web/components/core_components.ex:1284
+#: lib/lanttern_web/components/core_components.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -58,7 +58,7 @@ msgstr ""
 msgid "Strands"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:515
+#: lib/lanttern_web/components/core_components.ex:528
 #: lib/lanttern_web/components/overlay_components.ex:78
 #: lib/lanttern_web/components/overlay_components.ex:330
 #, elixir-autogen, elixir-format
@@ -115,8 +115,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:138
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:136
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:199
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:177
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:236
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:179
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:238
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:128
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:130
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:91
@@ -170,12 +170,12 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:141
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:165
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:201
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:139
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:206
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:180
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:239
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:255
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:182
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:241
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:257
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:131
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:133
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:94
@@ -317,17 +317,17 @@ msgstr ""
 msgid "or drag and drop here"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:554
+#: lib/lanttern_web/components/core_components.ex:567
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:545
+#: lib/lanttern_web/components/core_components.ex:558
 #, elixir-autogen, elixir-format
 msgid "Error!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:566
+#: lib/lanttern_web/components/core_components.ex:579
 #, elixir-autogen, elixir-format
 msgid "Hang in there while we get back on track"
 msgstr ""
@@ -337,22 +337,22 @@ msgstr ""
 msgid "Markdown supported"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:544
+#: lib/lanttern_web/components/core_components.ex:557
 #, elixir-autogen, elixir-format
 msgid "Success!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:549
+#: lib/lanttern_web/components/core_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:561
+#: lib/lanttern_web/components/core_components.ex:574
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:419
+#: lib/lanttern_web/components/core_components.ex:432
 #, elixir-autogen, elixir-format
 msgid "all %{type}"
 msgstr ""
@@ -395,7 +395,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:68
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:190
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:168
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:170
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:119
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:70
 #, elixir-autogen, elixir-format
@@ -461,12 +461,12 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:160
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:196
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:71
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:188
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:144
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:166
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:250
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:146
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:168
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:252
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:117
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:73
 #: lib/lanttern_web/live/shared/notes/note_component.ex:50
@@ -475,7 +475,7 @@ msgid "Are you sure?"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:53
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:73
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:74
 #, elixir-autogen, elixir-format
 msgid "Current assessment points"
 msgstr ""
@@ -537,7 +537,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:30
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:28
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:53
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:54
 #, elixir-autogen, elixir-format
 msgid "Reorder"
 msgstr ""
@@ -556,8 +556,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:83
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:67
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:45
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:42
 #, elixir-autogen, elixir-format
 msgid "Select a class"
 msgstr ""
@@ -578,7 +578,7 @@ msgid "Under the hood, goals in Lanttern are defined by assessment points linked
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:136
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:147
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:149
 #, elixir-autogen, elixir-format
 msgid "Understood. Delete anyway"
 msgstr ""
@@ -600,7 +600,7 @@ msgid "collapse"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:145
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:156
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:158
 #, elixir-autogen, elixir-format
 msgid "dismiss"
 msgstr ""
@@ -611,7 +611,7 @@ msgid "expand"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:40
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:44
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "to view students assessments"
 msgstr ""
@@ -724,42 +724,42 @@ msgstr ""
 msgid "Markdown supported in descriptors"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:23
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:24
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessing"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:125
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:127
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment Point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:194
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:196
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment Points Order"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:60
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:61
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:218
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:220
 #, elixir-autogen, elixir-format
 msgid "Move assessment point down"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:207
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:209
 #, elixir-autogen, elixir-format
 msgid "Move assessment point up"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:470
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:474
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This assessment point already have some entries. Deleting it will cause data loss."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:43
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:44
 #, elixir-autogen, elixir-format
 msgid "to assess students"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1221
+#: lib/lanttern_web/components/core_components.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -851,7 +851,7 @@ msgstr ""
 msgid "New moment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:66
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:67
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No assessment points for this moment yet"
 msgstr ""
@@ -972,7 +972,7 @@ msgstr ""
 msgid "Add to grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:123
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:159
 #, elixir-autogen, elixir-format
 msgid "Add to report card"
 msgstr ""
@@ -1111,10 +1111,10 @@ msgstr ""
 msgid "Cycle already added to this grade report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:185
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:222
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:280
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:282
 #, elixir-autogen, elixir-format
 msgid "Diff"
 msgstr ""
@@ -1257,7 +1257,7 @@ msgstr ""
 msgid "Final grade"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:24
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "Final strand goals assessment for"
 msgstr ""
@@ -1365,7 +1365,7 @@ msgstr ""
 msgid "Link strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:127
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:163
 #, elixir-autogen, elixir-format
 msgid "List of report cards linked to this strand."
 msgstr ""
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Move moment card up"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1211
+#: lib/lanttern_web/components/core_components.ex:1224
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1442,7 +1442,7 @@ msgstr ""
 msgid "No cycles linked to this grades report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:50
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:76
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No goals for this strand yet"
 msgstr ""
@@ -1547,7 +1547,7 @@ msgid "Report card id"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:29
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:116
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:152
 #: lib/lanttern_web/live/shared/menu_component.ex:52
 #, elixir-autogen, elixir-format
 msgid "Report cards"
@@ -1654,7 +1654,7 @@ msgstr ""
 msgid "Strand report deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:57
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:83
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strands goals"
 msgstr ""
@@ -1817,8 +1817,8 @@ msgid "Select classes"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:109
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:148
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:188
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:184
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:190
 #, elixir-autogen, elixir-format
 msgid "Select classes for assessment"
 msgstr ""
@@ -1913,8 +1913,8 @@ msgid_plural "%{count} entries updated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:162
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:252
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:198
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:254
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
@@ -1993,8 +1993,8 @@ msgstr ""
 msgid "Hey!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:959
-#: lib/lanttern_web/components/core_components.ex:981
+#: lib/lanttern_web/components/core_components.ex:972
+#: lib/lanttern_web/components/core_components.ex:994
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Selected"
 msgstr ""
@@ -2014,35 +2014,35 @@ msgstr ""
 msgid "Strands reports"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:49
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Add entry note"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:63
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "Entry report note"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:69
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:75
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:81
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save note"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:155
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:245
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:191
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 change"
 msgid_plural "%{count} changes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:141
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:177
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No report cards linked to this strand"
 msgstr ""
@@ -2497,4 +2497,31 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:107
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Attachments"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:71
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Compare"
+msgstr ""
+
+#: lib/lanttern/personalization/profile_settings.ex:58
+#, elixir-autogen, elixir-format
+msgid "Invalid assessment view"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:65
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:233
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Student"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:59
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:230
+#, elixir-autogen, elixir-format
+msgid "Teacher"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:53
+#, elixir-autogen, elixir-format, fuzzy
+msgid "View"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -11,8 +11,8 @@ msgstr ""
 "Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n>1);\n"
 
-#: lib/lanttern_web/components/core_components.ex:1271
-#: lib/lanttern_web/components/core_components.ex:1333
+#: lib/lanttern_web/components/core_components.ex:1284
+#: lib/lanttern_web/components/core_components.ex:1346
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Ações"
@@ -58,7 +58,7 @@ msgstr "Escola"
 msgid "Strands"
 msgstr "Trilhas"
 
-#: lib/lanttern_web/components/core_components.ex:515
+#: lib/lanttern_web/components/core_components.ex:528
 #: lib/lanttern_web/components/overlay_components.ex:78
 #: lib/lanttern_web/components/overlay_components.ex:330
 #, elixir-autogen, elixir-format
@@ -115,8 +115,8 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:138
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:136
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:199
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:177
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:236
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:179
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:238
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:128
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:130
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:91
@@ -170,12 +170,12 @@ msgstr "Nenhuma trilha criadas para os anos e componentes selecionados"
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:141
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:165
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:201
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:139
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:206
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:180
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:239
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:255
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:182
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:241
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:257
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:131
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:133
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:94
@@ -317,17 +317,17 @@ msgstr "cancelar"
 msgid "or drag and drop here"
 msgstr "ou arraste e solte aqui"
 
-#: lib/lanttern_web/components/core_components.ex:554
+#: lib/lanttern_web/components/core_components.ex:567
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr "Tentando reconectar"
 
-#: lib/lanttern_web/components/core_components.ex:545
+#: lib/lanttern_web/components/core_components.ex:558
 #, elixir-autogen, elixir-format
 msgid "Error!"
 msgstr "Erro!"
 
-#: lib/lanttern_web/components/core_components.ex:566
+#: lib/lanttern_web/components/core_components.ex:579
 #, elixir-autogen, elixir-format
 msgid "Hang in there while we get back on track"
 msgstr "Aguente firme enquanto nos reconectamos"
@@ -337,22 +337,22 @@ msgstr "Aguente firme enquanto nos reconectamos"
 msgid "Markdown supported"
 msgstr "Suporta Markdown"
 
-#: lib/lanttern_web/components/core_components.ex:544
+#: lib/lanttern_web/components/core_components.ex:557
 #, elixir-autogen, elixir-format
 msgid "Success!"
 msgstr "Sucesso!"
 
-#: lib/lanttern_web/components/core_components.ex:549
+#: lib/lanttern_web/components/core_components.ex:562
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr "Não conseguimos nos conectar"
 
-#: lib/lanttern_web/components/core_components.ex:561
+#: lib/lanttern_web/components/core_components.ex:574
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr "Algo deu errado!"
 
-#: lib/lanttern_web/components/core_components.ex:419
+#: lib/lanttern_web/components/core_components.ex:432
 #, elixir-autogen, elixir-format
 msgid "all %{type}"
 msgstr "todos %{type}"
@@ -395,7 +395,7 @@ msgstr "Não foi possível encontrar a trilha"
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:157
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:68
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:190
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:168
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:170
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:119
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:70
 #, elixir-autogen, elixir-format
@@ -461,12 +461,12 @@ msgstr "Adicione suas anotações..."
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:160
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:196
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:71
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:188
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:144
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:166
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:250
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:146
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:168
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:252
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:117
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:73
 #: lib/lanttern_web/live/shared/notes/note_component.ex:50
@@ -475,7 +475,7 @@ msgid "Are you sure?"
 msgstr "Você tem certeza?"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:53
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:73
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:74
 #, elixir-autogen, elixir-format
 msgid "Current assessment points"
 msgstr "Pontos de avaliação atuais"
@@ -537,7 +537,7 @@ msgstr "Nenhum ponto de avaliação para esta trilha ainda"
 
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:30
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:28
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:53
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:54
 #, elixir-autogen, elixir-format
 msgid "Reorder"
 msgstr "Reordenar"
@@ -556,8 +556,8 @@ msgstr "Salvar ordem atualizada"
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:83
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:38
 #: lib/lanttern_web/live/pages/strands/id/notes_component.ex:67
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:42
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:41
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:45
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:42
 #, elixir-autogen, elixir-format
 msgid "Select a class"
 msgstr "Selecione uma turma"
@@ -578,7 +578,7 @@ msgid "Under the hood, goals in Lanttern are defined by assessment points linked
 msgstr "Por baixo dos panos, objetivos no Lanttern são definidos por pontos de avaliação vinculados diretamente à trilha — ao adicionar objetivos, nós estamos adicionando pontos de avaliação que, por sua vez, contém os itens curriculares que nós queremos avaliar ao longo da trilha."
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:136
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:147
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:149
 #, elixir-autogen, elixir-format
 msgid "Understood. Delete anyway"
 msgstr "Compreendo. Deletar mesmo assim"
@@ -600,7 +600,7 @@ msgid "collapse"
 msgstr "fechar"
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:145
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:156
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:158
 #, elixir-autogen, elixir-format
 msgid "dismiss"
 msgstr "dispensar"
@@ -611,7 +611,7 @@ msgid "expand"
 msgstr "expandir"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:40
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:44
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "to view students assessments"
 msgstr "para visualizar avaliações dos estudantes"
@@ -724,42 +724,42 @@ msgstr "Selecione uma escala"
 msgid "Markdown supported in descriptors"
 msgstr "Suporta Markdown nos descritores"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:23
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:24
 #, elixir-autogen, elixir-format
 msgid "Assessing"
 msgstr "Avaliando"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:125
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:127
 #, elixir-autogen, elixir-format
 msgid "Assessment Point"
 msgstr "Ponto de Avaliação"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:194
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:196
 #, elixir-autogen, elixir-format
 msgid "Assessment Points Order"
 msgstr "Ordem dos Pontos de Avaliação"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:60
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "Create assessment point"
 msgstr "Criar ponto de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:218
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:220
 #, elixir-autogen, elixir-format
 msgid "Move assessment point down"
 msgstr "Mover ponto de avaliação para baixo"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:207
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:209
 #, elixir-autogen, elixir-format
 msgid "Move assessment point up"
 msgstr "Mover ponto de avaliação para cima"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:470
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:474
 #, elixir-autogen, elixir-format
 msgid "This assessment point already have some entries. Deleting it will cause data loss."
 msgstr "Este ponto de avaliação já possui alguns registros. Deletá-lo irá causar perda de dados."
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:43
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:44
 #, elixir-autogen, elixir-format
 msgid "to assess students"
 msgstr "para avaliar estudantes"
@@ -841,7 +841,7 @@ msgstr "Momento atualizado com sucesso"
 msgid "Moments"
 msgstr "Momentos"
 
-#: lib/lanttern_web/components/core_components.ex:1221
+#: lib/lanttern_web/components/core_components.ex:1234
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr "Mover momento para baixo"
@@ -851,7 +851,7 @@ msgstr "Mover momento para baixo"
 msgid "New moment"
 msgstr "Novo momento"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:66
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "No assessment points for this moment yet"
 msgstr "Nenhum ponto de avaliação para este momento ainda"
@@ -972,7 +972,7 @@ msgstr "Adicionar card de momento"
 msgid "Add to grade composition"
 msgstr "Adicionar à composição da nota"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:123
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:159
 #, elixir-autogen, elixir-format
 msgid "Add to report card"
 msgstr "Adicionar ao report card"
@@ -1111,10 +1111,10 @@ msgstr "Ciclo"
 msgid "Cycle already added to this grade report"
 msgstr "Ciclo já adicionado à este relatório de nota"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:185
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:222
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:280
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:282
 #, elixir-autogen, elixir-format
 msgid "Diff"
 msgstr "Dif"
@@ -1257,7 +1257,7 @@ msgstr "Filtrar itens curriculares por ano"
 msgid "Final grade"
 msgstr "Nota final"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:24
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "Final strand goals assessment for"
 msgstr "Avaliação final do objetivo da trilha"
@@ -1365,7 +1365,7 @@ msgstr "Nível"
 msgid "Link strand"
 msgstr "Vincular trilha"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:127
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:163
 #, elixir-autogen, elixir-format
 msgid "List of report cards linked to this strand."
 msgstr "Lista de report cards vinculados a esta trilha"
@@ -1405,7 +1405,7 @@ msgstr "Mover card de momento para baixo"
 msgid "Move moment card up"
 msgstr "Mover card de momento para cima"
 
-#: lib/lanttern_web/components/core_components.ex:1211
+#: lib/lanttern_web/components/core_components.ex:1224
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1442,7 +1442,7 @@ msgstr "Nenhum item curricular encontrado para os filtros selecionados."
 msgid "No cycles linked to this grades report"
 msgstr "Nenhum ciclo vinculado a este relatório de notas"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:50
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "No goals for this strand yet"
 msgstr "Nenhum objetivo para esta trilha ainda"
@@ -1547,7 +1547,7 @@ msgid "Report card id"
 msgstr "Id do report card"
 
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:29
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:116
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:152
 #: lib/lanttern_web/live/shared/menu_component.ex:52
 #, elixir-autogen, elixir-format
 msgid "Report cards"
@@ -1654,7 +1654,7 @@ msgstr "Relatório da trilha"
 msgid "Strand report deleted"
 msgstr "Relatório da trilha deletada"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:57
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:83
 #, elixir-autogen, elixir-format
 msgid "Strands goals"
 msgstr "Objetivos da trilha"
@@ -1817,8 +1817,8 @@ msgid "Select classes"
 msgstr "Selecione as turmas"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:109
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:148
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:188
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:184
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:190
 #, elixir-autogen, elixir-format
 msgid "Select classes for assessment"
 msgstr "Selecione turmas para a avaliação"
@@ -1913,8 +1913,8 @@ msgid_plural "%{count} entries updated"
 msgstr[0] "1 registro atualizado"
 msgstr[1] "%{count} registros atualizados"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:162
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:252
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:198
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:254
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr "Descartar"
@@ -1993,8 +1993,8 @@ msgstr "Limpar seleção"
 msgid "Hey!"
 msgstr "Olá!"
 
-#: lib/lanttern_web/components/core_components.ex:959
-#: lib/lanttern_web/components/core_components.ex:981
+#: lib/lanttern_web/components/core_components.ex:972
+#: lib/lanttern_web/components/core_components.ex:994
 #, elixir-autogen, elixir-format
 msgid "Selected"
 msgstr "Selecionado"
@@ -2014,35 +2014,35 @@ msgstr "Opcional"
 msgid "Strands reports"
 msgstr "Relatórios das trilhas"
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:49
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Add entry note"
 msgstr "Adicionar anotação ao registro"
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:63
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "Entry report note"
 msgstr "Anotação do registro para o relatório"
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:69
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "Note"
 msgstr "Anotação"
 
-#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:75
+#: lib/lanttern_web/live/shared/assessments/entry_editor_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Save note"
 msgstr "Salvar anotação"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:155
-#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:245
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:191
+#: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:247
 #, elixir-autogen, elixir-format
 msgid "1 change"
 msgid_plural "%{count} changes"
 msgstr[0] "1 alteração"
 msgstr[1] "%{count} alterações"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:141
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "No report cards linked to this strand"
 msgstr "Nenhum report card vinculado a esta trilha"
@@ -2498,3 +2498,30 @@ msgstr "Upload de arquivo"
 #, elixir-autogen, elixir-format
 msgid "Attachments"
 msgstr "Anexos"
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:71
+#, elixir-autogen, elixir-format
+msgid "Compare"
+msgstr "Comparar"
+
+#: lib/lanttern/personalization/profile_settings.ex:58
+#, elixir-autogen, elixir-format
+msgid "Invalid assessment view"
+msgstr "Visualização de avaliação inválida"
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:65
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:233
+#, elixir-autogen, elixir-format
+msgid "Student"
+msgstr "Estudante"
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:59
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:230
+#, elixir-autogen, elixir-format
+msgid "Teacher"
+msgstr "Professor"
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:53
+#, elixir-autogen, elixir-format
+msgid "View"
+msgstr "Visualização"

--- a/priv/repo/migrations/20240529153853_add_self_assessment_fields_to_assessment_point_entries.exs
+++ b/priv/repo/migrations/20240529153853_add_self_assessment_fields_to_assessment_point_entries.exs
@@ -1,0 +1,13 @@
+defmodule Lanttern.Repo.Migrations.AddSelfAssessmentFieldsToAssessmentPointEntries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:assessment_point_entries) do
+      add :student_score, :float
+      add :student_report_note, :text
+      add :student_ordinal_value_id, references(:ordinal_values, on_delete: :nothing)
+    end
+
+    create index(:assessment_point_entries, [:student_ordinal_value_id])
+  end
+end

--- a/priv/repo/migrations/20240605180410_add_self_assessment_fields_to_assessment_point_entries_log.exs
+++ b/priv/repo/migrations/20240605180410_add_self_assessment_fields_to_assessment_point_entries_log.exs
@@ -1,0 +1,13 @@
+defmodule Lanttern.Repo.Migrations.AddSelfAssessmentFieldsToAssessmentPointEntriesLog do
+  use Ecto.Migration
+
+  @prefix "log"
+
+  def change do
+    alter table(:assessment_point_entries, prefix: @prefix) do
+      add :student_score, :float
+      add :student_report_note, :text
+      add :student_ordinal_value_id, :bigint
+    end
+  end
+end

--- a/test/lanttern_web/helpers/assessment_helpers_test.exs
+++ b/test/lanttern_web/helpers/assessment_helpers_test.exs
@@ -1,0 +1,65 @@
+defmodule LantternWeb.AssessmentsHelpersTest do
+  use Lanttern.DataCase
+
+  alias LantternWeb.AssessmentsHelpers
+
+  describe "save entry editor component changes" do
+    import Lanttern.AssessmentsFixtures
+    alias Lanttern.GradingFixtures
+    alias Lanttern.SchoolsFixtures
+
+    test "save_entry_editor_component_changes/2 handles all mapped changes correctly" do
+      scale = GradingFixtures.scale_fixture(%{type: "ordinal"})
+      ov_1 = GradingFixtures.ordinal_value_fixture(%{scale_id: scale.id, normalized_value: 0})
+      ov_2 = GradingFixtures.ordinal_value_fixture(%{scale_id: scale.id, normalized_value: 1})
+
+      student = SchoolsFixtures.student_fixture()
+
+      assessment_point_1 = assessment_point_fixture(%{scale_id: scale.id})
+      assessment_point_2 = assessment_point_fixture(%{scale_id: scale.id})
+      assessment_point_3 = assessment_point_fixture(%{scale_id: scale.id})
+
+      entry_2 =
+        assessment_point_entry_fixture(%{
+          student_id: student.id,
+          assessment_point_id: assessment_point_2.id,
+          scale_id: scale.id,
+          scale_type: scale.type,
+          ordinal_value_id: ov_1.id
+        })
+
+      entry_3 =
+        assessment_point_entry_fixture(%{
+          student_id: student.id,
+          assessment_point_id: assessment_point_3.id,
+          scale_id: scale.id,
+          scale_type: scale.type,
+          ordinal_value_id: ov_1.id
+        })
+
+      params_1 = %{
+        "student_id" => student.id,
+        "scale_id" => scale.id,
+        "scale_type" => scale.type,
+        "assessment_point_id" => assessment_point_1.id,
+        "ordinal_value_id" => ov_1.id
+      }
+
+      params_2 = %{"ordinal_value_id" => ov_2.id}
+      params_3 = %{}
+
+      changes_map = %{
+        "1" => {:new, nil, params_1},
+        "2" => {:edit, entry_2.id, params_2},
+        "3" => {:delete, entry_3.id, params_3}
+      }
+
+      assert {:ok, results_message} =
+               AssessmentsHelpers.save_entry_editor_component_changes(changes_map)
+
+      assert String.contains?(results_message, "1 entry created")
+      assert String.contains?(results_message, "1 entry updated")
+      assert String.contains?(results_message, "1 entry removed")
+    end
+  end
+end

--- a/test/lanttern_web/live/pages/strands/id/reporting_component_test.exs
+++ b/test/lanttern_web/live/pages/strands/id/reporting_component_test.exs
@@ -1,0 +1,110 @@
+defmodule LantternWeb.StrandLive.ReportingComponentTest do
+  use LantternWeb.ConnCase
+
+  alias Lanttern.AssessmentsFixtures
+  alias Lanttern.Filters
+  alias Lanttern.GradingFixtures
+  alias Lanttern.LearningContextFixtures
+  alias Lanttern.SchoolsFixtures
+
+  @live_view_base_path "/strands"
+
+  setup [:register_and_log_in_teacher, :prepare]
+
+  describe "Assessment views" do
+    test "display teacher view", %{
+      conn: conn,
+      user: user,
+      strand: strand,
+      class: class,
+      student: student,
+      ordinal_value_1: ordinal_value_1
+    } do
+      # setup current user view
+      Filters.set_profile_current_filters(user, %{assessment_view: "teacher"})
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{strand.id}?tab=reporting")
+
+      assert view |> has_element?("button", class.name)
+      assert view |> has_element?("div", student.name)
+      assert view |> has_element?("option[selected]", ordinal_value_1.name)
+    end
+
+    test "display student view", %{
+      conn: conn,
+      user: user,
+      strand: strand,
+      class: class,
+      student: student,
+      ordinal_value_2: ordinal_value_2
+    } do
+      # setup current user view
+      Filters.set_profile_current_filters(user, %{assessment_view: "student"})
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{strand.id}?tab=reporting")
+
+      assert view |> has_element?("button", class.name)
+      assert view |> has_element?("div", student.name)
+      assert view |> has_element?("option[selected]", ordinal_value_2.name)
+    end
+
+    test "display compare view", %{
+      conn: conn,
+      user: user,
+      strand: strand,
+      class: class,
+      student: student,
+      ordinal_value_1: ordinal_value_1,
+      ordinal_value_2: ordinal_value_2
+    } do
+      # setup current user view
+      Filters.set_profile_current_filters(user, %{assessment_view: "compare"})
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{strand.id}?tab=reporting")
+
+      assert view |> has_element?("button", class.name)
+      assert view |> has_element?("div", student.name)
+      assert view |> has_element?("span", ordinal_value_1.name)
+      assert view |> has_element?("span", ordinal_value_2.name)
+    end
+  end
+
+  defp prepare(%{user: user}) do
+    strand = LearningContextFixtures.strand_fixture()
+
+    school_id = user.current_profile.school_id
+    class = SchoolsFixtures.class_fixture(%{school_id: school_id})
+    student = SchoolsFixtures.student_fixture(%{school_id: school_id, classes_ids: [class.id]})
+
+    scale = GradingFixtures.scale_fixture(%{type: "ordinal"})
+
+    ordinal_value_1 =
+      GradingFixtures.ordinal_value_fixture(%{scale_id: scale.id, name: "ov_1 name abc"})
+
+    ordinal_value_2 =
+      GradingFixtures.ordinal_value_fixture(%{scale_id: scale.id, name: "ov_2 name abc"})
+
+    assessment_point =
+      AssessmentsFixtures.assessment_point_fixture(%{strand_id: strand.id, scale_id: scale.id})
+
+    _entry_fixture =
+      AssessmentsFixtures.assessment_point_entry_fixture(%{
+        student_id: student.id,
+        assessment_point_id: assessment_point.id,
+        scale_id: scale.id,
+        scale_type: scale.type,
+        ordinal_value_id: ordinal_value_1.id,
+        student_ordinal_value_id: ordinal_value_2.id
+      })
+
+    # setup current user class filter
+    Filters.set_profile_strand_filters(user, strand.id, %{classes_ids: [class.id]})
+
+    {:ok,
+     strand: strand,
+     class: class,
+     student: student,
+     ordinal_value_1: ordinal_value_1,
+     ordinal_value_2: ordinal_value_2}
+  end
+end


### PR DESCRIPTION
now teachers can register, in strand reporting tab, the student self-assessment in addition to their own assessment.

resolves #160 