### PR TITLE
students ongoing assessment tracking

### DIFF
--- a/lib/lanttern/learning_context.ex
+++ b/lib/lanttern/learning_context.ex
@@ -139,6 +139,28 @@ defmodule Lanttern.LearningContext do
     do: apply_list_student_strands_opts(queryable, opts)
 
   @doc """
+  Returns the list of strands linked to the given report card.
+
+  Results are ordered by strand report position.
+
+  ## Examples
+
+      iex> list_report_card_strands(report_card_id)
+      [%Strand{}, ...]
+
+  """
+  @spec list_report_card_strands(report_card_id :: pos_integer()) :: [Strand.t()]
+  def list_report_card_strands(report_card_id) do
+    from(
+      s in Strand,
+      join: sr in assoc(s, :strand_reports),
+      where: sr.report_card_id == ^report_card_id,
+      order_by: sr.position
+    )
+    |> Repo.all()
+  end
+
+  @doc """
   Search strands by name.
 
   ## Options

--- a/lib/lanttern/learning_context.ex
+++ b/lib/lanttern/learning_context.ex
@@ -154,8 +154,12 @@ defmodule Lanttern.LearningContext do
     from(
       s in Strand,
       join: sr in assoc(s, :strand_reports),
+      left_join: m in assoc(s, :moments),
+      left_join: ap in assoc(m, :assessment_points),
       where: sr.report_card_id == ^report_card_id,
-      order_by: sr.position
+      order_by: sr.position,
+      group_by: [s.id, sr.position],
+      select: %{s | assessment_points_count: count(ap)}
     )
     |> Repo.all()
   end

--- a/lib/lanttern/learning_context/strand.ex
+++ b/lib/lanttern/learning_context/strand.ex
@@ -30,6 +30,7 @@ defmodule Lanttern.LearningContext.Strand do
           years_ids: [pos_integer()],
           is_starred: boolean(),
           strand_report_id: pos_integer(),
+          assessment_points_count: non_neg_integer(),
           report_cycle: Cycle.t(),
           moments: [Moment.t()],
           assessment_points: [AssessmentPoint.t()],
@@ -53,6 +54,7 @@ defmodule Lanttern.LearningContext.Strand do
     field :years_ids, {:array, :id}, virtual: true
     field :is_starred, :boolean, virtual: true
     field :strand_report_id, :id, virtual: true
+    field :assessment_points_count, :integer, virtual: true
     field :report_cycle, :map, virtual: true
 
     has_many :moments, Moment

--- a/lib/lanttern_web/components/reporting_components.ex
+++ b/lib/lanttern_web/components/reporting_components.ex
@@ -312,4 +312,99 @@ defmodule LantternWeb.ReportingComponents do
     </div>
     """
   end
