### PR TITLE
visual feedback when saving students self-assessments

### DIFF
--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -299,11 +299,11 @@ defmodule LantternWeb.CoreComponents do
       "disabled:opacity-40"
     ],
     "teacher" => [
-      "bg-ltrn-teacher-accent text-ltrn-teacher-dark hover:opacity-80",
+      "bg-ltrn-teacher-lighter text-ltrn-teacher-dark hover:opacity-80",
       "disabled:opacity-40"
     ],
     "student" => [
-      "bg-ltrn-student-accent text-ltrn-student-dark hover:opacity-80",
+      "bg-ltrn-student-lighter text-ltrn-student-dark hover:opacity-80",
       "disabled:opacity-40"
     ],
     "white" => "text-ltrn-dark bg-white hover:bg-ltrn-lightest",
@@ -729,7 +729,7 @@ defmodule LantternWeb.CoreComponents do
 
   def icon(%{name: "hero-" <> _} = assigns) do
     ~H"""
-    <span class={[@name, @class]} aria-hidden="true" id={@id} />
+    <span class={["shrink-0", @name, @class]} aria-hidden="true" id={@id} />
     """
   end
 

--- a/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
@@ -188,16 +188,15 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
       />
       <.fixed_bar :if={@entries_changes_map != %{}} class="flex items-center gap-6">
         <div class="flex-1 flex items-center gap-4 text-sm">
-          <p class="text-white">
+          <p class="text-white text-nowrap">
             <%= ngettext("1 change", "%{count} changes", map_size(@entries_changes_map)) %>
           </p>
           <p
             :if={@current_assessment_view == "student"}
-            class="p-2 rounded text-ltrn-student-dark bg-ltrn-student-lighter"
+            class="flex items-center gap-2 font-bold text-ltrn-student-accent"
           >
-            <%= gettext(
-              "You are registering students self-assessments. Make sure this is intended and, if needed, change to teacher view above."
-            ) %>
+            <.icon name="hero-information-circle" class="w-6 h-6" />
+            <%= gettext("You are registering students self-assessments") %>
           </p>
         </div>
         <.button
@@ -207,8 +206,15 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
         >
           <%= gettext("Discard") %>
         </.button>
-        <.button type="button" phx-click="save_changes" phx-target={@myself}>
-          <%= gettext("Save") %>
+        <.button
+          type="button"
+          phx-click="save_changes"
+          phx-target={@myself}
+          theme={if @current_assessment_view == "student", do: "student"}
+        >
+          <%= if @current_assessment_view == "student",
+            do: gettext("Save self-assessments"),
+            else: gettext("Save") %>
         </.button>
       </.fixed_bar>
     </div>

--- a/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/reporting_component.ex
@@ -187,9 +187,19 @@ defmodule LantternWeb.StrandLive.ReportingComponent do
         navigate={~p"/strands/#{@strand}?tab=reporting"}
       />
       <.fixed_bar :if={@entries_changes_map != %{}} class="flex items-center gap-6">
-        <p class="flex-1 text-sm text-white">
-          <%= ngettext("1 change", "%{count} changes", map_size(@entries_changes_map)) %>
-        </p>
+        <div class="flex-1 flex items-center gap-4 text-sm">
+          <p class="text-white">
+            <%= ngettext("1 change", "%{count} changes", map_size(@entries_changes_map)) %>
+          </p>
+          <p
+            :if={@current_assessment_view == "student"}
+            class="p-2 rounded text-ltrn-student-dark bg-ltrn-student-lighter"
+          >
+            <%= gettext(
+              "You are registering students self-assessments. Make sure this is intended and, if needed, change to teacher view above."
+            ) %>
+          </p>
+        </div>
         <.button
           phx-click={JS.navigate(~p"/strands/#{@strand}?tab=reporting")}
           theme="ghost"

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2024.6.13-alpha.23",
+      version: "2024.6.14-alpha.24",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -170,7 +170,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:141
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:201
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:217
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:139
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:206
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:182
@@ -461,7 +461,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:196
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:205
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:71
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:188
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:146
@@ -1111,7 +1111,7 @@ msgstr ""
 msgid "Cycle already added to this grade report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:222
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:238
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:282
@@ -1908,7 +1908,7 @@ msgid_plural "%{count} entries updated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:198
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:207
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:254
 #, elixir-autogen, elixir-format
 msgid "Discard"
