### PR TITLE
Support retake history and other grades report-related adjustments

### DIFF
--- a/lib/lanttern/grades_reports.ex
+++ b/lib/lanttern/grades_reports.ex
@@ -1121,18 +1121,19 @@ defmodule Lanttern.GradesReports do
           sgre.grades_report_subject_id == grs.id and
           sgre.student_id == std.id,
       left_join: ov in assoc(sgre, :ordinal_value),
+      left_join: prov in assoc(sgre, :pre_retake_ordinal_value),
       where: std.id in ^students_ids,
       where: grc.grades_report_id == ^grades_report_id,
       where: grc.school_cycle_id == ^cycle_id,
-      select: {std.id, grs.id, sgre, ov}
+      select: {std.id, grs.id, sgre, ov, prov}
     )
     |> Repo.all()
-    |> Enum.reduce(%{}, fn {std_id, grs_id, sgre, ov}, acc ->
+    |> Enum.reduce(%{}, fn {std_id, grs_id, sgre, ov, prov}, acc ->
       # "preload" ordinal value in student grade report entry
       sgre =
         case sgre do
           nil -> nil
-          sgre -> %{sgre | ordinal_value: ov}
+          sgre -> %{sgre | ordinal_value: ov, pre_retake_ordinal_value: prov}
         end
 
       # build student map

--- a/lib/lanttern/grades_reports.ex
+++ b/lib/lanttern/grades_reports.ex
@@ -1121,19 +1121,19 @@ defmodule Lanttern.GradesReports do
           sgre.grades_report_subject_id == grs.id and
           sgre.student_id == std.id,
       left_join: ov in assoc(sgre, :ordinal_value),
-      left_join: prov in assoc(sgre, :pre_retake_ordinal_value),
+      left_join: pr_ov in assoc(sgre, :pre_retake_ordinal_value),
       where: std.id in ^students_ids,
       where: grc.grades_report_id == ^grades_report_id,
       where: grc.school_cycle_id == ^cycle_id,
-      select: {std.id, grs.id, sgre, ov, prov}
+      select: {std.id, grs.id, sgre, ov, pr_ov}
     )
     |> Repo.all()
-    |> Enum.reduce(%{}, fn {std_id, grs_id, sgre, ov, prov}, acc ->
+    |> Enum.reduce(%{}, fn {std_id, grs_id, sgre, ov, pr_ov}, acc ->
       # "preload" ordinal value in student grade report entry
       sgre =
         case sgre do
           nil -> nil
-          sgre -> %{sgre | ordinal_value: ov, pre_retake_ordinal_value: prov}
+          sgre -> %{sgre | ordinal_value: ov, pre_retake_ordinal_value: pr_ov}
         end
 
       # build student map
@@ -1175,16 +1175,17 @@ defmodule Lanttern.GradesReports do
           sgre.grades_report_subject_id == grs.id and
           sgre.student_id == src.student_id,
       left_join: ov in assoc(sgre, :ordinal_value),
+      left_join: pr_ov in assoc(sgre, :pre_retake_ordinal_value),
       where: src.id == ^student_report_card_id,
-      select: {grc.id, grs.id, sgre, ov}
+      select: {grc.id, grs.id, sgre, ov, pr_ov}
     )
     |> Repo.all()
-    |> Enum.reduce(%{}, fn {grc_id, grs_id, sgre, ov}, acc ->
+    |> Enum.reduce(%{}, fn {grc_id, grs_id, sgre, ov, pr_ov}, acc ->
       # "preload" ordinal value in student grade report entry
       sgre =
         case sgre do
           nil -> nil
-          sgre -> %{sgre | ordinal_value: ov}
+          sgre -> %{sgre | ordinal_value: ov, pre_retake_ordinal_value: pr_ov}
         end
 
       # build cycle map

--- a/lib/lanttern/grades_reports.ex
+++ b/lib/lanttern/grades_reports.ex
@@ -553,6 +553,8 @@ defmodule Lanttern.GradesReports do
       join: gr in assoc(gc, :grades_report),
       join: grc in assoc(gc, :grades_report_cycle),
       join: grs in assoc(gc, :grades_report_subject),
+      # exclude entries where there are only student self-assessments
+      where: not is_nil(e.ordinal_value_id) or not is_nil(e.score),
       where: e.student_id == ^student_id,
       where: gr.id == ^grades_report_id,
       where: grc.id == ^grades_report_cycle_id,
@@ -759,6 +761,8 @@ defmodule Lanttern.GradesReports do
         join: gr in assoc(gc, :grades_report),
         join: grc in assoc(gc, :grades_report_cycle),
         join: grs in assoc(gc, :grades_report_subject),
+        # exclude entries where there are only student self-assessments
+        where: not is_nil(e.ordinal_value_id) or not is_nil(e.score),
         where: e.student_id == ^student_id,
         where: grc.id == ^grades_report_cycle_id,
         order_by: gc.position,
@@ -876,6 +880,8 @@ defmodule Lanttern.GradesReports do
         join: gr in assoc(gc, :grades_report),
         join: grc in assoc(gc, :grades_report_cycle),
         join: grs in assoc(gc, :grades_report_subject),
+        # exclude entries where there are only student self-assessments
+        where: not is_nil(e.ordinal_value_id) or not is_nil(e.score),
         where: e.student_id in ^students_ids,
         where: gr.id == ^grades_report_id,
         where: grc.id == ^grades_report_cycle_id,
@@ -1000,6 +1006,8 @@ defmodule Lanttern.GradesReports do
         join: gr in assoc(gc, :grades_report),
         join: grc in assoc(gc, :grades_report_cycle),
         join: grs in assoc(gc, :grades_report_subject),
+        # exclude entries where there are only student self-assessments
+        where: not is_nil(e.ordinal_value_id) or not is_nil(e.score),
         where: e.student_id in ^students_ids,
         where: gr.id == ^grades_report_id,
         where: grc.id == ^grades_report_cycle_id,

--- a/lib/lanttern/grades_reports/student_grade_report_entry.ex
+++ b/lib/lanttern/grades_reports/student_grade_report_entry.ex
@@ -16,6 +16,7 @@ defmodule Lanttern.GradesReports.StudentGradeReportEntry do
           id: pos_integer(),
           comment: String.t(),
           score: float(),
+          pre_retake_score: float(),
           student: Student.t(),
           student_id: pos_integer(),
           grades_report: GradesReport.t(),
@@ -26,6 +27,8 @@ defmodule Lanttern.GradesReports.StudentGradeReportEntry do
           grades_report_subject_id: pos_integer(),
           ordinal_value: OrdinalValue.t(),
           ordinal_value_id: pos_integer(),
+          pre_retake_ordinal_value: OrdinalValue.t(),
+          pre_retake_ordinal_value_id: pos_integer(),
           composition_normalized_value: float(),
           composition_ordinal_value: OrdinalValue.t(),
           composition_ordinal_value_id: pos_integer(),
@@ -38,12 +41,14 @@ defmodule Lanttern.GradesReports.StudentGradeReportEntry do
   schema "student_grade_report_entries" do
     field :comment, :string
     field :score, :float
+    field :pre_retake_score, :float
 
     belongs_to :student, Student
     belongs_to :grades_report, GradesReport
     belongs_to :grades_report_cycle, GradesReportCycle
     belongs_to :grades_report_subject, GradesReportSubject
     belongs_to :ordinal_value, OrdinalValue
+    belongs_to :pre_retake_ordinal_value, OrdinalValue
 
     # composition related fields
     field :composition_normalized_value, :float
@@ -78,11 +83,13 @@ defmodule Lanttern.GradesReports.StudentGradeReportEntry do
     |> cast(attrs, [
       :comment,
       :score,
+      :pre_retake_score,
       :student_id,
       :grades_report_id,
       :grades_report_cycle_id,
       :grades_report_subject_id,
       :ordinal_value_id,
+      :pre_retake_ordinal_value_id,
       :composition_normalized_value,
       :composition_ordinal_value_id,
       :composition_score,

--- a/lib/lanttern_web/components/grades_reports_components.ex
+++ b/lib/lanttern_web/components/grades_reports_components.ex
@@ -169,15 +169,29 @@ defmodule LantternWeb.GradesReportsComponents do
            assigns
        ) do
     ~H"""
-    <.button
-      type="button"
-      phx-click={@on_student_grade_click}
-      phx-value-gradesreportsubjectid={@student_grade_report_entry.grades_report_subject_id}
-      phx-value-gradesreportcycleid={@student_grade_report_entry.grades_report_cycle_id}
-      {apply_style_from_ordinal_value(@student_grade_report_entry.ordinal_value)}
-    >
-      <%= @student_grade_report_entry.ordinal_value.name %>
-    </.button>
+    <div class="flex items-stretch justify-stretch gap-1">
+      <.button
+        :if={@student_grade_report_entry.pre_retake_ordinal_value}
+        type="button"
+        phx-click={@on_student_grade_click}
+        phx-value-gradesreportsubjectid={@student_grade_report_entry.grades_report_subject_id}
+        phx-value-gradesreportcycleid={@student_grade_report_entry.grades_report_cycle_id}
+        {apply_style_from_ordinal_value(@student_grade_report_entry.pre_retake_ordinal_value)}
+        class="flex-1 my-2 opacity-70"
+      >
+        <%= @student_grade_report_entry.pre_retake_ordinal_value.name %>
+      </.button>
+      <.button
+        type="button"
+        phx-click={@on_student_grade_click}
+        phx-value-gradesreportsubjectid={@student_grade_report_entry.grades_report_subject_id}
+        phx-value-gradesreportcycleid={@student_grade_report_entry.grades_report_cycle_id}
+        {apply_style_from_ordinal_value(@student_grade_report_entry.ordinal_value)}
+        class="flex-[2]"
+      >
+        <%= @student_grade_report_entry.ordinal_value.name %>
+      </.button>
+    </div>
     """
   end
 
@@ -185,15 +199,27 @@ defmodule LantternWeb.GradesReportsComponents do
          %{student_grade_report_entry: %StudentGradeReportEntry{}} = assigns
        ) do
     ~H"""
-    <.button
-      type="button"
-      phx-click={@on_student_grade_click}
-      phx-value-gradesreportsubjectid={@student_grade_report_entry.grades_report_subject_id}
-      phx-value-gradesreportcycleid={@student_grade_report_entry.grades_report_cycle_id}
-      class="border border-ltrn-lighter"
-    >
-      <%= @student_grade_report_entry.score %>
-    </.button>
+    <div class="flex items-stretch justify-stretch gap-1 font-mono font-bold">
+      <button
+        :if={@student_grade_report_entry.pre_retake_score}
+        type="button"
+        phx-click={@on_student_grade_click}
+        phx-value-gradesreportsubjectid={@student_grade_report_entry.grades_report_subject_id}
+        phx-value-gradesreportcycleid={@student_grade_report_entry.grades_report_cycle_id}
+        class="flex-1 rounded border border-ltrn-lighter my-2 text-sm bg-ltrn-lightest opacity-70"
+      >
+        <%= @student_grade_report_entry.pre_retake_score %>
+      </button>
+      <button
+        type="button"
+        phx-click={@on_student_grade_click}
+        phx-value-gradesreportsubjectid={@student_grade_report_entry.grades_report_subject_id}
+        phx-value-gradesreportcycleid={@student_grade_report_entry.grades_report_cycle_id}
+        class="flex-[2] rounded border border-ltrn-lighter text-base bg-ltrn-lightest"
+      >
+        <%= @student_grade_report_entry.score %>
+      </button>
+    </div>
     """
   end
 
@@ -497,7 +523,7 @@ defmodule LantternWeb.GradesReportsComponents do
     ~H"""
     <button
       :if={@has_retake_history}
-      class="flex-1 self-stretch flex items-center justify-center border rounded-sm text-xs opacity-70"
+      class="flex-1 self-stretch flex items-center justify-center border rounded-sm my-2 text-xs opacity-70"
       {apply_style_from_ordinal_value(@student_grade_report_entry.pre_retake_ordinal_value)}
       phx-click={if(@on_entry_click, do: @on_entry_click.(@student_grade_report_entry.id))}
     >

--- a/lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex
+++ b/lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex
@@ -86,6 +86,12 @@
     >
       <%= @student_grade_report_entry.ordinal_value.name %>
     </div>
+    <div
+      :if={@student_grade_report_entry.score}
+      class="self-stretch flex items-center p-6 border border-ltrn-lighter rounded font-mono font-bold bg-ltrn-lightes"
+    >
+      <%= @student_grade_report_entry.score %>
+    </div>
     <div class="flex-1">
       <.metadata class="mb-4" icon_name="hero-bookmark">
         <span class="font-bold"><%= gettext("Subject") %>:</span>
@@ -100,6 +106,29 @@
         <%= @student_grade_report_entry.grades_report_cycle.school_cycle.name %>
       </.metadata>
     </div>
+  </div>
+
+  <div
+    :if={
+      @student_grade_report_entry.pre_retake_ordinal_value ||
+        @student_grade_report_entry.pre_retake_score
+    }
+    class="flex items-center gap-4 p-4 rounded mb-10 bg-ltrn-lightest"
+  >
+    <div
+      :if={@student_grade_report_entry.pre_retake_ordinal_value}
+      class="self-stretch flex items-center px-4 py-2 rounded text-sm opacity-70"
+      {apply_style_from_ordinal_value(@student_grade_report_entry.pre_retake_ordinal_value)}
+    >
+      <%= @student_grade_report_entry.pre_retake_ordinal_value.name %>
+    </div>
+    <div
+      :if={@student_grade_report_entry.pre_retake_score}
+      class="self-stretch flex items-center px-4 py-2 rounded font-mono font-bold text-sm opacity-70"
+    >
+      <%= @student_grade_report_entry.pre_retake_score %>
+    </div>
+    <p class="text-sm text-ltrn-subtle"><%= gettext("Grade before retake process") %></p>
   </div>
   <%= if @student_grade_report_entry.comment do %>
     <h6 class="mb-4 font-display font-bold"><%= gettext("Comment") %></h6>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2024.6.12-alpha.22",
+      version: "2024.6.13-alpha.23",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -22,7 +22,7 @@ msgstr ""
 msgid "Assessment points"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:488
+#: lib/lanttern_web/components/grades_reports_components.ex:578
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.ex:11
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:12
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
@@ -269,7 +269,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:150
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:73
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:55
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:81
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:54
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:63
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:83
@@ -373,7 +373,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:489
+#: lib/lanttern_web/components/grades_reports_components.ex:579
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:37
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:46
 #, elixir-autogen, elixir-format
@@ -655,7 +655,7 @@ msgstr ""
 msgid "Select strand"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:487
+#: lib/lanttern_web/components/grades_reports_components.ex:577
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:25
 #, elixir-autogen, elixir-format
 msgid "Strand"
@@ -992,22 +992,22 @@ msgstr ""
 msgid "Background color format not accepted. Use hex color."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:292
+#: lib/lanttern_web/components/grades_reports_components.ex:334
 #, elixir-autogen, elixir-format
 msgid "Calculate all"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:467
+#: lib/lanttern_web/components/grades_reports_components.ex:503
 #, elixir-autogen, elixir-format
 msgid "Calculate grade"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:341
+#: lib/lanttern_web/components/grades_reports_components.ex:393
 #, elixir-autogen, elixir-format
 msgid "Calculate student grades"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:312
+#: lib/lanttern_web/components/grades_reports_components.ex:358
 #, elixir-autogen, elixir-format
 msgid "Calculate subject grades"
 msgstr ""
@@ -1028,13 +1028,13 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:134
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:212
+#: lib/lanttern_web/components/grades_reports_components.ex:238
 #, elixir-autogen, elixir-format
 msgid "Comp"
 msgstr ""
@@ -1099,7 +1099,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:34
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:23
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:99
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Cycle"
@@ -1181,11 +1181,6 @@ msgstr ""
 msgid "Edit student report card"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:419
-#, elixir-autogen, elixir-format
-msgid "Entry with comments"
-msgstr ""
-
 #: lib/lanttern_web/live/pages/grading/grades_report_grid_setup_overlay_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Error adding cycle to grades report"
@@ -1252,7 +1247,7 @@ msgstr ""
 msgid "Filter curriculum items by year"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:521
+#: lib/lanttern_web/components/grades_reports_components.ex:611
 #, elixir-autogen, elixir-format
 msgid "Final grade"
 msgstr ""
@@ -1268,7 +1263,7 @@ msgid "Grade calculated succesfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:113
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:108
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Grade composition"
 msgstr ""
@@ -1437,7 +1432,7 @@ msgid "No curriculum items found for selected filters."
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:102
-#: lib/lanttern_web/components/grades_reports_components.ex:318
+#: lib/lanttern_web/components/grades_reports_components.ex:369
 #, elixir-autogen, elixir-format
 msgid "No cycles linked to this grades report"
 msgstr ""
@@ -1467,7 +1462,7 @@ msgstr ""
 msgid "No strands linked to this report yet"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:361
+#: lib/lanttern_web/components/grades_reports_components.ex:420
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr ""
@@ -1487,7 +1482,7 @@ msgstr ""
 msgid "No subjects linked to this grades report"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:491
+#: lib/lanttern_web/components/grades_reports_components.ex:581
 #, elixir-autogen, elixir-format
 msgid "Normalized value"
 msgstr ""
@@ -1509,8 +1504,7 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:412
-#: lib/lanttern_web/components/grades_reports_components.ex:450
+#: lib/lanttern_web/components/grades_reports_components.ex:485
 #, elixir-autogen, elixir-format
 msgid "Recalculate grade"
 msgstr ""
@@ -1589,12 +1583,13 @@ msgstr ""
 msgid "Save moment card"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:56
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Save student grade report entry"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:29
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:69
 #, elixir-autogen, elixir-format
 msgid "Select a level"
 msgstr ""
@@ -1669,7 +1664,7 @@ msgstr ""
 msgid "Student already linked to report card"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:162
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:207
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry created successfully"
 msgstr ""
@@ -1679,7 +1674,7 @@ msgstr ""
 msgid "Student grade report entry deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:186
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:231
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry updated successfully"
 msgstr ""
@@ -1715,7 +1710,7 @@ msgstr ""
 msgid "Sub cycle"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:91
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr ""
@@ -1755,7 +1750,7 @@ msgstr ""
 msgid "Viewing all grades reports"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:490
+#: lib/lanttern_web/components/grades_reports_components.ex:580
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Weight"
@@ -2575,4 +2570,39 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_report_grid_setup_overlay_component.ex:43
 #, elixir-autogen, elixir-format
 msgid "Visibility in grades reports"
+msgstr ""
+
+#: lib/lanttern_web/components/grades_reports_components.ex:328
+#, elixir-autogen, elixir-format
+msgid "Are you sure? All grades will be created, updated, and removed based on their grade composition."
+msgstr ""
+
+#: lib/lanttern_web/components/grades_reports_components.ex:396
+#, elixir-autogen, elixir-format
+msgid "Are you sure? Grades related to this student will be created, updated, and removed based on their grade composition."
+msgstr ""
+
+#: lib/lanttern_web/components/grades_reports_components.ex:361
+#, elixir-autogen, elixir-format
+msgid "Are you sure? Grades related to this subject will be created, updated, and removed based on their grade composition."
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:131
+#, elixir-autogen, elixir-format
+msgid "Grade before retake process"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:78
+#, elixir-autogen, elixir-format
+msgid "If needed, use this area to keep the student grade history before retake."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "Level before retake"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:75
+#, elixir-autogen, elixir-format
+msgid "Score before retake"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -22,7 +22,7 @@ msgstr ""
 msgid "Assessment points"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:488
+#: lib/lanttern_web/components/grades_reports_components.ex:578
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.ex:11
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:12
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
@@ -269,7 +269,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:150
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:73
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:55
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:81
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:54
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:63
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:83
@@ -373,7 +373,7 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:489
+#: lib/lanttern_web/components/grades_reports_components.ex:579
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:37
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:46
 #, elixir-autogen, elixir-format, fuzzy
@@ -655,7 +655,7 @@ msgstr ""
 msgid "Select strand"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:487
+#: lib/lanttern_web/components/grades_reports_components.ex:577
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:25
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strand"
@@ -992,22 +992,22 @@ msgstr ""
 msgid "Background color format not accepted. Use hex color."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:292
+#: lib/lanttern_web/components/grades_reports_components.ex:334
 #, elixir-autogen, elixir-format
 msgid "Calculate all"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:467
+#: lib/lanttern_web/components/grades_reports_components.ex:503
 #, elixir-autogen, elixir-format
 msgid "Calculate grade"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:341
+#: lib/lanttern_web/components/grades_reports_components.ex:393
 #, elixir-autogen, elixir-format
 msgid "Calculate student grades"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:312
+#: lib/lanttern_web/components/grades_reports_components.ex:358
 #, elixir-autogen, elixir-format
 msgid "Calculate subject grades"
 msgstr ""
@@ -1028,13 +1028,13 @@ msgstr ""
 msgid "Code"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:134
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:49
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Comment"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:212
+#: lib/lanttern_web/components/grades_reports_components.ex:238
 #, elixir-autogen, elixir-format
 msgid "Comp"
 msgstr ""
@@ -1099,7 +1099,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:34
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:23
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:99
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Cycle"
@@ -1181,11 +1181,6 @@ msgstr ""
 msgid "Edit student report card"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:419
-#, elixir-autogen, elixir-format
-msgid "Entry with comments"
-msgstr ""
-
 #: lib/lanttern_web/live/pages/grading/grades_report_grid_setup_overlay_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Error adding cycle to grades report"
@@ -1252,7 +1247,7 @@ msgstr ""
 msgid "Filter curriculum items by year"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:521
+#: lib/lanttern_web/components/grades_reports_components.ex:611
 #, elixir-autogen, elixir-format
 msgid "Final grade"
 msgstr ""
@@ -1268,7 +1263,7 @@ msgid "Grade calculated succesfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:113
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:108
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Grade composition"
 msgstr ""
@@ -1437,7 +1432,7 @@ msgid "No curriculum items found for selected filters."
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:102
-#: lib/lanttern_web/components/grades_reports_components.ex:318
+#: lib/lanttern_web/components/grades_reports_components.ex:369
 #, elixir-autogen, elixir-format
 msgid "No cycles linked to this grades report"
 msgstr ""
@@ -1467,7 +1462,7 @@ msgstr ""
 msgid "No strands linked to this report yet"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:361
+#: lib/lanttern_web/components/grades_reports_components.ex:420
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr ""
@@ -1487,7 +1482,7 @@ msgstr ""
 msgid "No subjects linked to this grades report"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:491
+#: lib/lanttern_web/components/grades_reports_components.ex:581
 #, elixir-autogen, elixir-format
 msgid "Normalized value"
 msgstr ""
@@ -1509,8 +1504,7 @@ msgstr ""
 msgid "Preview"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:412
-#: lib/lanttern_web/components/grades_reports_components.ex:450
+#: lib/lanttern_web/components/grades_reports_components.ex:485
 #, elixir-autogen, elixir-format
 msgid "Recalculate grade"
 msgstr ""
@@ -1589,12 +1583,13 @@ msgstr ""
 msgid "Save moment card"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:56
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Save student grade report entry"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:29
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:69
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a level"
 msgstr ""
@@ -1669,7 +1664,7 @@ msgstr ""
 msgid "Student already linked to report card"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:162
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:207
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry created successfully"
 msgstr ""
@@ -1679,7 +1674,7 @@ msgstr ""
 msgid "Student grade report entry deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:186
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:231
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry updated successfully"
 msgstr ""
@@ -1715,7 +1710,7 @@ msgstr ""
 msgid "Sub cycle"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:91
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:97
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Subject"
 msgstr ""
@@ -1755,7 +1750,7 @@ msgstr ""
 msgid "Viewing all grades reports"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:490
+#: lib/lanttern_web/components/grades_reports_components.ex:580
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Weight"
@@ -2575,4 +2570,39 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grading/grades_report_grid_setup_overlay_component.ex:43
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Visibility in grades reports"
+msgstr ""
+
+#: lib/lanttern_web/components/grades_reports_components.ex:328
+#, elixir-autogen, elixir-format
+msgid "Are you sure? All grades will be created, updated, and removed based on their grade composition."
+msgstr ""
+
+#: lib/lanttern_web/components/grades_reports_components.ex:396
+#, elixir-autogen, elixir-format
+msgid "Are you sure? Grades related to this student will be created, updated, and removed based on their grade composition."
+msgstr ""
+
+#: lib/lanttern_web/components/grades_reports_components.ex:361
+#, elixir-autogen, elixir-format
+msgid "Are you sure? Grades related to this subject will be created, updated, and removed based on their grade composition."
+msgstr ""
+
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:131
+#, elixir-autogen, elixir-format
+msgid "Grade before retake process"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:78
+#, elixir-autogen, elixir-format
+msgid "If needed, use this area to keep the student grade history before retake."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "Level before retake"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:75
+#, elixir-autogen, elixir-format
+msgid "Score before retake"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -22,7 +22,7 @@ msgstr "Ações"
 msgid "Assessment points"
 msgstr "Pontos de avaliação"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:488
+#: lib/lanttern_web/components/grades_reports_components.ex:578
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.ex:11
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:12
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
@@ -269,7 +269,7 @@ msgstr "Salvar Trilha"
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:150
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:73
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:55
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:81
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:54
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:63
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:83
@@ -373,7 +373,7 @@ msgstr "anos"
 msgid "About"
 msgstr "Sobre"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:489
+#: lib/lanttern_web/components/grades_reports_components.ex:579
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:37
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:46
 #, elixir-autogen, elixir-format
@@ -655,7 +655,7 @@ msgstr "Selecionar item curricular"
 msgid "Select strand"
 msgstr "Selecionar trilha"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:487
+#: lib/lanttern_web/components/grades_reports_components.ex:577
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:25
 #, elixir-autogen, elixir-format
 msgid "Strand"
@@ -992,22 +992,22 @@ msgstr "Já selecionado"
 msgid "Background color format not accepted. Use hex color."
 msgstr "Cor de fundo inválida. Utilize cores hex."
 
-#: lib/lanttern_web/components/grades_reports_components.ex:292
+#: lib/lanttern_web/components/grades_reports_components.ex:334
 #, elixir-autogen, elixir-format
 msgid "Calculate all"
 msgstr "Calcular tudo"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:467
+#: lib/lanttern_web/components/grades_reports_components.ex:503
 #, elixir-autogen, elixir-format
 msgid "Calculate grade"
 msgstr "Calcular nota"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:341
+#: lib/lanttern_web/components/grades_reports_components.ex:393
 #, elixir-autogen, elixir-format
 msgid "Calculate student grades"
 msgstr "Calcular notas do estudante"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:312
+#: lib/lanttern_web/components/grades_reports_components.ex:358
 #, elixir-autogen, elixir-format
 msgid "Calculate subject grades"
 msgstr "Calcular notas da disciplina"
@@ -1028,13 +1028,13 @@ msgstr "Cards"
 msgid "Code"
 msgstr "Código"
 
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:134
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr "Comentário"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:212
+#: lib/lanttern_web/components/grades_reports_components.ex:238
 #, elixir-autogen, elixir-format
 msgid "Comp"
 msgstr "Comp"
@@ -1099,7 +1099,7 @@ msgstr "Itens curriculares"
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_strand_report_live.html.heex:34
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:23
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:99
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:105
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Cycle"
@@ -1181,11 +1181,6 @@ msgstr "Editar registro de relatório de nota de estudante"
 msgid "Edit student report card"
 msgstr "Editar report card de estudante"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:419
-#, elixir-autogen, elixir-format
-msgid "Entry with comments"
-msgstr "Registro com comentários"
-
 #: lib/lanttern_web/live/pages/grading/grades_report_grid_setup_overlay_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Error adding cycle to grades report"
@@ -1252,7 +1247,7 @@ msgstr "Filtrar itens curriculares por disciplina"
 msgid "Filter curriculum items by year"
 msgstr "Filtrar itens curriculares por ano"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:521
+#: lib/lanttern_web/components/grades_reports_components.ex:611
 #, elixir-autogen, elixir-format
 msgid "Final grade"
 msgstr "Nota final"
@@ -1268,7 +1263,7 @@ msgid "Grade calculated succesfully"
 msgstr "Nota calculada com sucesso"
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:113
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:108
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:137
 #, elixir-autogen, elixir-format
 msgid "Grade composition"
 msgstr "Composição de nota"
@@ -1437,7 +1432,7 @@ msgid "No curriculum items found for selected filters."
 msgstr "Nenhum item curricular encontrado para os filtros selecionados."
 
 #: lib/lanttern_web/components/grades_reports_components.ex:102
-#: lib/lanttern_web/components/grades_reports_components.ex:318
+#: lib/lanttern_web/components/grades_reports_components.ex:369
 #, elixir-autogen, elixir-format
 msgid "No cycles linked to this grades report"
 msgstr "Nenhum ciclo vinculado a este relatório de notas"
@@ -1467,7 +1462,7 @@ msgstr "Nenhum report card criado ainda"
 msgid "No strands linked to this report yet"
 msgstr "Nenhuma trilha vinculada a este relatório ainda"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:361
+#: lib/lanttern_web/components/grades_reports_components.ex:420
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr "Nenhum estudante vinculado a este relatório de notas"
@@ -1487,7 +1482,7 @@ msgstr "Nenhuma disciplina vinculada"
 msgid "No subjects linked to this grades report"
 msgstr "Nenhuma disciplina vinculada a este relatório de notas"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:491
+#: lib/lanttern_web/components/grades_reports_components.ex:581
 #, elixir-autogen, elixir-format
 msgid "Normalized value"
 msgstr "Valor normalizado"
@@ -1509,8 +1504,7 @@ msgstr "Resultados parciais"
 msgid "Preview"
 msgstr "Prévia"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:412
-#: lib/lanttern_web/components/grades_reports_components.ex:450
+#: lib/lanttern_web/components/grades_reports_components.ex:485
 #, elixir-autogen, elixir-format
 msgid "Recalculate grade"
 msgstr "Recalcular nota"
@@ -1589,12 +1583,13 @@ msgstr "Salvar relatório de nota"
 msgid "Save moment card"
 msgstr "Salvar card de momento"
 
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:56
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Save student grade report entry"
 msgstr "Salvar registro de relatório de nota de estudante"
 
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:29
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:69
 #, elixir-autogen, elixir-format
 msgid "Select a level"
 msgstr "Selecione uma escala"
@@ -1669,7 +1664,7 @@ msgstr "Trilha vinculada ao relatório"
 msgid "Student already linked to report card"
 msgstr "Estudante já vinculado ao report card"
 
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:162
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:207
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry created successfully"
 msgstr "Registro de relatório de nota de estudante criado com sucesso"
@@ -1679,7 +1674,7 @@ msgstr "Registro de relatório de nota de estudante criado com sucesso"
 msgid "Student grade report entry deleted"
 msgstr "Registro de relatório de nota de estudante deletado"
 
-#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:186
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:231
 #, elixir-autogen, elixir-format
 msgid "Student grade report entry updated successfully"
 msgstr "Registro de relatório de nota de estudante atualizado com sucesso"
@@ -1715,7 +1710,7 @@ msgstr "Filtro de notas de estudantes"
 msgid "Sub cycle"
 msgstr "Sub ciclo"
 
-#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:91
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "Subject"
 msgstr "Disciplina"
@@ -1755,7 +1750,7 @@ msgstr "Utilize esta funcionalidade para adicionar uma camada de organização a
 msgid "Viewing all grades reports"
 msgstr "Visualizando todos os relatórios de nota"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:490
+#: lib/lanttern_web/components/grades_reports_components.ex:580
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Weight"
@@ -2576,3 +2571,38 @@ msgstr "Nenhuma descrição de relatório da trilha"
 #, elixir-autogen, elixir-format
 msgid "Visibility in grades reports"
 msgstr "Visibilidade nos relatórios de notas"
+
+#: lib/lanttern_web/components/grades_reports_components.ex:328
+#, elixir-autogen, elixir-format
+msgid "Are you sure? All grades will be created, updated, and removed based on their grade composition."
+msgstr "Você tem certeza? Todas as notas serão criadas, atualizadas e removidas com base em suas composições."
+
+#: lib/lanttern_web/components/grades_reports_components.ex:396
+#, elixir-autogen, elixir-format
+msgid "Are you sure? Grades related to this student will be created, updated, and removed based on their grade composition."
+msgstr "Você tem certeza? Notas relacionadas ao estudante serão criadas, atualizadas e removidas com base em suas composições."
+
+#: lib/lanttern_web/components/grades_reports_components.ex:361
+#, elixir-autogen, elixir-format
+msgid "Are you sure? Grades related to this subject will be created, updated, and removed based on their grade composition."
+msgstr "Você tem certeza? Notas relacionadas à disciplina serão criadas, atualizadas e removidas com base em suas composições."
+
+#: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:131
+#, elixir-autogen, elixir-format
+msgid "Grade before retake process"
+msgstr "Nota anterior ao processo de recuperação"
+
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:78
+#, elixir-autogen, elixir-format
+msgid "If needed, use this area to keep the student grade history before retake."
+msgstr "Se necessário, utilize esta área para manter o histórico de nota do estudante antes da recuperação."
+
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "Level before retake"
+msgstr "Nível anterior à recuperação"
+
+#: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:75
+#, elixir-autogen, elixir-format
+msgid "Score before retake"
+msgstr "Score anterior à recuperação"

--- a/priv/repo/migrations/20240612153246_add_retake_fields_to_student_grade_report_entries.exs
+++ b/priv/repo/migrations/20240612153246_add_retake_fields_to_student_grade_report_entries.exs
@@ -1,0 +1,12 @@
+defmodule Lanttern.Repo.Migrations.AddRetakeFieldsToStudentGradeReportEntries do
+  use Ecto.Migration
+
+  def change do
+    alter table(:student_grade_report_entries) do
+      add :pre_retake_score, :float
+      add :pre_retake_ordinal_value_id, references(:ordinal_values, on_delete: :nothing)
+    end
+
+    create index(:student_grade_report_entries, [:pre_retake_ordinal_value_id])
+  end
+end


### PR DESCRIPTION
- now it's possible to keep the register of the grade before the retake process when needed. closes #174 
- grade calculation functions where adjusted to support entries with student self-assessment but no teacher assessment. fixes #175 