### PR TITLE
display self-assessment in report cards

### DIFF
--- a/lib/lanttern_web/components/reporting_components.ex
+++ b/lib/lanttern_web/components/reporting_components.ex
@@ -134,7 +134,7 @@ defmodule LantternWeb.ReportingComponents do
       </div>
       <div
         :if={@entry.student_ordinal_value_id}
-        class="grid grid-cols-subgrid border-t-2 pt-1 border-ltrn-student-accent"
+        class="grid grid-cols-subgrid pt-1 px-1 border-2 border-ltrn-student-lighter rounded-sm bg-ltrn-student-lightest"
         style={@grid_column_span_style}
       >
         <div
@@ -144,10 +144,11 @@ defmodule LantternWeb.ReportingComponents do
         >
           <%= ordinal_value.name %>
         </div>
-        <div class="border-t-2 border-ltrn-student-accent mt-1" style={@grid_column_span_style}>
-          <div class="inline-block p-2 rounded-bl rounded-br text-xs text-ltrn-sudent-dark bg-ltrn-student-accent">
-            <%= gettext("Student self-assessment") %>
-          </div>
+        <div
+          class="p-1 rounded-t mt-1 text-xs text-center text-ltrn-student-dark bg-ltrn-student-lighter"
+          style={@grid_column_span_style}
+        >
+          <%= gettext("Student self-assessment") %>
         </div>
       </div>
     </div>
@@ -160,15 +161,12 @@ defmodule LantternWeb.ReportingComponents do
       <.report_scale_numeric_bar score={@entry && @entry.score} scale={@scale} />
       <div
         :if={@entry && @entry.student_score}
-        class="mt-1 py-1 border-y-2 border-ltrn-student-accent"
+        class="mt-1 pt-1 px-1 border-2 border-ltrn-student-lighter rounded-sm bg-ltrn-student-lightest"
       >
         <.report_scale_numeric_bar score={@entry.student_score} scale={@scale} is_student />