@@ -2029,7 +2029,7 @@ msgstr ""
 msgid "Save note"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:191
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:192
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:247
 #, elixir-autogen, elixir-format
 msgid "1 change"
@@ -2505,13 +2505,13 @@ msgid "Invalid assessment view"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:65
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:233
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:249
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:59
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:230
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:246
 #, elixir-autogen, elixir-format
 msgid "Teacher"
 msgstr ""
@@ -2605,4 +2605,14 @@ msgstr ""
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "Score before retake"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:199
+#, elixir-autogen, elixir-format
+msgid "You are registering students self-assessments"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:216
+#, elixir-autogen, elixir-format
+msgid "Save self-assessments"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -170,7 +170,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:141
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:201
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:217
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:139
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:206
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:182
@@ -461,7 +461,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:196
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:205
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:71
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:188
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:146
@@ -1111,7 +1111,7 @@ msgstr ""
 msgid "Cycle already added to this grade report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:222
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:238
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:282
@@ -1908,7 +1908,7 @@ msgid_plural "%{count} entries updated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:198
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:207
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:254
 #, elixir-autogen, elixir-format
 msgid "Discard"
@@ -2029,7 +2029,7 @@ msgstr ""
 msgid "Save note"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:191
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:192
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:247
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 change"
@@ -2505,13 +2505,13 @@ msgid "Invalid assessment view"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:65
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:233
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:249
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:59
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:230
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:246
 #, elixir-autogen, elixir-format
 msgid "Teacher"
 msgstr ""
@@ -2605,4 +2605,14 @@ msgstr ""
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "Score before retake"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:199
+#, elixir-autogen, elixir-format
+msgid "You are registering students self-assessments"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:216
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Save self-assessments"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -170,7 +170,7 @@ msgstr "Nenhuma trilha criadas para os anos e componentes selecionados"
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:169
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:96
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:141
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:201
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:217
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:139
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:206
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:182
@@ -461,7 +461,7 @@ msgstr "Adicione suas anotações..."
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:133
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:155
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:196
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:205
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:71
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:188
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:146
@@ -1111,7 +1111,7 @@ msgstr "Ciclo"
 msgid "Cycle already added to this grade report"
 msgstr "Ciclo já adicionado à este relatório de nota"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:222
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:238
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:282
@@ -1908,7 +1908,7 @@ msgid_plural "%{count} entries updated"
 msgstr[0] "1 registro atualizado"
 msgstr[1] "%{count} registros atualizados"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:198
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:207
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:254
 #, elixir-autogen, elixir-format
 msgid "Discard"
@@ -2029,7 +2029,7 @@ msgstr "Anotação"
 msgid "Save note"
 msgstr "Salvar anotação"
 
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:191
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:192
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:247
 #, elixir-autogen, elixir-format
 msgid "1 change"
@@ -2505,13 +2505,13 @@ msgid "Invalid assessment view"
 msgstr "Visualização de avaliação inválida"
 
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:65
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:233
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:249
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Estudante"
 
 #: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:59
-#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:230
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:246
 #, elixir-autogen, elixir-format
 msgid "Teacher"
 msgstr "Professor"
@@ -2606,3 +2606,13 @@ msgstr "Nível anterior à recuperação"
 #, elixir-autogen, elixir-format
 msgid "Score before retake"
 msgstr "Score anterior à recuperação"
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:199
+#, elixir-autogen, elixir-format
+msgid "You are registering students self-assessments"
+msgstr "Você está registrando autoavaliações de estudantes"
+
+#: lib/lanttern_web/live/pages/strands/id/reporting_component.ex:216
+#, elixir-autogen, elixir-format
+msgid "Save self-assessments"
+msgstr "Salvar autoavaliações"


### PR DESCRIPTION
added some basic UI changes to prevent users from saving students self-assessments by mistake.

should resolve #176 