### PR TITLE
fix: report card assessment tracking breaking when there's student self-assessment without teacher assessment

### DIFF
--- a/lib/lanttern_web/live/shared/assessments/entry_particle_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_particle_component.ex
@@ -94,26 +94,7 @@ defmodule LantternWeb.Assessments.EntryParticleComponent do
       end
 
     {additional_classes, style, particle_text, full_text} =
-      case ordinal_value_or_score do
-        %OrdinalValue{} = ordinal_value ->
-          style =
-            "color: #{ordinal_value.text_color}; background-color: #{ordinal_value.bg_color}"
-
-          {nil, style, String.first(ordinal_value.name), ordinal_value.name}
-
-        score when is_float(score) ->
-          {"text-ltrn-dark bg-ltrn-lighter", nil, "•", score}
-
-        _ ->
-          full_text =
-            case {assigns.entry, is_student} do
-              {%AssessmentPointEntry{}, true} -> gettext("No student self-assessment")
-              {%AssessmentPointEntry{}, _} -> gettext("No teacher assessment")
-              _ -> gettext("No entry")
-            end
-
-          {"border border-dashed border-ltrn-light text-ltrn-light", nil, "-", full_text}
-      end
+      get_particle_styles_and_text(ordinal_value_or_score, assigns.entry, is_student)
 
     socket
     |> assign(assigns)
@@ -121,5 +102,26 @@ defmodule LantternWeb.Assessments.EntryParticleComponent do
     |> assign(:style, style)
     |> assign(:particle_text, particle_text)
     |> assign(:full_text, full_text)
+  end
+
+  defp get_particle_styles_and_text(%OrdinalValue{} = ordinal_value, _, _) do
+    style =
+      "color: #{ordinal_value.text_color}; background-color: #{ordinal_value.bg_color}"
+
+    {nil, style, String.first(ordinal_value.name), ordinal_value.name}
+  end
+
+  defp get_particle_styles_and_text(score, _, _) when is_float(score),
+    do: {"text-ltrn-dark bg-ltrn-lighter", nil, "•", score}
+
+  defp get_particle_styles_and_text(_, entry, is_student) do
+    full_text =
+      case {entry, is_student} do
+        {%AssessmentPointEntry{}, true} -> gettext("No student self-assessment")
+        {%AssessmentPointEntry{}, _} -> gettext("No teacher assessment")
+        _ -> gettext("No entry")
+      end
+
+    {"border border-dashed border-ltrn-light text-ltrn-light", nil, "-", full_text}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2024.9.4-alpha.30",
+      version: "2024.9.9-alpha.31",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -50,8 +50,6 @@ msgstr ""
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
 #: lib/lanttern_web/live/shared/menu_component.ex:37
-#: lib/lanttern_web/live/shared/menu_component.ex:64
-#: lib/lanttern_web/live/shared/menu_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr ""
@@ -1448,7 +1446,7 @@ msgid "No strands linked to this report yet"
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:420
-#: lib/lanttern_web/components/reporting_components.ex:424
+#: lib/lanttern_web/components/reporting_components.ex:427
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr ""
@@ -2708,6 +2706,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/assessments_components.ex:67
 #: lib/lanttern_web/components/assessments_components.ex:206
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "No entry"
 msgstr ""
@@ -2796,4 +2795,14 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Tracking"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:120
+#, elixir-autogen, elixir-format
+msgid "No student self-assessment"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:121
+#, elixir-autogen, elixir-format
+msgid "No teacher assessment"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -50,8 +50,6 @@ msgstr ""
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
 #: lib/lanttern_web/live/shared/menu_component.ex:37
-#: lib/lanttern_web/live/shared/menu_component.ex:64
-#: lib/lanttern_web/live/shared/menu_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr ""
@@ -1448,7 +1446,7 @@ msgid "No strands linked to this report yet"
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:420
-#: lib/lanttern_web/components/reporting_components.ex:424
+#: lib/lanttern_web/components/reporting_components.ex:427
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr ""
@@ -2708,6 +2706,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/assessments_components.ex:67
 #: lib/lanttern_web/components/assessments_components.ex:206
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "No entry"
 msgstr ""
@@ -2796,4 +2795,14 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:46
 #, elixir-autogen, elixir-format
 msgid "Tracking"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:120
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No student self-assessment"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:121
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No teacher assessment"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -50,8 +50,6 @@ msgstr "Escola"
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
 #: lib/lanttern_web/live/shared/menu_component.ex:37
-#: lib/lanttern_web/live/shared/menu_component.ex:64
-#: lib/lanttern_web/live/shared/menu_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr "Trilhas"
@@ -1448,7 +1446,7 @@ msgid "No strands linked to this report yet"
 msgstr "Nenhuma trilha vinculada a este relatório ainda"
 
 #: lib/lanttern_web/components/grades_reports_components.ex:420
-#: lib/lanttern_web/components/reporting_components.ex:424
+#: lib/lanttern_web/components/reporting_components.ex:427
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr "Nenhum estudante vinculado a este relatório de notas"
@@ -2708,6 +2706,7 @@ msgstr "Aqui você irá encontrar informações sobre as avaliações final e fo
 
 #: lib/lanttern_web/components/assessments_components.ex:67
 #: lib/lanttern_web/components/assessments_components.ex:206
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "No entry"
 msgstr "Sem registro"
@@ -2797,3 +2796,13 @@ msgstr "Acompanhe o progresso de todos estudantes vinculados na aba estudantes."
 #, elixir-autogen, elixir-format
 msgid "Tracking"
 msgstr "Acompanhamento"
+
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:120
+#, elixir-autogen, elixir-format
+msgid "No student self-assessment"
+msgstr "Sem autoavaliação do estudante"
+
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:121
+#, elixir-autogen, elixir-format
+msgid "No teacher assessment"
+msgstr "Sem avaliação do professor"


### PR DESCRIPTION
we implemented some minor adjustments to `Assessments.EntryParticleComponent`:

- "official" support to students self-assessment display — which also fixes #209
- changes in UI, rendering the first letter of the ordinal value name and adding a title attr with the full ordinal value name or score or a contextualized message when there's no entry to display