+
+  @doc """
+  Renders a student moments entries grid for a given report card.
+  """
+
+  attr :students_stream, :any, required: true
+  attr :has_students, :boolean, required: true
+  attr :strands, :list, required: true
+  # attr :students_entries_map, :map, required: true
+  attr :class, :any, default: nil
+
+  def students_moments_entries_grid(assigns) do
+    strands_count = length(assigns.strands)
+
+    grid_template_columns_style =
+      case strands_count do
+        n when n > 0 ->
+          "grid-template-columns: 200px repeat(#{n}, minmax(144px, 1fr))"
+
+        _ ->
+          "grid-template-columns: 200px minmax(144px, 1fr)"
+      end
+
+    grid_column_style =
+      case strands_count do
+        0 -> "grid-column: span 2 / span 2"
+        n -> "grid-column: span #{n + 1} / span #{n + 1}"
+      end
+
+    assigns =
+      assigns
+      |> assign(:grid_template_columns_style, grid_template_columns_style)
+      |> assign(:grid_column_style, grid_column_style)
+
+    ~H"""
+    <div class={[
+      "relative w-full max-h-[calc(100vh-4rem)] rounded bg-white shadow-xl overflow-x-auto",
+      @class
+    ]}>
+      <div class="relative grid gap-1 w-max text-sm" style={@grid_template_columns_style}>
+        <div class="sticky top-0 z-20 grid grid-cols-subgrid p-1 bg-white" style={@grid_column_style}>
+          <div class="sticky left-1"></div>
+          <%= if @strands != [] do %>
+            <div
+              :for={strand <- @strands}
+              id={"moments-entries-grid-strand-#{strand.id}"}
+              class="flex items-center justify-center gap-2 px-1 py-4 rounded text-center bg-white shadow-lg"
+            >
+              <span class="flex-1 truncate">
+                <%= strand.name %>
+              </span>
+            </div>
+          <% else %>
+            <div class="p-2 rounded text-ltrn-subtle bg-ltrn-lightest">
+              <%= gettext("No strands linked to this report card") %>
+            </div>
+          <% end %>
+        </div>
+        <%= if @has_students do %>
+          <div
+            :for={{dom_id, student} <- @students_stream}
+            id={dom_id}
+            class="grid grid-cols-subgrid px-1"
+            style={@grid_column_style}
+          >
+            <div class="sticky left-1 z-10 flex items-center gap-2 px-2 py-4 rounded bg-white shadow-lg">
+              <.profile_icon_with_name
+                icon_size="sm"
+                class="flex-1"
+                profile_name={student.name}
+                extra_info={student.classes |> Enum.map(& &1.name) |> Enum.join(", ")}
+              />
+            </div>
+            <%= if @strands != [] do %>
+              TBD
+            <% else %>
+              <div class="rounded border border-ltrn-lighter bg-ltrn-lightest"></div>
+            <% end %>
+          </div>
+        <% else %>
+          <div class="grid grid-cols-subgrid" style={@grid_column_style}>
+            <div class="p-4 rounded text-ltrn-subtle bg-ltrn-lightest">
+              <%= gettext("No students linked to this grades report") %>
+            </div>
+            <%= if @strands != [] do %>
+              TBD
+            <% else %>
+              <div class="rounded border border-ltrn-lighter bg-ltrn-lightest"></div>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
 end

--- a/lib/lanttern_web/components/reporting_components.ex
+++ b/lib/lanttern_web/components/reporting_components.ex
@@ -20,6 +20,9 @@ defmodule LantternWeb.ReportingComponents do
   alias Lanttern.Schools.Cycle
   alias Lanttern.Taxonomy.Year
 
+  # shared components
+  alias LantternWeb.Assessments.EntryParticleComponent
+
   @doc """
   Renders a teacher or student comment area
   """
@@ -319,24 +322,30 @@ defmodule LantternWeb.ReportingComponents do
 
   attr :students_stream, :any, required: true
   attr :has_students, :boolean, required: true
-  attr :strands, :list, required: true
-  # attr :students_entries_map, :map, required: true
+
+  attr :strands, :list,
+    required: true,
+    doc: "requires `assessment_points_count` field to be calculated"
+
+  attr :students_entries_map, :map, required: true
   attr :class, :any, default: nil
 
   def students_moments_entries_grid(assigns) do
-    strands_count = length(assigns.strands)
+    assessment_points_count =
+      assigns.strands
+      |> Enum.reduce(0, fn strand, count -> count + strand.assessment_points_count end)
 
     grid_template_columns_style =
-      case strands_count do
+      case assessment_points_count do
         n when n > 0 ->
-          "grid-template-columns: 200px repeat(#{n}, minmax(144px, 1fr))"
+          "grid-template-columns: 200px repeat(#{n}, 16px)"
 
         _ ->
-          "grid-template-columns: 200px minmax(144px, 1fr)"
+          "grid-template-columns: 200px minmax(10px, 1fr)"
       end
 
     grid_column_style =
-      case strands_count do
+      case assessment_points_count do
         0 -> "grid-column: span 2 / span 2"
         n -> "grid-column: span #{n + 1} / span #{n + 1}"
       end
@@ -351,22 +360,30 @@ defmodule LantternWeb.ReportingComponents do
       "relative w-full max-h-[calc(100vh-4rem)] rounded bg-white shadow-xl overflow-x-auto",
       @class
     ]}>
-      <div class="relative grid gap-1 w-max text-sm" style={@grid_template_columns_style}>
-        <div class="sticky top-0 z-20 grid grid-cols-subgrid p-1 bg-white" style={@grid_column_style}>
-          <div class="sticky left-1"></div>
+      <div class="relative grid gap-1 w-max min-w-full" style={@grid_template_columns_style}>
+        <div
+          class="sticky top-0 z-20 grid grid-cols-subgrid py-1 pr-1 bg-white"
+          style={@grid_column_style}
+        >
+          <div class="sticky left-0 bg-white"></div>
           <%= if @strands != [] do %>
-            <div
+            <a
               :for={strand <- @strands}
               id={"moments-entries-grid-strand-#{strand.id}"}
-              class="flex items-center justify-center gap-2 px-1 py-4 rounded text-center bg-white shadow-lg"
+              href={"/strands/#{strand.id}?tab=assessment"}
+              target="_blank"
+              class="w-full p-1 rounded-sm border border-ltrn-lighter text-center truncate bg-white hover:bg-ltrn-lighter"
+              style={"grid-column: span #{strand.assessment_points_count} / span #{strand.assessment_points_count}"}
+              title={"#{if strand.type, do: "#{strand.type} | "}#{strand.name}"}
             >
-              <span class="flex-1 truncate">
+              <span class="font-display font-black text-sm">
+                <%= if strand.type, do: "#{strand.type} | " %>
                 <%= strand.name %>
               </span>
-            </div>
+            </a>
           <% else %>
-            <div class="p-2 rounded text-ltrn-subtle bg-ltrn-lightest">
-              <%= gettext("No strands linked to this report card") %>
+            <div class="w-full p-2 rounded text-ltrn-subtle text-center bg-ltrn-lightest">
+              <%= gettext("No strands with moments assessment linked to this report card") %>
             </div>
           <% end %>
         </div>
@@ -374,21 +391,31 @@ defmodule LantternWeb.ReportingComponents do
           <div
             :for={{dom_id, student} <- @students_stream}
             id={dom_id}
-            class="grid grid-cols-subgrid px-1"
+            class="grid grid-cols-subgrid items-center pr-1 hover:bg-ltrn-mesh-cyan"
             style={@grid_column_style}
           >
-            <div class="sticky left-1 z-10 flex items-center gap-2 px-2 py-4 rounded bg-white shadow-lg">
-              <.profile_icon_with_name
-                icon_size="sm"
-                class="flex-1"
-                profile_name={student.name}
-                extra_info={student.classes |> Enum.map(& &1.name) |> Enum.join(", ")}
-              />
+            <div class="sticky left-0 z-10 p-2 text-xs truncate bg-white" title={student.name}>
+              <%= student.name %>
             </div>
             <%= if @strands != [] do %>
-              TBD
+              <%= for strand <- @strands do %>
+                <%= for {moment_id, assessment_point_id, entry} <- @students_entries_map[student.id][strand.id] do %>
+                  <a
+                    href={"/strands/moment/#{moment_id}?tab=assessment"}
+                    target="_blank"
+                    class="block w-min rounded-sm outline-ltrn-primary text-center hover:outline"
+                  >
+                    <.live_component
+                      module={EntryParticleComponent}
+                      id={"student-#{student.id}-ap-#{assessment_point_id}"}
+                      entry={entry}
+                      size="sm"
+                    />
+                  </a>
+                <% end %>
+              <% end %>
             <% else %>
-              <div class="rounded border border-ltrn-lighter bg-ltrn-lightest"></div>
+              <div class="h-full rounded border border-ltrn-lighter bg-ltrn-lightest"></div>
             <% end %>
           </div>
         <% else %>

--- a/lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex
@@ -9,6 +9,7 @@ defmodule LantternWeb.ReportCardLive do
   alias __MODULE__.StrandsReportsComponent
   alias __MODULE__.GradesComponent
   alias __MODULE__.StudentsGradesComponent
+  alias __MODULE__.StudentsTrackingComponent
 
   # shared components
   alias LantternWeb.Reporting.ReportCardFormComponent
@@ -16,7 +17,8 @@ defmodule LantternWeb.ReportCardLive do
   @tabs %{
     "students" => :students,
     "strands" => :strands,
-    "grades" => :grades
+    "grades" => :grades,
+    "tracking" => :tracking
   }
 
   # lifecycle

--- a/lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex
+++ b/lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex
@@ -39,6 +39,12 @@
       >
         <%= gettext("Grades") %>
       </:tab>
+      <:tab
+        patch={~p"/report_cards/#{@report_card}?#{%{tab: "tracking"}}"}
+        is_current={@current_tab == :tracking && "true"}
+      >
+        <%= gettext("Tracking") %>
+      </:tab>
     </.nav_tabs>
     <.menu_button id={@report_card.id}>
       <:item
@@ -90,6 +96,15 @@
     <.live_component
       module={StudentsGradesComponent}
       id="report-card-students-grades"
+      report_card={@report_card}
+      current_user={@current_user}
+      params={@params}
+    />
+  </div>
+  <div :if={@current_tab == :tracking}>
+    <.live_component
+      module={StudentsTrackingComponent}
+      id="report-card-students-tracking"
       report_card={@report_card}
       current_user={@current_user}
       params={@params}

--- a/lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex
@@ -1,0 +1,121 @@
+defmodule LantternWeb.ReportCardLive.StudentsTrackingComponent do
+  alias Lanttern.LearningContext
+  use LantternWeb, :live_component
+
+  alias Lanttern.Reporting
+  alias Lanttern.Schools
+
+  import LantternWeb.FiltersHelpers,
+    only: [assign_user_filters: 4, save_profile_filters: 4]
+
+  # shared
+  alias LantternWeb.Filters.InlineFiltersComponent
+  import LantternWeb.ReportingComponents
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="py-10">
+      <div class="container mx-auto lg:max-w-5xl">
+        <h5 class="font-display font-bold text-2xl">
+          <%= gettext("Students tracking") %>
+        </h5>
+        <p class="mt-2">
+          <%= gettext("Track progress of all students linked in the students tab.") %>
+        </p>
+        <.live_component
+          module={InlineFiltersComponent}
+          id="linked-students-grades-classes-filter"
+          filter_items={@linked_students_classes}
+          selected_items_ids={@selected_linked_students_classes_ids}
+          class="mt-4"
+          notify_component={@myself}
+        />
+      </div>
+      <%= if !@has_students do %>
+        <div class="container mx-auto mt-4 lg:max-w-5xl">
+          <div class="p-10 rounded shadow-xl bg-white">
+            <.empty_state>
+              <%= gettext("Add students to report card to track entries") %>
+            </.empty_state>
+          </div>
+        </div>
+      <% else %>
+        <div class="p-6">
+          <.students_moments_entries_grid
+            students_stream={@streams.students}
+            strands={@strands}
+            has_students={@has_students}
+          />
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+
+  # lifecycle
+
+  @impl true
+  def mount(socket) do
+    {:ok, socket, temporary_assigns: [students_entries_map: %{}]}
+  end
+
+  @impl true
+  def update(%{action: {InlineFiltersComponent, {:apply, classes_ids}}}, socket) do
+    socket =
+      socket
+      |> assign(:selected_linked_students_classes_ids, classes_ids)
+      |> save_profile_filters(
+        socket.assigns.current_user,
+        [:linked_students_classes],
+        report_card_id: socket.assigns.report_card.id
+      )
+      |> assign_students_entries_grid()
+
+    {:ok, socket}
+  end
+
+  def update(assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign_user_filters([:classes, :linked_students_classes], assigns.current_user,
+        report_card_id: assigns.report_card.id
+      )
+      |> stream_report_card_strands()
+      |> assign_students_entries_grid()
+
+    {:ok, socket}
+  end
+
+  defp stream_report_card_strands(socket) do
+    strands =
+      LearningContext.list_report_card_strands(socket.assigns.report_card.id)
+
+    socket
+    |> assign(:strands, strands)
+  end
+
+  defp assign_students_entries_grid(socket) do
+    students =
+      Schools.list_students(
+        report_card_id: socket.assigns.report_card.id,
+        classes_ids: socket.assigns.selected_linked_students_classes_ids
+      )
+
+    students_ids =
+      students
+      |> Enum.map(& &1.id)
+
+    students_entries_map =
+      Reporting.build_students_moments_entries_map_for_report_card(
+        socket.assigns.report_card.id,
+        students_ids
+      )
+
+    socket
+    |> stream(:students, students)
+    |> assign(:has_students, students != [])
+    |> assign(:students_entries_map, students_entries_map)
+  end
+end

--- a/lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex
@@ -16,9 +16,9 @@ defmodule LantternWeb.ReportCardLive.StudentsTrackingComponent do
   def render(assigns) do
     ~H"""
     <div class="py-10">