-      </div>
-      <div
-        :if={@entry && @entry.student_score}
-        class="inline-block p-2 rounded-bl rounded-br text-xs text-ltrn-sudent-dark bg-ltrn-student-accent"
-      >
-        <%= gettext("Student self-assessment") %>
+        <div class="p-2 rounded-t mt-1 text-xs text-center text-ltrn-student-dark bg-ltrn-student-lighter">
+          <%= gettext("Student self-assessment") %>
+        </div>
       </div>
     </div>
     """

--- a/lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex
@@ -55,7 +55,19 @@ defmodule LantternWeb.ReportCardLive.StrandsReportsComponent do
               )
             }
             class="shrink-0 w-64 sm:w-auto"
-          />
+          >
+            <:bottom_content>
+              <%= if strand_report.description do %>
+                <div class="p-6 bg-ltrn-mesh-cyan">
+                  <.markdown text={strand_report.description} size="sm" class="line-clamp-3" />
+                </div>
+              <% else %>
+                <p class="p-6 text-sm text-ltrn-subtle bg-ltrn-lightest">
+                  <%= gettext("No strand report description") %>
+                </p>
+              <% end %>
+            </:bottom_content>
+          </.strand_card>
         </.responsive_grid>
       <% else %>
         <.empty_state><%= gettext("No strands linked to this report yet") %></.empty_state>

--- a/lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.ex
+++ b/lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.ex
@@ -23,6 +23,10 @@ defmodule LantternWeb.StudentStrandReportLive do
 
   @impl true
   def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> assign(:info_level, "full")
+
     {:ok, socket, layout: {LantternWeb.Layouts, :app_logged_in_blank}}
   end
 
@@ -112,4 +116,9 @@ defmodule LantternWeb.StudentStrandReportLive do
 
   defp assign_current_tab(socket, _params),
     do: assign(socket, :current_tab, :general)
+
+  @impl true
+  def handle_event("set_info_level", %{"level" => level}, socket) do
+    {:noreply, assign(socket, :info_level, level)}
+  end
 end

--- a/lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex
+++ b/lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex
@@ -118,19 +118,35 @@
                 _ -> rubric
               end
             }
+            class="float-left"
           />
+          <%!-- fix for padding right. we need the float-left above and this emtpy div below --%>
+          <div class="w-6"></div>
         </div>
         <div :if={entry && entry.report_note} class="sm:pt-6 sm:px-6 last:sm:pb-6">
-          <.markdown
-            text={entry.report_note}
-            size="sm"
-            class="max-w-none p-4 sm:rounded bg-ltrn-diff-lightest"
-          />
+          <div class="p-4 sm:rounded bg-ltrn-teacher-lightest">
+            <div class="flex items-center gap-2 font-bold text-sm">
+              <.icon name="hero-chat-bubble-oval-left" class="w-6 h-6 text-ltrn-teacher-accent" />
+              <span class="text-ltrn-teacher-dark"><%= gettext("Teacher comment") %></span>
+            </div>
+            <.markdown text={entry.report_note} size="sm" class="max-w-none mt-4" />
+          </div>
+        </div>
+        <div :if={entry && entry.student_report_note} class="sm:pt-6 sm:px-6 last:sm:pb-6">
+          <div class="p-4 sm:rounded bg-ltrn-student-lightest">
+            <div class="flex items-center gap-2 font-bold text-sm">
+              <.icon name="hero-chat-bubble-oval-left" class="w-6 h-6 text-ltrn-student-accent" />
+              <span class="text-ltrn-student-dark">
+                <%= gettext("%{student} comment", student: @student_report_card.student.name) %>
+              </span>
+            </div>
+            <.markdown text={entry.student_report_note} size="sm" class="max-w-none mt-4" />
+          </div>
         </div>
         <div :if={report_info} class="sm:pt-6 sm:px-6 last:sm:pb-6">
           <div class="p-4 sm:rounded bg-ltrn-mesh-cyan">
-            <div class="flex items-center gap-2 font-bold text-sm text-ltrn-subtle">
-              <.icon name="hero-information-circle" class="w-6 h-6" />
+            <div class="flex items-center gap-2 font-bold text-sm">
+              <.icon name="hero-information-circle" class="w-6 h-6 text-ltrn-subtle" />
               <%= gettext("About this assessment") %>
             </div>
             <.markdown text={report_info} size="sm" class="max-w-none mt-4" />

--- a/lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex
+++ b/lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex
@@ -67,7 +67,24 @@
 <div class="ltrn-bg-main-local">
   <.responsive_container :if={@current_tab == :general} class="py-10">
     <.markdown text={@strand_report.description} />
-    <div class="mt-10">
+    <div class="flex items-center gap-2 mt-10">
+      <span class="text-sm font-bold">
+        <%= gettext("Information level") %>
+      </span>
+      <.badge_button
+        theme={if @info_level == "full", do: "primary"}
+        phx-click={JS.push("set_info_level", value: %{"level" => "full"})}
+      >
+        <%= gettext("Full") %>
+      </.badge_button>
+      <.badge_button
+        theme={if @info_level == "simplified", do: "primary"}
+        phx-click={JS.push("set_info_level", value: %{"level" => "simplified"})}
+      >
+        <%= gettext("Simplified") %>
+      </.badge_button>
+    </div>
+    <div class="mt-4">
       <div
         :for={
           {%AssessmentPoint{
@@ -83,14 +100,25 @@
         class="rounded mt-4 bg-white shadow"
       >
         <div class="pt-6 px-6">
-          <p class="font-display font-bold text-sm mb-2">
-            <%= curriculum_item.curriculum_component.name %>
-          </p>
-          <%= curriculum_item.name %>
+          <%= if @info_level == "simplified" do %>
+            <p class="text-sm">
+              <span class="inline-block mr-1 font-display font-bold text-ltrn-subtle">
+                <%= curriculum_item.curriculum_component.name %>
+              </span>
+              <%= curriculum_item.name %>
+            </p>
+          <% else %>
+            <p class="mb-2 font-display font-bold text-sm">
+              <%= curriculum_item.curriculum_component.name %>
+            </p>
+            <p class="text-base">
+              <%= curriculum_item.name %>
+            </p>
+          <% end %>
           <div
             :if={
-              curriculum_item.code ||
-                curriculum_item.subjects != []
+              @info_level == "full" &&
+                (curriculum_item.code || curriculum_item.subjects != [])
             }
             class="flex flex-wrap items-center gap-2 mt-4"
           >
@@ -123,7 +151,10 @@
           <%!-- fix for padding right. we need the float-left above and this emtpy div below --%>
           <div class="w-6"></div>
         </div>
-        <div :if={entry && entry.report_note} class="sm:pt-6 sm:px-6 last:sm:pb-6">
+        <div
+          :if={entry && entry.report_note && @info_level == "full"}
+          class="sm:pt-6 sm:px-6 last:sm:pb-6"
+        >
           <div class="p-4 sm:rounded bg-ltrn-teacher-lightest">
             <div class="flex items-center gap-2 font-bold text-sm">
               <.icon name="hero-chat-bubble-oval-left" class="w-6 h-6 text-ltrn-teacher-accent" />
@@ -132,7 +163,10 @@
             <.markdown text={entry.report_note} size="sm" class="max-w-none mt-4" />
           </div>
         </div>
-        <div :if={entry && entry.student_report_note} class="sm:pt-6 sm:px-6 last:sm:pb-6">
+        <div
+          :if={entry && entry.student_report_note && @info_level == "full"}
+          class="sm:pt-6 sm:px-6 last:sm:pb-6"
+        >
           <div class="p-4 sm:rounded bg-ltrn-student-lightest">
             <div class="flex items-center gap-2 font-bold text-sm">
               <.icon name="hero-chat-bubble-oval-left" class="w-6 h-6 text-ltrn-student-accent" />
@@ -143,7 +177,7 @@
             <.markdown text={entry.student_report_note} size="sm" class="max-w-none mt-4" />
           </div>
         </div>
-        <div :if={report_info} class="sm:pt-6 sm:px-6 last:sm:pb-6">
+        <div :if={report_info && @info_level == "full"} class="sm:pt-6 sm:px-6 last:sm:pb-6">
           <div class="p-4 sm:rounded bg-ltrn-mesh-cyan">
             <div class="flex items-center gap-2 font-bold text-sm">
               <.icon name="hero-information-circle" class="w-6 h-6 text-ltrn-subtle" />

--- a/lib/lanttern_web/live/shared/assessments/entry_editor_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_editor_component.ex
@@ -51,7 +51,7 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
         sr_text={gettext("Add entry note")}
         size="sm"
         class="ml-2"
-        disabled={!@entry_value}
+        disabled={!@entry.id}
         phx-click="edit_note"
         phx-target={@myself}
       />
@@ -345,7 +345,6 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
   defp assign_entry_note(socket) do
     %{
       entry: entry,
-      entry_value: entry_value,
       assessment_view: assessment_view
     } = socket.assigns
 
@@ -357,8 +356,8 @@ defmodule LantternWeb.Assessments.EntryEditorComponent do
 
     note_button_theme =
       cond do
-        entry_note && entry_value && assessment_view == "student" -> "student"
-        entry_note && entry_value -> "teacher"
+        entry_note && assessment_view == "student" -> "student"
+        entry_note -> "teacher"
         true -> "ghost"
       end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2024.6.10-alpha.20",
+      version: "2024.6.10-alpha.21",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1079,7 +1079,7 @@ msgstr ""
 msgid "Curriculum components"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:101
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Curriculum differentiation"
 msgstr ""
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Different from grade composition. Use comments field to justify it if needed."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:104
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Differentiation rubric"
 msgstr ""
@@ -1877,7 +1877,7 @@ msgstr ""
 msgid "You must log in to access this page."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:134
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "About this assessment"
 msgstr ""
@@ -2524,4 +2524,35 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:53
 #, elixir-autogen, elixir-format
 msgid "View"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "%{student} comment"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:78
+#, elixir-autogen, elixir-format
+msgid "Full"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:72
+#, elixir-autogen, elixir-format
+msgid "Information level"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Simplified"
+msgstr ""
+
+#: lib/lanttern_web/components/reporting_components.ex:151
+#: lib/lanttern_web/components/reporting_components.ex:168
+#, elixir-autogen, elixir-format
+msgid "Student self-assessment"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:161
+#, elixir-autogen, elixir-format
+msgid "Teacher comment"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1079,7 +1079,7 @@ msgstr ""
 msgid "Curriculum components"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:101
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Curriculum differentiation"
 msgstr ""
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Different from grade composition. Use comments field to justify it if needed."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:104
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:132
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Differentiation rubric"
 msgstr ""
@@ -1877,7 +1877,7 @@ msgstr ""
 msgid "You must log in to access this page."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:134
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "About this assessment"
 msgstr ""
@@ -2524,4 +2524,35 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "View"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "%{student} comment"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:78
+#, elixir-autogen, elixir-format
+msgid "Full"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:72
+#, elixir-autogen, elixir-format
+msgid "Information level"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Simplified"
+msgstr ""
+
+#: lib/lanttern_web/components/reporting_components.ex:151
+#: lib/lanttern_web/components/reporting_components.ex:168
+#, elixir-autogen, elixir-format
+msgid "Student self-assessment"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:161
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Teacher comment"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -1079,7 +1079,7 @@ msgstr "Componente curricular"
 msgid "Curriculum components"
 msgstr "Componentes curriculares"
 
-#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:101
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:129
 #, elixir-autogen, elixir-format
 msgid "Curriculum differentiation"
 msgstr "Diferenciação curricular"
@@ -1124,7 +1124,7 @@ msgstr "Dif"
 msgid "Different from grade composition. Use comments field to justify it if needed."
 msgstr "Diferente da composição da nota. Use o campo de comentários para justificar se necessário."
 
-#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:104
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:132
 #, elixir-autogen, elixir-format
 msgid "Differentiation rubric"
 msgstr "Rubrica de diferenciação"
@@ -1877,7 +1877,7 @@ msgstr "Bem-vinda!"
 msgid "You must log in to access this page."
 msgstr "Você precisa estar logado para acessar esta página."
 
-#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:134
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:184
 #, elixir-autogen, elixir-format
 msgid "About this assessment"
 msgstr "Sobre esta avaliação"
@@ -2525,3 +2525,34 @@ msgstr "Professor"
 #, elixir-autogen, elixir-format
 msgid "View"
 msgstr "Visualização"
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:174
+#, elixir-autogen, elixir-format
+msgid "%{student} comment"
+msgstr "Comentário de %{student}"
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:78
+#, elixir-autogen, elixir-format
+msgid "Full"
+msgstr "Completo"
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:72
+#, elixir-autogen, elixir-format
+msgid "Information level"
+msgstr "Nível de informação"
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:84
+#, elixir-autogen, elixir-format
+msgid "Simplified"
+msgstr "Simplificado"
+
+#: lib/lanttern_web/components/reporting_components.ex:151
+#: lib/lanttern_web/components/reporting_components.ex:168
+#, elixir-autogen, elixir-format
+msgid "Student self-assessment"
+msgstr "Autoavaliação do estudante"
+
+#: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:161
+#, elixir-autogen, elixir-format
+msgid "Teacher comment"
+msgstr "Comentário do professor"


### PR DESCRIPTION
added student self-assessment visualization in student strand report page. resolves #168

other minor usability features:

- added basic support for controlling the amount of information displayed in student strand report page. now the user can toggle between "Full" and "Simplified" view, to hide year/subject information as well as teacher and student comments, and extra assessment point info
- added a simple strand report description preview in strands tab (report card page), which allow users to quick identify strand report texts that have already been written/registered