-      <div class="container mx-auto lg:max-w-5xl">
+      <.responsive_container>
         <h5 class="font-display font-bold text-2xl">
-          <%= gettext("Students tracking") %>
+          <%= gettext("Students moments assessment tracking") %>
         </h5>
         <p class="mt-2">
           <%= gettext("Track progress of all students linked in the students tab.") %>
@@ -31,7 +31,7 @@ defmodule LantternWeb.ReportCardLive.StudentsTrackingComponent do
           class="mt-4"
           notify_component={@myself}
         />
-      </div>
+      </.responsive_container>
       <%= if !@has_students do %>
         <div class="container mx-auto mt-4 lg:max-w-5xl">
           <div class="p-10 rounded shadow-xl bg-white">
@@ -46,6 +46,7 @@ defmodule LantternWeb.ReportCardLive.StudentsTrackingComponent do
             students_stream={@streams.students}
             strands={@strands}
             has_students={@has_students}
+            students_entries_map={@students_entries_map}
           />
         </div>
       <% end %>
@@ -90,7 +91,10 @@ defmodule LantternWeb.ReportCardLive.StudentsTrackingComponent do
 
   defp stream_report_card_strands(socket) do
     strands =
-      LearningContext.list_report_card_strands(socket.assigns.report_card.id)
+      socket.assigns.report_card.id
+      |> LearningContext.list_report_card_strands()
+      # remove strands without assessment points
+      |> Enum.filter(&(&1.assessment_points_count > 0))
 
     socket
     |> assign(:strands, strands)

--- a/lib/lanttern_web/live/shared/assessments/entry_particle_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_particle_component.ex
@@ -25,7 +25,7 @@ defmodule LantternWeb.Assessments.EntryParticleComponent do
     ~H"""
     <div
       class={[
-        "flex items-center justify-center  rounded-sm",
+        "flex items-center justify-center rounded-sm",
         if(@size == "sm", do: "w-4 h-4 max-w-4 text-sm", else: "w-6 h-6 max-w-6 text-base"),
         @additional_classes,
         @class

--- a/lib/lanttern_web/live/shared/menu_component.ex
+++ b/lib/lanttern_web/live/shared/menu_component.ex
@@ -60,11 +60,11 @@ defmodule LantternWeb.MenuComponent do
                 <.nav_item active={@active_nav == :student_report_card} path={~p"/student"}>
                   <%= gettext("Report cards") %>
                 </.nav_item>
-                <.nav_item active={@active_nav == :student_strands} path={~p"/student_strands"}>
+                <%!-- <.nav_item active={@active_nav == :student_strands} path={~p"/student_strands"}>
                   <%= gettext("Strands") %>
-                </.nav_item>
+                </.nav_item> --%>
                 <%!-- use this li as placeholder when nav items % 3 != 0 (sm) or nav items % 2 != 0 --%>
-                <%!-- <li class="bg-white"></li> --%>
+                <li class="bg-white"></li>
                 <li class="hidden lg:block bg-white"></li>
               <% end %>
 
@@ -72,11 +72,11 @@ defmodule LantternWeb.MenuComponent do
                 <.nav_item active={@active_nav == :student_report_card} path={~p"/guardian"}>
                   <%= gettext("Report cards") %>
                 </.nav_item>
-                <.nav_item active={@active_nav == :student_strands} path={~p"/student_strands"}>
+                <%!-- <.nav_item active={@active_nav == :student_strands} path={~p"/student_strands"}>
                   <%= gettext("Strands") %>
-                </.nav_item>
+                </.nav_item> --%>
                 <%!-- use this li as placeholder when nav items % 3 != 0 (sm) or nav items % 2 != 0 --%>
-                <%!-- <li class="bg-white"></li> --%>
+                <li class="bg-white"></li>
                 <li class="hidden lg:block bg-white"></li>
               <% end %>
             </ul>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2024.9.3-alpha.28",
+      version: "2024.9.4-alpha.28",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -102,7 +102,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:211
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:101
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:119
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:134
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:136
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:186
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:142
@@ -161,7 +161,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:214
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:104
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:122
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:137
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:139
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:189
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:145
@@ -388,7 +388,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:202
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:92
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:51
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:127
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:133
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:130
@@ -454,7 +454,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:200
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:90
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:54
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:60
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:125
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:131
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
@@ -763,7 +763,7 @@ msgstr ""
 msgid "to assess students"
 msgstr ""
 
-#: lib/lanttern/learning_context/strand.ex:95
+#: lib/lanttern/learning_context/strand.ex:97
 #, elixir-autogen, elixir-format
 msgid "Strand has linked assessment points."
 msgstr ""
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Save moment"
 msgstr ""
 
-#: lib/lanttern/learning_context.ex:531
+#: lib/lanttern/learning_context.ex:557
 #: lib/lanttern/repo_helpers.ex:122
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
@@ -887,7 +887,7 @@ msgstr ""
 msgid "Strand has linked moments and/or assessment points (goals). Deleting it would cause some data loss."
 msgstr ""
 
-#: lib/lanttern/learning_context/strand.ex:90
+#: lib/lanttern/learning_context/strand.ex:92
 #, elixir-autogen, elixir-format
 msgid "Strand has linked moments."
 msgstr ""
@@ -1091,7 +1091,7 @@ msgstr ""
 msgid "Curriculum items"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:108
+#: lib/lanttern_web/components/reporting_components.ex:111
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:39
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:34
@@ -1109,7 +1109,7 @@ msgstr ""
 msgid "Cycle already added to this grade report"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:306
+#: lib/lanttern_web/components/reporting_components.ex:309
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:353
@@ -1134,7 +1134,7 @@ msgstr ""
 msgid "E.g. project, unit, course, etc."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:105
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Edit card"
 msgstr ""
@@ -1156,7 +1156,7 @@ msgstr ""
 msgid "Edit grade report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:46
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:52
 #, elixir-autogen, elixir-format
 msgid "Edit report card"
 msgstr ""
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "Error deleting grade report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:77
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Error deleting report card"
 msgstr ""
@@ -1448,6 +1448,7 @@ msgid "No strands linked to this report yet"
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:420
+#: lib/lanttern_web/components/reporting_components.ex:424
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr ""
@@ -1517,7 +1518,7 @@ msgstr ""
 msgid "Report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:69
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Report card deleted"
 msgstr ""
@@ -2232,7 +2233,7 @@ msgstr ""
 msgid "Students report cards access updated"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:120
+#: lib/lanttern_web/components/reporting_components.ex:123
 #, elixir-autogen, elixir-format
 msgid "Under development"
 msgstr ""
@@ -2432,7 +2433,7 @@ msgstr ""
 msgid "Student self-assessment"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:36
+#: lib/lanttern_web/components/reporting_components.ex:39
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:224
 #: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:207
 #, elixir-autogen, elixir-format
@@ -2711,7 +2712,7 @@ msgstr ""
 msgid "No entry"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:40
+#: lib/lanttern_web/components/reporting_components.ex:43
 #: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:212
 #, elixir-autogen, elixir-format
 msgid "Student comment"
@@ -2770,4 +2771,29 @@ msgstr ""
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "Rubric differentiation"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex:39
+#, elixir-autogen, elixir-format
+msgid "Add students to report card to track entries"
+msgstr ""
+
+#: lib/lanttern_web/components/reporting_components.ex:386
+#, elixir-autogen, elixir-format
+msgid "No strands with moments assessment linked to this report card"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex:21
+#, elixir-autogen, elixir-format
+msgid "Students moments assessment tracking"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex:24
+#, elixir-autogen, elixir-format
+msgid "Track progress of all students linked in the students tab."
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:46
+#, elixir-autogen, elixir-format
+msgid "Tracking"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -102,7 +102,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:211
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:101
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:119
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:134
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:136
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:186
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:142
@@ -161,7 +161,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:214
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:104
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:122
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:137
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:139
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:189
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:145
@@ -388,7 +388,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:202
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:92
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:51
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:127
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:133
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:130
@@ -454,7 +454,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:200
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:90
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:54
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:60
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:125
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:131
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
@@ -763,7 +763,7 @@ msgstr ""
 msgid "to assess students"
 msgstr ""
 
-#: lib/lanttern/learning_context/strand.ex:95
+#: lib/lanttern/learning_context/strand.ex:97
 #, elixir-autogen, elixir-format
 msgid "Strand has linked assessment points."
 msgstr ""
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Save moment"
 msgstr ""
 
-#: lib/lanttern/learning_context.ex:531
+#: lib/lanttern/learning_context.ex:557
 #: lib/lanttern/repo_helpers.ex:122
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
@@ -887,7 +887,7 @@ msgstr ""
 msgid "Strand has linked moments and/or assessment points (goals). Deleting it would cause some data loss."
 msgstr ""
 
-#: lib/lanttern/learning_context/strand.ex:90
+#: lib/lanttern/learning_context/strand.ex:92
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strand has linked moments."
 msgstr ""
@@ -1091,7 +1091,7 @@ msgstr ""
 msgid "Curriculum items"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:108
+#: lib/lanttern_web/components/reporting_components.ex:111
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:39
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:34
@@ -1109,7 +1109,7 @@ msgstr ""
 msgid "Cycle already added to this grade report"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:306
+#: lib/lanttern_web/components/reporting_components.ex:309
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:353
@@ -1134,7 +1134,7 @@ msgstr ""
 msgid "E.g. project, unit, course, etc."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:105
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:120
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit card"
 msgstr ""
@@ -1156,7 +1156,7 @@ msgstr ""
 msgid "Edit grade report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:46
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:52
 #, elixir-autogen, elixir-format
 msgid "Edit report card"
 msgstr ""
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "Error deleting grade report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:77
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Error deleting report card"
 msgstr ""
@@ -1448,6 +1448,7 @@ msgid "No strands linked to this report yet"
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:420
+#: lib/lanttern_web/components/reporting_components.ex:424
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr ""
@@ -1517,7 +1518,7 @@ msgstr ""
 msgid "Report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:69
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Report card deleted"
 msgstr ""
@@ -2232,7 +2233,7 @@ msgstr ""
 msgid "Students report cards access updated"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:120
+#: lib/lanttern_web/components/reporting_components.ex:123
 #, elixir-autogen, elixir-format
 msgid "Under development"
 msgstr ""
@@ -2432,7 +2433,7 @@ msgstr ""
 msgid "Student self-assessment"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:36
+#: lib/lanttern_web/components/reporting_components.ex:39
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:224
 #: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:207
 #, elixir-autogen, elixir-format, fuzzy
@@ -2711,7 +2712,7 @@ msgstr ""
 msgid "No entry"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:40
+#: lib/lanttern_web/components/reporting_components.ex:43
 #: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student comment"
@@ -2770,4 +2771,29 @@ msgstr ""
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:61
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Rubric differentiation"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex:39
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Add students to report card to track entries"
+msgstr ""
+
+#: lib/lanttern_web/components/reporting_components.ex:386
+#, elixir-autogen, elixir-format
+msgid "No strands with moments assessment linked to this report card"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex:21
+#, elixir-autogen, elixir-format
+msgid "Students moments assessment tracking"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex:24
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Track progress of all students linked in the students tab."
+msgstr ""
+
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:46
+#, elixir-autogen, elixir-format
+msgid "Tracking"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -102,7 +102,7 @@ msgstr "Aplicando filtros..."
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:211
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:101
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:119
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:134
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:136
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:186
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:142
@@ -161,7 +161,7 @@ msgstr "Nenhuma trilha criadas para os anos e componentes selecionados"
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:214
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:104
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:122
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:137
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:139
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:189
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:145
@@ -388,7 +388,7 @@ msgstr "Não foi possível encontrar a trilha"
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:202
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:92
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:51
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:57
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:127
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:133
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:130
@@ -454,7 +454,7 @@ msgstr "Adicione suas anotações..."
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:200
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:90
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:54
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:60
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:125
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:131
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:128
@@ -763,7 +763,7 @@ msgstr "Este ponto de avaliação já possui alguns registros. Deletá-lo irá c
 msgid "to assess students"
 msgstr "para avaliar estudantes"
 
-#: lib/lanttern/learning_context/strand.ex:95
+#: lib/lanttern/learning_context/strand.ex:97
 #, elixir-autogen, elixir-format
 msgid "Strand has linked assessment points."
 msgstr "Trilha possui pontos de avaliação conectados."
@@ -862,7 +862,7 @@ msgstr "Nenhum momento para esta trilha ainda"
 msgid "Save moment"
 msgstr "Salvar momento"
 
-#: lib/lanttern/learning_context.ex:531
+#: lib/lanttern/learning_context.ex:557
 #: lib/lanttern/repo_helpers.ex:122
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:283
@@ -887,7 +887,7 @@ msgstr "Ordem dos Momentos da Trilha"
 msgid "Strand has linked moments and/or assessment points (goals). Deleting it would cause some data loss."
 msgstr "Trilha com momentos e/ou pontos de avaliação (objetivos) conectados. Deletá-la causaria perda de dados."
 
-#: lib/lanttern/learning_context/strand.ex:90
+#: lib/lanttern/learning_context/strand.ex:92
 #, elixir-autogen, elixir-format
 msgid "Strand has linked moments."
 msgstr "Trilha possui momentos conectados."
@@ -1091,7 +1091,7 @@ msgstr "Item curricular removido"
 msgid "Curriculum items"
 msgstr "Itens curriculares"
 
-#: lib/lanttern_web/components/reporting_components.ex:108
+#: lib/lanttern_web/components/reporting_components.ex:111
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:39
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:34
@@ -1109,7 +1109,7 @@ msgstr "Ciclo"
 msgid "Cycle already added to this grade report"
 msgstr "Ciclo já adicionado à este relatório de nota"
 
-#: lib/lanttern_web/components/reporting_components.ex:306
+#: lib/lanttern_web/components/reporting_components.ex:309
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:353
@@ -1134,7 +1134,7 @@ msgstr "Critério da rubrica de diferenciação"
 msgid "E.g. project, unit, course, etc."
 msgstr "Ex: projeto, unidade, curso, etc."
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:105
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "Edit card"
 msgstr "Editar card"
@@ -1156,7 +1156,7 @@ msgstr "Editar composição de nota"
 msgid "Edit grade report"
 msgstr "Editar relatório de nota"
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:46
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:52
 #, elixir-autogen, elixir-format
 msgid "Edit report card"
 msgstr "Editar report card"
@@ -1196,7 +1196,7 @@ msgstr "Erro ao deletar item curricular"
 msgid "Error deleting grade report"
 msgstr "Erro ao deletar relatório de nota"
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:77
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:79
 #, elixir-autogen, elixir-format
 msgid "Error deleting report card"
 msgstr "Erro ao deletar report card"
@@ -1448,6 +1448,7 @@ msgid "No strands linked to this report yet"
 msgstr "Nenhuma trilha vinculada a este relatório ainda"
 
 #: lib/lanttern_web/components/grades_reports_components.ex:420
+#: lib/lanttern_web/components/reporting_components.ex:424
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr "Nenhum estudante vinculado a este relatório de notas"
@@ -1517,7 +1518,7 @@ msgstr "Report Cards"
 msgid "Report card"
 msgstr "Report card"
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:69
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:71
 #, elixir-autogen, elixir-format
 msgid "Report card deleted"
 msgstr "Report card deletado"
@@ -2232,7 +2233,7 @@ msgstr "Acesso de estudantes"
 msgid "Students report cards access updated"
 msgstr "Report cards de estudante atualizados"
 
-#: lib/lanttern_web/components/reporting_components.ex:120
+#: lib/lanttern_web/components/reporting_components.ex:123
 #, elixir-autogen, elixir-format
 msgid "Under development"
 msgstr "Em desenvolvimento"
@@ -2432,7 +2433,7 @@ msgstr "Comentário de %{student}"
 msgid "Student self-assessment"
 msgstr "Autoavaliação do estudante"
 
-#: lib/lanttern_web/components/reporting_components.ex:36
+#: lib/lanttern_web/components/reporting_components.ex:39
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:224
 #: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:207
 #, elixir-autogen, elixir-format
@@ -2711,7 +2712,7 @@ msgstr "Aqui você irá encontrar informações sobre as avaliações final e fo
 msgid "No entry"
 msgstr "Sem registro"
 
-#: lib/lanttern_web/components/reporting_components.ex:40
+#: lib/lanttern_web/components/reporting_components.ex:43
 #: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:212
 #, elixir-autogen, elixir-format
 msgid "Student comment"
@@ -2771,3 +2772,28 @@ msgstr "Nenhum registro de avaliação para esta trilha ainda"
 #, elixir-autogen, elixir-format
 msgid "Rubric differentiation"
 msgstr "Rubrica de diferenciação"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex:39
+#, elixir-autogen, elixir-format
+msgid "Add students to report card to track entries"
+msgstr "Adicione estudantes ao report card para acompanhar os registros"
+
+#: lib/lanttern_web/components/reporting_components.ex:386
+#, elixir-autogen, elixir-format
+msgid "No strands with moments assessment linked to this report card"
+msgstr "Nenhuma trilha com avaliações nos momentos vinculada a este report card"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex:21
+#, elixir-autogen, elixir-format
+msgid "Students moments assessment tracking"
+msgstr "Acompanhamento de avaliações dos estudantes nos momentos"
+
+#: lib/lanttern_web/live/pages/report_cards/id/students_tracking_component.ex:24
+#, elixir-autogen, elixir-format
+msgid "Track progress of all students linked in the students tab."
+msgstr "Acompanhe o progresso de todos estudantes vinculados na aba estudantes."
+
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:46
+#, elixir-autogen, elixir-format
+msgid "Tracking"
+msgstr "Acompanhamento"

--- a/test/lanttern/learning_context_test.exs
+++ b/test/lanttern/learning_context_test.exs
@@ -8,6 +8,7 @@ defmodule Lanttern.LearningContextTest do
     alias Lanttern.LearningContext.Strand
 
     import Lanttern.TaxonomyFixtures
+    import Lanttern.AssessmentsFixtures
 
     @invalid_attrs %{name: nil, description: nil}
 
@@ -271,10 +272,27 @@ defmodule Lanttern.LearningContextTest do
       assert expected_strand_4.report_cycle == cycle_2023
     end
 
-    test "list_report_card_strands/1 returns all strands related to given report card" do
+    test "list_report_card_strands/1 returns all strands related to given report card with correct assessment points count" do
       strand_1 = strand_fixture()
       strand_2 = strand_fixture()
       strand_3 = strand_fixture()
+
+      # moments and assessment points fixture
+      # strand_1 = 3 moments, 1 assessment point each = 3 aps
+      # strand_2 = 1 moment, 2 assessment points = 2 aps
+      # strand_3 = 1 moment, no assessment points = 0 aps
+
+      m_1_1 = moment_fixture(%{strand_id: strand_1.id})
+      m_1_2 = moment_fixture(%{strand_id: strand_1.id})
+      m_1_3 = moment_fixture(%{strand_id: strand_1.id})
+      m_2_1 = moment_fixture(%{strand_id: strand_2.id})
+      _m_3_1 = moment_fixture(%{strand_id: strand_3.id})
+
+      _ap_1_1 = assessment_point_fixture(%{moment_id: m_1_1.id})
+      _ap_1_2 = assessment_point_fixture(%{moment_id: m_1_2.id})
+      _ap_1_3 = assessment_point_fixture(%{moment_id: m_1_3.id})
+      _ap_2_1_1 = assessment_point_fixture(%{moment_id: m_2_1.id})
+      _ap_2_1_2 = assessment_point_fixture(%{moment_id: m_2_1.id})
 
       report_card =
         Lanttern.ReportingFixtures.report_card_fixture()
@@ -315,8 +333,17 @@ defmodule Lanttern.LearningContextTest do
           strand_id: other_strand.id
         })
 
-      assert LearningContext.list_report_card_strands(report_card.id) ==
-               [strand_1, strand_2, strand_3]
+      assert [expected_strand_1, expected_strand_2, expected_strand_3] =
+               LearningContext.list_report_card_strands(report_card.id)
+
+      assert expected_strand_1.id == strand_1.id
+      assert expected_strand_1.assessment_points_count == 3
+
+      assert expected_strand_2.id == strand_2.id
+      assert expected_strand_2.assessment_points_count == 2
+
+      assert expected_strand_3.id == strand_3.id
+      assert expected_strand_3.assessment_points_count == 0
     end
 
     test "search_strands/2 returns all items matched by search" do

--- a/test/lanttern/learning_context_test.exs
+++ b/test/lanttern/learning_context_test.exs
@@ -271,6 +271,54 @@ defmodule Lanttern.LearningContextTest do
       assert expected_strand_4.report_cycle == cycle_2023
     end
 
+    test "list_report_card_strands/1 returns all strands related to given report card" do
+      strand_1 = strand_fixture()
+      strand_2 = strand_fixture()
+      strand_3 = strand_fixture()
+
+      report_card =
+        Lanttern.ReportingFixtures.report_card_fixture()
+
+      # create strand reports
+
+      _strand_report_1 =
+        Lanttern.ReportingFixtures.strand_report_fixture(%{
+          report_card_id: report_card.id,
+          strand_id: strand_1.id
+        })
+
+      _strand_report_2 =
+        Lanttern.ReportingFixtures.strand_report_fixture(%{
+          report_card_id: report_card.id,
+          strand_id: strand_2.id
+        })
+
+      _strand_report_3 =
+        Lanttern.ReportingFixtures.strand_report_fixture(%{
+          report_card_id: report_card.id,
+          strand_id: strand_3.id
+        })
+
+      # use same strand in different reports
+      _other_strand_3_report =
+        Lanttern.ReportingFixtures.strand_report_fixture(%{
+          strand_id: strand_3.id
+        })
+
+      # extra fixtures for filter testing
+      other_strand = strand_fixture()
+      other_report_card = Lanttern.ReportingFixtures.report_card_fixture()
+
+      _other_strand_report =
+        Lanttern.ReportingFixtures.strand_report_fixture(%{
+          report_card_id: other_report_card.id,
+          strand_id: other_strand.id
+        })
+
+      assert LearningContext.list_report_card_strands(report_card.id) ==
+               [strand_1, strand_2, strand_3]
+    end
+
     test "search_strands/2 returns all items matched by search" do
       _strand_1 = strand_fixture(%{name: "lorem ipsum xolor sit amet"})
       strand_2 = strand_fixture(%{name: "lorem ipsum dolor sit amet"})

--- a/test/lanttern/reporting_test.exs
+++ b/test/lanttern/reporting_test.exs
@@ -1178,6 +1178,276 @@ defmodule Lanttern.ReportingTest do
     end
   end
 
+  describe "report card students assessments tracking" do
+    import Lanttern.ReportingFixtures
+
+    alias Lanttern.AssessmentsFixtures
+    alias Lanttern.CurriculaFixtures
+    alias Lanttern.GradingFixtures
+    alias Lanttern.LearningContextFixtures
+    alias Lanttern.SchoolsFixtures
+    alias Lanttern.TaxonomyFixtures
+
+    test "build_students_moments_entries_map_for_report_card/2 returns the map of students with strands and entries correctly" do
+      # expected grid for this test case:
+
+      # students  |      strand 1      | st 2 |  strand 3   |
+      # -----------------------------------------------------
+      # student A | m1_1 | m1_2 | nil  | m1_1 | nil  | m2_1 |
+      # student B | nil  | m1_2 | m2_1 | nil  | nil  | nil  |
+      # student C | m1_1 | m1_2 | m2_1 | m1_1 | m1_1 | nil  |
+
+      student_a = SchoolsFixtures.student_fixture()
+      student_b = SchoolsFixtures.student_fixture()
+      student_c = SchoolsFixtures.student_fixture()
+
+      # strands and moments fixtures
+
+      strand_1 = LearningContextFixtures.strand_fixture()
+      moment_1_1 = LearningContextFixtures.moment_fixture(%{strand_id: strand_1.id})
+      moment_1_2 = LearningContextFixtures.moment_fixture(%{strand_id: strand_1.id})
+
+      strand_2 = LearningContextFixtures.strand_fixture()
+      moment_2_1 = LearningContextFixtures.moment_fixture(%{strand_id: strand_2.id})
+
+      strand_3 = LearningContextFixtures.strand_fixture()
+      moment_3_1 = LearningContextFixtures.moment_fixture(%{strand_id: strand_3.id})
+      moment_3_2 = LearningContextFixtures.moment_fixture(%{strand_id: strand_3.id})
+
+      # assessments fixtures
+
+      scale = GradingFixtures.scale_fixture(%{type: "numeric"})
+
+      ap_1_1_1 =
+        AssessmentsFixtures.assessment_point_fixture(%{
+          moment_id: moment_1_1.id,
+          scale_id: scale.id
+        })
+
+      ap_1_1_2 =
+        AssessmentsFixtures.assessment_point_fixture(%{
+          moment_id: moment_1_1.id,
+          scale_id: scale.id
+        })
+
+      ap_1_2_1 =
+        AssessmentsFixtures.assessment_point_fixture(%{
+          moment_id: moment_1_2.id,
+          scale_id: scale.id
+        })
+
+      ap_2_1_1 =
+        AssessmentsFixtures.assessment_point_fixture(%{
+          moment_id: moment_2_1.id,
+          scale_id: scale.id
+        })
+
+      ap_3_1_1 =
+        AssessmentsFixtures.assessment_point_fixture(%{
+          moment_id: moment_3_1.id,
+          scale_id: scale.id
+        })
+
+      ap_3_2_1 =
+        AssessmentsFixtures.assessment_point_fixture(%{
+          moment_id: moment_3_2.id,
+          scale_id: scale.id
+        })
+
+      entry_std_a_ap_1_1_1 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_a.id,
+          assessment_point_id: ap_1_1_1.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      entry_std_a_ap_1_1_2 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_a.id,
+          assessment_point_id: ap_1_1_2.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      entry_std_a_ap_2_1_1 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_a.id,
+          assessment_point_id: ap_2_1_1.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      entry_std_a_ap_3_2_1 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_a.id,
+          assessment_point_id: ap_3_2_1.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      entry_std_b_ap_1_1_2 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_b.id,
+          assessment_point_id: ap_1_1_2.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      entry_std_b_ap_1_2_1 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_b.id,
+          assessment_point_id: ap_1_2_1.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      entry_std_c_ap_1_1_1 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_c.id,
+          assessment_point_id: ap_1_1_1.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      entry_std_c_ap_1_1_2 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_c.id,
+          assessment_point_id: ap_1_1_2.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      entry_std_c_ap_1_2_1 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_c.id,
+          assessment_point_id: ap_1_2_1.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      entry_std_c_ap_2_1_1 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_c.id,
+          assessment_point_id: ap_2_1_1.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      entry_std_c_ap_3_1_1 =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          student_id: student_c.id,
+          assessment_point_id: ap_3_1_1.id,
+          scale_id: scale.id,
+          scale_type: "numeric"
+        })
+
+      # report fixtures
+
+      report_card = report_card_fixture()
+
+      _strand_1_report =
+        strand_report_fixture(%{
+          report_card_id: report_card.id,
+          strand_id: strand_1.id
+        })
+
+      _strand_2_report =
+        strand_report_fixture(%{
+          report_card_id: report_card.id,
+          strand_id: strand_2.id
+        })
+
+      _strand_3_report =
+        strand_report_fixture(%{
+          report_card_id: report_card.id,
+          strand_id: strand_3.id
+        })
+
+      _student_a_report_card =
+        student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_a.id})
+
+      _student_b_report_card =
+        student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_b.id})
+
+      _student_c_report_card =
+        student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_c.id})
+
+      expected =
+        Reporting.build_students_moments_entries_map_for_report_card(report_card.id, [
+          student_a.id,
+          student_b.id,
+          student_c.id
+        ])
+
+      # ids for pattern match
+      moment_1_1_id = moment_1_1.id
+      moment_1_2_id = moment_1_2.id
+      moment_2_1_id = moment_2_1.id
+      moment_3_1_id = moment_3_1.id
+      moment_3_2_id = moment_3_2.id
+      ap_1_1_1_id = ap_1_1_1.id
+      ap_1_1_2_id = ap_1_1_2.id
+      ap_1_2_1_id = ap_1_2_1.id
+      ap_2_1_1_id = ap_2_1_1.id
+      ap_3_1_1_id = ap_3_1_1.id
+      ap_3_2_1_id = ap_3_2_1.id
+
+      # assertions
+
+      expected_std_a_strands_map = expected[student_a.id]
+
+      assert [
+               {^moment_1_1_id, ^ap_1_1_1_id, ^entry_std_a_ap_1_1_1},
+               {^moment_1_1_id, ^ap_1_1_2_id, ^entry_std_a_ap_1_1_2},
+               {^moment_1_2_id, ^ap_1_2_1_id, nil}
+             ] = expected_std_a_strands_map[strand_1.id]
+
+      assert [
+               {^moment_2_1_id, ^ap_2_1_1_id, ^entry_std_a_ap_2_1_1}
+             ] = expected_std_a_strands_map[strand_2.id]
+
+      assert [
+               {^moment_3_1_id, ^ap_3_1_1_id, nil},
+               {^moment_3_2_id, ^ap_3_2_1_id, ^entry_std_a_ap_3_2_1}
+             ] = expected_std_a_strands_map[strand_3.id]
+
+      expected_std_b_strands_map = expected[student_b.id]
+
+      assert [
+               {^moment_1_1_id, ^ap_1_1_1_id, nil},
+               {^moment_1_1_id, ^ap_1_1_2_id, ^entry_std_b_ap_1_1_2},
+               {^moment_1_2_id, ^ap_1_2_1_id, ^entry_std_b_ap_1_2_1}
+             ] = expected_std_b_strands_map[strand_1.id]
+
+      assert [
+               {^moment_2_1_id, ^ap_2_1_1_id, nil}
+             ] = expected_std_b_strands_map[strand_2.id]
+
+      assert [
+               {^moment_3_1_id, ^ap_3_1_1_id, nil},
+               {^moment_3_2_id, ^ap_3_2_1_id, nil}
+             ] = expected_std_b_strands_map[strand_3.id]
+
+      expected_std_c_strands_map = expected[student_c.id]
+
+      assert [
+               {^moment_1_1_id, ^ap_1_1_1_id, ^entry_std_c_ap_1_1_1},
+               {^moment_1_1_id, ^ap_1_1_2_id, ^entry_std_c_ap_1_1_2},
+               {^moment_1_2_id, ^ap_1_2_1_id, ^entry_std_c_ap_1_2_1}
+             ] = expected_std_c_strands_map[strand_1.id]
+
+      assert [
+               {^moment_2_1_id, ^ap_2_1_1_id, ^entry_std_c_ap_2_1_1}
+             ] = expected_std_c_strands_map[strand_2.id]
+
+      assert [
+               {^moment_3_1_id, ^ap_3_1_1_id, ^entry_std_c_ap_3_1_1},
+               {^moment_3_2_id, ^ap_3_2_1_id, nil}
+             ] = expected_std_c_strands_map[strand_3.id]
+    end
+  end
+
   describe "extra" do
     import Lanttern.ReportingFixtures
     alias Lanttern.AssessmentsFixtures


### PR DESCRIPTION
this PR adds a "Tracking" tab in report card page, which allows teachers to visualize all the students moments assessments linked to the report card in a single view.

resolves #204 