### PR TITLE
display entry evidences in strand reports

### DIFF
--- a/lib/lanttern/assessments/assessment_point_entry.ex
+++ b/lib/lanttern/assessments/assessment_point_entry.ex
@@ -26,6 +26,7 @@ defmodule Lanttern.Assessments.AssessmentPointEntry do
   alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.Assessments.AssessmentPointEntryEvidence
   alias Lanttern.Assessments.Feedback
+  alias Lanttern.Attachments.Attachment
   alias Lanttern.Schools.Student
   alias Lanttern.Grading.Scale
   alias Lanttern.Grading.OrdinalValue
@@ -54,6 +55,7 @@ defmodule Lanttern.Assessments.AssessmentPointEntry do
           differentiation_rubric: Rubric.t() | nil,
           differentiation_rubric_id: pos_integer() | nil,
           assessment_point_entry_evidences: [AssessmentPointEntryEvidence.t()],
+          evidences: [Attachment.t()],
           feedback: Feedback.t() | nil,
           inserted_at: DateTime.t(),
           updated_at: DateTime.t()
@@ -82,6 +84,7 @@ defmodule Lanttern.Assessments.AssessmentPointEntry do
     belongs_to :differentiation_rubric, Rubric
 
     has_many :assessment_point_entry_evidences, AssessmentPointEntryEvidence
+    has_many :evidences, through: [:assessment_point_entry_evidences, :attachment]
 
     # warning: don't use `Repo.preload/3` with this association.
     # we can get this in query, usign assessment_point_id and student_id

--- a/lib/lanttern_web/components/attachments_components.ex
+++ b/lib/lanttern_web/components/attachments_components.ex
@@ -9,6 +9,36 @@ defmodule LantternWeb.AttachmentsComponents do
   import LantternWeb.CoreComponents
   import LantternWeb.OverlayComponents
 
+  alias Lanttern.Attachments.Attachment
+
+  @doc """
+  Renders an attachment card.
+  """
+  attr :attachment, Attachment, required: true
+  attr :id, :string, default: nil
+  attr :class, :any, default: nil
+  slot :inner_block
+
+  def attachment_card(assigns) do
+    ~H"""
+    <.card_base id={@id} class={["p-6", @class]}>
+      <%= if(@attachment.is_external) do %>
+        <.badge><%= gettext("External link") %></.badge>
+      <% else %>
+        <.badge theme="cyan"><%= gettext("Upload") %></.badge>
+      <% end %>
+      <a
+        href={@attachment.link}
+        target="_blank"
+        class="block mt-2 text-sm underline hover:text-ltrn-subtle"
+      >
+        <%= @attachment.name %>
+      </a>
+      <%= render_slot(@inner_block) %>
+    </.card_base>
+    """
+  end
+
   @doc """
   Renders an assessment point entry badge.
   """

--- a/lib/lanttern_web/components/attachments_components.ex
+++ b/lib/lanttern_web/components/attachments_components.ex
@@ -1,0 +1,126 @@
+defmodule LantternWeb.AttachmentsComponents do
+  @moduledoc """
+  Shared function components related to `Attachments` context
+  """
+
+  use Phoenix.Component
+
+  import LantternWeb.Gettext
+  import LantternWeb.CoreComponents
+  import LantternWeb.OverlayComponents
+
+  @doc """
+  Renders an assessment point entry badge.
+  """
+  attr :attachments, :any, required: true, doc: "list or stream of attachments."
+  attr :allow_editing, :boolean, default: false
+  attr :attachments_length, :integer, default: nil, doc: "required when edit is allowed"
+  attr :on_move_up, :any, default: nil, doc: "function. required when edit is allowed"
+  attr :on_move_down, :any, default: nil, doc: "function. required when edit is allowed"
+  attr :on_edit, :any, default: nil, doc: "function. required when edit is allowed"
+  attr :on_remove, :any, default: nil, doc: "function. required when edit is allowed"
+  attr :id, :string, default: nil
+  attr :class, :any, default: nil
+
+  def attachments_list(assigns) do
+    attachments = normalize_attachments(assigns)
+    assigns = assign(assigns, :attachments, attachments)
+
+    ~H"""
+    <ul id={@id} phx-update="stream" class={@class}>
+      <li
+        :for={{dom_id, {attachment, i}} <- @attachments}
+        id={dom_id}
+        class="flex items-center gap-4 mt-4"
+      >
+        <%= if @allow_editing do %>
+          <.sortable_card
+            is_move_up_disabled={i == 0}
+            on_move_up={@on_move_up.(i)}
+            is_move_down_disabled={i + 1 == @attachments_length}
+            on_move_down={@on_move_down.(i)}
+            class="flex-1 min-w-0"
+          >
+            <div class="flex items-center gap-4">
+              <button
+                type="button"
+                phx-hook="CopyToClipboard"
+                data-clipboard-text={"[#{attachment.name}](#{attachment.link})"}
+                id={"clipboard-#{dom_id}"}
+                class={[
+                  "group relative shrink-0 p-1 rounded-full text-ltrn-subtle hover:bg-ltrn-lighter",
+                  "[&.copied-to-clipboard]:text-ltrn-primary [&.copied-to-clipboard]:bg-ltrn-mesh-cyan"
+                ]}
+              >
+                <.icon
+                  name="hero-square-2-stack"
+                  class="block group-[.copied-to-clipboard]:hidden w-6 h-6"
+                />
+                <.icon name="hero-check hidden group-[.copied-to-clipboard]:block" class="w-6 h-6" />
+                <.tooltip><%= gettext("Copy attachment link markdown") %></.tooltip>
+              </button>
+              <div class="flex-1 min-w-o">
+                <%= if(attachment.is_external) do %>
+                  <.badge><%= gettext("External link") %></.badge>
+                <% else %>
+                  <.badge theme="cyan"><%= gettext("Upload") %></.badge>
+                <% end %>
+                <a
+                  href={attachment.link}
+                  target="_blank"
+                  class="block mt-2 text-sm underline hover:text-ltrn-subtle"
+                >
+                  <%= attachment.name %>
+                </a>
+              </div>
+            </div>
+          </.sortable_card>
+          <.menu_button id={attachment.id}>
+            <:item
+              :if={attachment.is_external}
+              id={"edit-attachment-#{attachment.id}"}
+              text={gettext("Edit")}
+              on_click={@on_edit.(attachment.id)}
+            />
+            <:item
+              id={"remove-attachment-#{attachment.id}"}
+              text={gettext("Remove")}
+              on_click={@on_remove.(attachment.id)}
+              theme="alert"
+              confirm_msg={gettext("Are you sure? This action cannot be undone.")}
+            />
+          </.menu_button>
+        <% else %>
+          <div class="flex-1 min-w-0 p-4 rounded bg-white shadow-lg">
+            <%= if(attachment.is_external) do %>
+              <.badge><%= gettext("External link") %></.badge>
+            <% else %>
+              <.badge theme="cyan"><%= gettext("Upload") %></.badge>
+            <% end %>
+            <a
+              href={attachment.link}
+              target="_blank"
+              class="block mt-2 text-sm underline hover:text-ltrn-subtle"
+            >
+              <%= attachment.name %>
+            </a>
+          </div>
+        <% end %>
+      </li>
+    </ul>
+    """
+  end
+
+  # normalize all attachments to indexed LiveStream format {dom_id, {attachment, index}}
+
+  defp normalize_attachments(%{attachments: %Phoenix.LiveView.LiveStream{} = attachments}),
+    do: attachments
+
+  defp normalize_attachments(%{attachments: attachments, id: component_id}) do
+    attachments
+    |> Enum.with_index()
+    |> Enum.map(fn {attachment, i} ->
+      {"#{component_id}-attachment-#{attachment.id}", {attachment, i}}
+    end)
+  end
+end

--- a/lib/lanttern_web/components/reporting_components.ex
+++ b/lib/lanttern_web/components/reporting_components.ex
@@ -9,6 +9,7 @@ defmodule LantternWeb.ReportingComponents do
   import LantternWeb.CoreComponents
 
   import LantternWeb.AssessmentsComponents
+  import LantternWeb.AttachmentsComponents
   import LantternWeb.GradingComponents
   import Lanttern.SupabaseHelpers, only: [object_url_to_render_url: 2]
 
@@ -323,6 +324,11 @@ defmodule LantternWeb.ReportingComponents do
         <.assessment_point_entry_badge entry={@entry} class="shrink-0" />
       </div>
       <.comment_area :if={@entry && @entry.report_note} comment={@entry.report_note} class="mt-2" />
+      <.attachments_list
+        :if={@entry && is_list(@entry.evidences) && @entry.evidences != []}
+        attachments={@entry.evidences}
+        class="mt-2"
+      />
     </div>
     """
   end

--- a/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
@@ -608,6 +608,12 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
     {:ok, socket}
   end
 
+  def update(
+        %{action: {EntryDetailsComponent, _}},
+        socket
+      ),
+      do: {:ok, socket}
+
   def update(assigns, socket) do
     socket =
       socket

--- a/lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex
@@ -18,6 +18,7 @@ defmodule LantternWeb.Assessments.StrandGoalDetailsOverlayComponent do
 
   # shared components
   import LantternWeb.AssessmentsComponents
+  import LantternWeb.AttachmentsComponents
   import LantternWeb.ReportingComponents
 
   @impl true
@@ -75,6 +76,13 @@ defmodule LantternWeb.Assessments.StrandGoalDetailsOverlayComponent do
             rubric={@rubric}
             entry={!@prevent_preview && @entry}
           />
+        </div>
+        <div :if={@entry && @entry.evidences != []} class="mt-10">
+          <h5 class="flex items-center gap-2 font-display font-black text-base">
+            <.icon name="hero-paper-clip" class="w-6 h-6" />
+            <%= gettext("Learning evidences") %>
+          </h5>
+          <.attachments_list id="goals-attachments-list" attachments={@entry.evidences} />
         </div>
         <div :if={@has_formative_assessment} class="mt-10">
           <h5 class="font-display font-black text-base"><%= gettext("Formative assessment") %></h5>
@@ -161,7 +169,7 @@ defmodule LantternWeb.Assessments.StrandGoalDetailsOverlayComponent do
       Assessments.get_assessment_point_student_entry(
         socket.assigns.strand_goal.id,
         socket.assigns.student_id,
-        preloads: [:scale, :ordinal_value, :student_ordinal_value]
+        preloads: [:scale, :ordinal_value, :student_ordinal_value, :evidences]
       )
 
     assign(socket, :entry, entry)

--- a/lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex
+++ b/lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex
@@ -61,7 +61,7 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
           <div class="flex items-center gap-2">
             <.icon name="hero-paper-clip" class="w-6 h-6" />
             <h4 class="font-display font-black">
-              <%= gettext("All strands evidences") %>
+              <%= gettext("All strand evidences") %>
             </h4>
           </div>
           <div id="strand-evidences" phx-update="stream">
@@ -73,7 +73,7 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
             >
               <p class="mt-4 text-xs">
                 <%= if moment_name do
-                  "#{gettext("In the context of")} #{moment_name}."
+                  "#{gettext("In the context of")} \"#{moment_name}\"."
                 end %>
                 <.link
                   patch={"#{@base_path}&strand_goal_id=#{goal_id}"}

--- a/lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex
+++ b/lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex
@@ -38,11 +38,12 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
           <%= gettext("You can click the assessment card to view more details about it.") %>
         </p>
         <.goal_card
-          :for={{goal, entry, moment_entries, _} <- @strand_goals_student_entries}
+          :for={{goal, entry, moment_entries, has_evidence} <- @strand_goals_student_entries}
           patch={"#{@base_path}&strand_goal_id=#{goal.id}"}
           goal={goal}
           entry={entry}
           moment_entries={moment_entries}
+          has_evidence={has_evidence}
           prevent_preview={@prevent_final_assessment_preview}
         />
         <.empty_state :if={!@has_strand_goals_with_student_entries}>
@@ -61,11 +62,14 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
           </div>
           <div id="strand-goals-without-student-entries" class="hidden">
             <.goal_card
-              :for={{goal, entry, moment_entries, _} <- @strand_goals_without_student_entries}
+              :for={
+                {goal, entry, moment_entries, has_evidence} <- @strand_goals_without_student_entries
+              }
               patch={"#{@base_path}&strand_goal_id=#{goal.id}"}
               goal={goal}
               entry={entry}
               moment_entries={moment_entries}
+              has_evidence={has_evidence}
               prevent_preview={@prevent_final_assessment_preview}
             />
           </div>
@@ -87,6 +91,7 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
   attr :goal, AssessmentPoint, required: true
   attr :entry, :any, required: true
   attr :moment_entries, :list, required: true
+  attr :has_evidence, :boolean, required: true
   attr :patch, :string, required: true
   attr :prevent_preview, :boolean, required: true
 
@@ -94,14 +99,15 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
     %{
       goal: goal,
       entry: entry,
-      moment_entries: moment_entries
+      moment_entries: moment_entries,
+      has_evidence: has_evidence
     } = assigns
 
     render_icons_area =
       goal.is_differentiation ||
         (entry && entry.report_note) ||
         (entry && entry.student_report_note) ||
-        (entry && entry.has_evidences) ||
+        has_evidence ||
         goal.report_info ||
         goal.rubric_id
 
@@ -147,7 +153,7 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
                 :if={@entry && @entry.student_report_note}
                 type={:student_comment}
               />
-              <.assessment_metadata_icon :if={@entry && @entry.has_evidences} type={:evidences} />
+              <.assessment_metadata_icon :if={@has_evidence} type={:evidences} />
               <.assessment_metadata_icon :if={@goal.report_info} type={:info} />
               <.assessment_metadata_icon :if={@goal.rubric_id} type={:rubric} />
             </div>

--- a/lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex
+++ b/lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex
@@ -38,7 +38,7 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
           <%= gettext("You can click the assessment card to view more details about it.") %>
         </p>
         <.goal_card
-          :for={{goal, entry, moment_entries} <- @strand_goals_student_entries}
+          :for={{goal, entry, moment_entries, _} <- @strand_goals_student_entries}
           patch={"#{@base_path}&strand_goal_id=#{goal.id}"}
           goal={goal}
           entry={entry}
@@ -61,7 +61,7 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
           </div>
           <div id="strand-goals-without-student-entries" class="hidden">
             <.goal_card
-              :for={{goal, entry, moment_entries} <- @strand_goals_without_student_entries}
+              :for={{goal, entry, moment_entries, _} <- @strand_goals_without_student_entries}
               patch={"#{@base_path}&strand_goal_id=#{goal.id}"}
               goal={goal}
               entry={entry}
@@ -101,6 +101,7 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
       goal.is_differentiation ||
         (entry && entry.report_note) ||
         (entry && entry.student_report_note) ||
+        (entry && entry.has_evidences) ||
         goal.report_info ||
         goal.rubric_id
 
@@ -146,6 +147,7 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
                 :if={@entry && @entry.student_report_note}
                 type={:student_comment}
               />
+              <.assessment_metadata_icon :if={@entry && @entry.has_evidences} type={:evidences} />
               <.assessment_metadata_icon :if={@goal.report_info} type={:info} />
               <.assessment_metadata_icon :if={@goal.rubric_id} type={:rubric} />
             </div>
@@ -212,6 +214,11 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
       {gettext("Student comment"), "hero-chat-bubble-oval-left-mini", "bg-ltrn-student-lighter",
        "text-ltrn-student-accent"}
 
+  defp assessment_metadata_icon_attrs(:evidences),
+    do:
+      {gettext("With learning evidences"), "hero-paper-clip-mini", "bg-ltrn-lighter",
+       "text-ltrn-subtle"}
+
   defp assessment_metadata_icon_attrs(:info),
     do:
       {gettext("Assessment info"), "hero-information-circle-mini", "bg-ltrn-lighter",
@@ -255,17 +262,19 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
 
     strand_goals_ids =
       all_strand_goals_student_entries
-      |> Enum.map(fn {strand_goal, _, _} -> "#{strand_goal.id}" end)
+      |> Enum.map(fn {strand_goal, _, _, _} -> "#{strand_goal.id}" end)
 
     strand_goals_student_entries =
       all_strand_goals_student_entries
-      |> Enum.filter(fn {_, entry, moments_entries} ->
+      |> Enum.filter(fn {_, entry, moments_entries, _} ->
         not is_nil(entry) or moments_entries != []
       end)
 
     strand_goals_without_student_entries =
       all_strand_goals_student_entries
-      |> Enum.filter(fn {_, entry, moments_entries} -> is_nil(entry) and moments_entries == [] end)
+      |> Enum.filter(fn {_, entry, moments_entries, _} ->
+        is_nil(entry) and moments_entries == []
+      end)
 
     socket
     |> assign(:strand_goals_student_entries, strand_goals_student_entries)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2024.9.26-alpha.34",
+      version: "2024.10.3-alpha.35",
       elixir: "~> 1.15",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -119,8 +119,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:91
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:94
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:269
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:151
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:184
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:93
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:126
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:54
@@ -178,7 +178,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:94
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:172
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:69
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:154
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:96
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:56
 #, elixir-autogen, elixir-format
@@ -266,7 +266,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:200
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:130
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:153
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:95
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:73
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:81
@@ -312,7 +312,7 @@ msgid "cancel"
 msgstr ""
 
 #: lib/lanttern_web/components/form_components.ex:608
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:221
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:163
 #, elixir-autogen, elixir-format
 msgid "or drag and drop here"
 msgstr ""
@@ -486,8 +486,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:74
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:84
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:28
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:65
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:181
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:66
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:229
 #, elixir-autogen, elixir-format
 msgid "Differentiation"
 msgstr ""
@@ -497,6 +497,7 @@ msgstr ""
 msgid "Differentiation for %{name}"
 msgstr ""
 
+#: lib/lanttern_web/components/attachments_components.ex:112
 #: lib/lanttern_web/components/learning_context_components.ex:55
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:326
@@ -504,7 +505,6 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:227
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:65
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:258
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:95
 #: lib/lanttern_web/live/shared/notes/note_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -1075,7 +1075,7 @@ msgstr ""
 msgid "Curriculum components"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:39
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:40
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "Curriculum differentiation"
@@ -1091,7 +1091,7 @@ msgstr ""
 msgid "Curriculum items"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:122
+#: lib/lanttern_web/components/reporting_components.ex:123
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:39
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:34
@@ -1109,7 +1109,7 @@ msgstr ""
 msgid "Cycle already added to this grade report"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:320
+#: lib/lanttern_web/components/reporting_components.ex:321
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:353
@@ -1449,7 +1449,7 @@ msgid "No strands linked to this report yet"
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:424
-#: lib/lanttern_web/components/reporting_components.ex:438
+#: lib/lanttern_web/components/reporting_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr ""
@@ -1498,7 +1498,7 @@ msgstr ""
 msgid "Recalculate grade"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:100
+#: lib/lanttern_web/components/attachments_components.ex:117
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
 msgid "Remove"
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "You must log in to access this page."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:104
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:112
 #, elixir-autogen, elixir-format
 msgid "About this assessment"
 msgstr ""
@@ -2167,7 +2167,7 @@ msgid "Has footnote"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:427
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:145
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:87
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgstr ""
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "Students report cards access updated"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:134
+#: lib/lanttern_web/components/reporting_components.ex:135
 #, elixir-autogen, elixir-format
 msgid "Under development"
 msgstr ""
@@ -2324,33 +2324,34 @@ msgstr ""
 msgid "updated"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:235
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "(e.g. Google Docs)"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:103
+#: lib/lanttern_web/components/attachments_components.ex:120
 #, elixir-autogen, elixir-format
 msgid "Are you sure? This action cannot be undone."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:138
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:80
 #, elixir-autogen, elixir-format
 msgid "Attachment name"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:73
+#: lib/lanttern_web/components/attachments_components.ex:90
 #, elixir-autogen, elixir-format
 msgid "Copy attachment link markdown"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:390
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:332
 #, elixir-autogen, elixir-format
 msgid "Error deleting attachment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:77
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:109
+#: lib/lanttern_web/components/attachments_components.ex:26
+#: lib/lanttern_web/components/attachments_components.ex:94
+#: lib/lanttern_web/components/attachments_components.ex:126
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr ""
@@ -2360,7 +2361,7 @@ msgstr ""
 msgid "File too large (max. %{file_size}MB)"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:165
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:107
 #, elixir-autogen, elixir-format
 msgid "File upload"
 msgstr ""
@@ -2385,19 +2386,20 @@ msgstr ""
 msgid "Only %{formats} files accepted"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:234
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:176
 #, elixir-autogen, elixir-format
 msgid "Or add a link to an external file"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:79
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:111
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:187
+#: lib/lanttern_web/components/attachments_components.ex:28
+#: lib/lanttern_web/components/attachments_components.ex:96
+#: lib/lanttern_web/components/attachments_components.ex:128
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:129
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:218
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:160
 #, elixir-autogen, elixir-format
 msgid "Upload a file"
 msgstr ""
@@ -2433,9 +2435,9 @@ msgstr ""
 msgid "Student self-assessment"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:39
+#: lib/lanttern_web/components/reporting_components.ex:40
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:224
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:207
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:255
 #, elixir-autogen, elixir-format
 msgid "Teacher comment"
 msgstr ""
@@ -2664,44 +2666,44 @@ msgstr ""
 msgid "Strand removed from your starred list"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:217
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:270
 #, elixir-autogen, elixir-format
 msgid "Assessment info"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "Assessment rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "Assessment scale"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:69
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:70
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:68
 #, elixir-autogen, elixir-format
 msgid "Criteria:"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:80
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:88
 #, elixir-autogen, elixir-format
 msgid "Formative assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:39
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:160
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Formative assessment pattern"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:221
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:274
 #, elixir-autogen, elixir-format
 msgid "Has rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:33
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Here you'll find information about the strand final and formative assessments."
 msgstr ""
@@ -2713,8 +2715,8 @@ msgstr ""
 msgid "No entry"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:43
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:212
+#: lib/lanttern_web/components/reporting_components.ex:44
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Student comment"
 msgstr ""
@@ -2739,7 +2741,7 @@ msgstr ""
 msgid "Strand rubrics"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:38
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:40
 #, elixir-autogen, elixir-format
 msgid "You can click the assessment card to view more details about it."
 msgstr ""
@@ -2754,17 +2756,17 @@ msgstr ""
 msgid "Final assessment not available yet"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:31
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:33
 #, elixir-autogen, elixir-format
 msgid "Goals assessment entries"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:54
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:91
 #, elixir-autogen, elixir-format
 msgid "Goals without assessment entries"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:49
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:58
 #, elixir-autogen, elixir-format
 msgid "No assessment entries for this strand yet"
 msgstr ""
@@ -2779,7 +2781,7 @@ msgstr ""
 msgid "Add students to report card to track entries"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:397
+#: lib/lanttern_web/components/reporting_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "No strands with moments assessment linked to this report card"
 msgstr ""
@@ -2847,4 +2849,29 @@ msgstr ""
 #: lib/lanttern_web/live/shared/dataviz/lanttern_viz_component.ex:19
 #, elixir-autogen, elixir-format
 msgid "Layers (moments)"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:76
+#, elixir-autogen, elixir-format
+msgid "In the context of"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:83
+#, elixir-autogen, elixir-format
+msgid "Learning evidences"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:82
+#, elixir-autogen, elixir-format
+msgid "View assessment details"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "With learning evidences"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:64
+#, elixir-autogen, elixir-format
+msgid "All strand evidences"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -119,8 +119,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:91
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:94
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:269
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:151
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:184
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:93
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:126
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:54
@@ -178,7 +178,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:94
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:172
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:69
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:154
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:96
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:56
 #, elixir-autogen, elixir-format
@@ -266,7 +266,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:200
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:130
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:153
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:95
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:73
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:81
@@ -312,7 +312,7 @@ msgid "cancel"
 msgstr ""
 
 #: lib/lanttern_web/components/form_components.ex:608
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:221
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:163
 #, elixir-autogen, elixir-format
 msgid "or drag and drop here"
 msgstr ""
@@ -486,8 +486,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:74
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:84
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:28
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:65
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:181
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:66
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:229
 #, elixir-autogen, elixir-format
 msgid "Differentiation"
 msgstr ""
@@ -497,6 +497,7 @@ msgstr ""
 msgid "Differentiation for %{name}"
 msgstr ""
 
+#: lib/lanttern_web/components/attachments_components.ex:112
 #: lib/lanttern_web/components/learning_context_components.ex:55
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:326
@@ -504,7 +505,6 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:227
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:65
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:258
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:95
 #: lib/lanttern_web/live/shared/notes/note_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -1075,7 +1075,7 @@ msgstr ""
 msgid "Curriculum components"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:39
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:40
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "Curriculum differentiation"
@@ -1091,7 +1091,7 @@ msgstr ""
 msgid "Curriculum items"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:122
+#: lib/lanttern_web/components/reporting_components.ex:123
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:39
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:34
@@ -1109,7 +1109,7 @@ msgstr ""
 msgid "Cycle already added to this grade report"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:320
+#: lib/lanttern_web/components/reporting_components.ex:321
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:353
@@ -1449,7 +1449,7 @@ msgid "No strands linked to this report yet"
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:424
-#: lib/lanttern_web/components/reporting_components.ex:438
+#: lib/lanttern_web/components/reporting_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr ""
@@ -1498,7 +1498,7 @@ msgstr ""
 msgid "Recalculate grade"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:100
+#: lib/lanttern_web/components/attachments_components.ex:117
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
 msgid "Remove"
@@ -1851,7 +1851,7 @@ msgstr ""
 msgid "You must log in to access this page."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:104
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:112
 #, elixir-autogen, elixir-format
 msgid "About this assessment"
 msgstr ""
@@ -2167,7 +2167,7 @@ msgid "Has footnote"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:427
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:145
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:87
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgstr ""
@@ -2234,7 +2234,7 @@ msgstr ""
 msgid "Students report cards access updated"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:134
+#: lib/lanttern_web/components/reporting_components.ex:135
 #, elixir-autogen, elixir-format
 msgid "Under development"
 msgstr ""
@@ -2324,33 +2324,34 @@ msgstr ""
 msgid "updated"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:235
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "(e.g. Google Docs)"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:103
+#: lib/lanttern_web/components/attachments_components.ex:120
 #, elixir-autogen, elixir-format
 msgid "Are you sure? This action cannot be undone."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:138
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:80
 #, elixir-autogen, elixir-format
 msgid "Attachment name"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:73
+#: lib/lanttern_web/components/attachments_components.ex:90
 #, elixir-autogen, elixir-format
 msgid "Copy attachment link markdown"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:390
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:332
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error deleting attachment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:77
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:109
+#: lib/lanttern_web/components/attachments_components.ex:26
+#: lib/lanttern_web/components/attachments_components.ex:94
+#: lib/lanttern_web/components/attachments_components.ex:126
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr ""
@@ -2360,7 +2361,7 @@ msgstr ""
 msgid "File too large (max. %{file_size}MB)"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:165
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:107
 #, elixir-autogen, elixir-format
 msgid "File upload"
 msgstr ""
@@ -2385,19 +2386,20 @@ msgstr ""
 msgid "Only %{formats} files accepted"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:234
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:176
 #, elixir-autogen, elixir-format
 msgid "Or add a link to an external file"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:79
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:111
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:187
+#: lib/lanttern_web/components/attachments_components.ex:28
+#: lib/lanttern_web/components/attachments_components.ex:96
+#: lib/lanttern_web/components/attachments_components.ex:128
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:129
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:218
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:160
 #, elixir-autogen, elixir-format
 msgid "Upload a file"
 msgstr ""
@@ -2433,9 +2435,9 @@ msgstr ""
 msgid "Student self-assessment"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:39
+#: lib/lanttern_web/components/reporting_components.ex:40
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:224
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:207
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:255
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Teacher comment"
 msgstr ""
@@ -2664,44 +2666,44 @@ msgstr ""
 msgid "Strand removed from your starred list"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:217
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:270
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment info"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:63
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:63
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment scale"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:69
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:70
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:68
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Criteria:"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:80
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Formative assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:39
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:160
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Formative assessment pattern"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:221
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Has rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:33
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Here you'll find information about the strand final and formative assessments."
 msgstr ""
@@ -2713,8 +2715,8 @@ msgstr ""
 msgid "No entry"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:43
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:212
+#: lib/lanttern_web/components/reporting_components.ex:44
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:260
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student comment"
 msgstr ""
@@ -2739,7 +2741,7 @@ msgstr ""
 msgid "Strand rubrics"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:38
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:40
 #, elixir-autogen, elixir-format, fuzzy
 msgid "You can click the assessment card to view more details about it."
 msgstr ""
@@ -2754,17 +2756,17 @@ msgstr ""
 msgid "Final assessment not available yet"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:31
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:33
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Goals assessment entries"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:54
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:91
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Goals without assessment entries"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:49
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:58
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No assessment entries for this strand yet"
 msgstr ""
@@ -2779,7 +2781,7 @@ msgstr ""
 msgid "Add students to report card to track entries"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:397
+#: lib/lanttern_web/components/reporting_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "No strands with moments assessment linked to this report card"
 msgstr ""
@@ -2847,4 +2849,29 @@ msgstr ""
 #: lib/lanttern_web/live/shared/dataviz/lanttern_viz_component.ex:19
 #, elixir-autogen, elixir-format
 msgid "Layers (moments)"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:76
+#, elixir-autogen, elixir-format
+msgid "In the context of"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:83
+#, elixir-autogen, elixir-format
+msgid "Learning evidences"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:82
+#, elixir-autogen, elixir-format
+msgid "View assessment details"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "With learning evidences"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:64
+#, elixir-autogen, elixir-format, fuzzy
+msgid "All strand evidences"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -119,8 +119,8 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:91
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:94
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:269
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:151
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:184
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:93
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:126
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:54
@@ -178,7 +178,7 @@ msgstr "Nenhuma trilha criadas para os anos e componentes selecionados"
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:94
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:172
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:69
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:154
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:96
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:56
 #, elixir-autogen, elixir-format
@@ -266,7 +266,7 @@ msgstr "Salvar Trilha"
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:200
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:130
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:153
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:95
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:73
 #: lib/lanttern_web/live/shared/grades_reports/student_grade_report_entry_form_component.ex:81
@@ -312,7 +312,7 @@ msgid "cancel"
 msgstr "cancelar"
 
 #: lib/lanttern_web/components/form_components.ex:608
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:221
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:163
 #, elixir-autogen, elixir-format
 msgid "or drag and drop here"
 msgstr "ou arraste e solte aqui"
@@ -486,8 +486,8 @@ msgstr "Deletar anotação"
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:74
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:84
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:28
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:65
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:181
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:66
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:229
 #, elixir-autogen, elixir-format
 msgid "Differentiation"
 msgstr "Diferenciação"
@@ -497,6 +497,7 @@ msgstr "Diferenciação"
 msgid "Differentiation for %{name}"
 msgstr "Diferenciação para %{name}"
 
+#: lib/lanttern_web/components/attachments_components.ex:112
 #: lib/lanttern_web/components/learning_context_components.ex:55
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:30
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:326
@@ -504,7 +505,6 @@ msgstr "Diferenciação para %{name}"
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:227
 #: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:65
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:258
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:95
 #: lib/lanttern_web/live/shared/notes/note_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -1075,7 +1075,7 @@ msgstr "Componente curricular"
 msgid "Curriculum components"
 msgstr "Componentes curriculares"
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:39
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:40
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "Curriculum differentiation"
@@ -1091,7 +1091,7 @@ msgstr "Item curricular removido"
 msgid "Curriculum items"
 msgstr "Itens curriculares"
 
-#: lib/lanttern_web/components/reporting_components.ex:122
+#: lib/lanttern_web/components/reporting_components.ex:123
 #: lib/lanttern_web/live/pages/grading/grades_reports_live.html.heex:39
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:34
@@ -1109,7 +1109,7 @@ msgstr "Ciclo"
 msgid "Cycle already added to this grade report"
 msgstr "Ciclo já adicionado à este relatório de nota"
 
-#: lib/lanttern_web/components/reporting_components.ex:320
+#: lib/lanttern_web/components/reporting_components.ex:321
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:353
@@ -1449,7 +1449,7 @@ msgid "No strands linked to this report yet"
 msgstr "Nenhuma trilha vinculada a este relatório ainda"
 
 #: lib/lanttern_web/components/grades_reports_components.ex:424
-#: lib/lanttern_web/components/reporting_components.ex:438
+#: lib/lanttern_web/components/reporting_components.ex:444
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr "Nenhum estudante vinculado a este relatório de notas"
@@ -1498,7 +1498,7 @@ msgstr "Prévia"
 msgid "Recalculate grade"
 msgstr "Recalcular nota"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:100
+#: lib/lanttern_web/components/attachments_components.ex:117
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
 msgid "Remove"
@@ -1851,7 +1851,7 @@ msgstr "Bem-vinda!"
 msgid "You must log in to access this page."
 msgstr "Você precisa estar logado para acessar esta página."
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:104
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:112
 #, elixir-autogen, elixir-format
 msgid "About this assessment"
 msgstr "Sobre esta avaliação"
@@ -2167,7 +2167,7 @@ msgid "Has footnote"
 msgstr "Possui nota de rodapé"
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:427
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:145
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:87
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgstr "Vincular"
@@ -2234,7 +2234,7 @@ msgstr "Acesso de estudantes"
 msgid "Students report cards access updated"
 msgstr "Report cards de estudante atualizados"
 
-#: lib/lanttern_web/components/reporting_components.ex:134
+#: lib/lanttern_web/components/reporting_components.ex:135
 #, elixir-autogen, elixir-format
 msgid "Under development"
 msgstr "Em desenvolvimento"
@@ -2324,33 +2324,34 @@ msgstr "para visualizar anotações de estudantes sobre a trilha"
 msgid "updated"
 msgstr "atualizado"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:235
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "(e.g. Google Docs)"
 msgstr "(por exemplo: Google Docs)"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:103
+#: lib/lanttern_web/components/attachments_components.ex:120
 #, elixir-autogen, elixir-format
 msgid "Are you sure? This action cannot be undone."
 msgstr "Você tem certeza? Esta ação não pode ser desfeita."
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:138
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:80
 #, elixir-autogen, elixir-format
 msgid "Attachment name"
 msgstr "Nome do anexo"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:73
+#: lib/lanttern_web/components/attachments_components.ex:90
 #, elixir-autogen, elixir-format
 msgid "Copy attachment link markdown"
 msgstr "Copiar link do anexo em markdown"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:390
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:332
 #, elixir-autogen, elixir-format
 msgid "Error deleting attachment"
 msgstr "Erro ao deletar anexo"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:77
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:109
+#: lib/lanttern_web/components/attachments_components.ex:26
+#: lib/lanttern_web/components/attachments_components.ex:94
+#: lib/lanttern_web/components/attachments_components.ex:126
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr "Link externo"
@@ -2360,7 +2361,7 @@ msgstr "Link externo"
 msgid "File too large (max. %{file_size}MB)"
 msgstr "Arquivo muito grande (máx. %{file_size}MB)"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:165
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:107
 #, elixir-autogen, elixir-format
 msgid "File upload"
 msgstr "Upload de arquivo"
@@ -2385,19 +2386,20 @@ msgstr "Anexos da anotação"
 msgid "Only %{formats} files accepted"
 msgstr "Apenas arquivos do tipo %{formats} são aceitos"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:234
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:176
 #, elixir-autogen, elixir-format
 msgid "Or add a link to an external file"
 msgstr "Ou adicione um link para um arquivo externo"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:79
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:111
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:187
+#: lib/lanttern_web/components/attachments_components.ex:28
+#: lib/lanttern_web/components/attachments_components.ex:96
+#: lib/lanttern_web/components/attachments_components.ex:128
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:129
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr "Upload"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:218
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:160
 #, elixir-autogen, elixir-format
 msgid "Upload a file"
 msgstr "Upload de arquivo"
@@ -2433,9 +2435,9 @@ msgstr "Comentário de %{student}"
 msgid "Student self-assessment"
 msgstr "Autoavaliação do estudante"
 
-#: lib/lanttern_web/components/reporting_components.ex:39
+#: lib/lanttern_web/components/reporting_components.ex:40
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:224
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:207
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:255
 #, elixir-autogen, elixir-format
 msgid "Teacher comment"
 msgstr "Comentário do professor"
@@ -2664,44 +2666,44 @@ msgstr "Nenhuma trilha favoritada ainda"
 msgid "Strand removed from your starred list"
 msgstr "Trilha removida da sua lista de favoritas"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:217
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:270
 #, elixir-autogen, elixir-format
 msgid "Assessment info"
 msgstr "Informações da avaliação"
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "Assessment rubric"
 msgstr "Rubrica de avaliação"
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "Assessment scale"
 msgstr "Escala da avaliação"
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:69
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:70
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:68
 #, elixir-autogen, elixir-format
 msgid "Criteria:"
 msgstr "Critério:"
 
-#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:80
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:88
 #, elixir-autogen, elixir-format
 msgid "Formative assessment"
 msgstr "Avaliação formativa"
 
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:39
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:160
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:208
 #, elixir-autogen, elixir-format
 msgid "Formative assessment pattern"
 msgstr "Padrão da avaliação formativa"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:221
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:274
 #, elixir-autogen, elixir-format
 msgid "Has rubric"
 msgstr "Possui rubrica"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:33
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Here you'll find information about the strand final and formative assessments."
 msgstr "Aqui você irá encontrar informações sobre as avaliações final e formativa da trilha."
@@ -2713,8 +2715,8 @@ msgstr "Aqui você irá encontrar informações sobre as avaliações final e fo
 msgid "No entry"
 msgstr "Sem registro"
 
-#: lib/lanttern_web/components/reporting_components.ex:43
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:212
+#: lib/lanttern_web/components/reporting_components.ex:44
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Student comment"
 msgstr "Comentário do estudante"
@@ -2739,7 +2741,7 @@ msgstr "Nenhuma informação do relatório ainda."
 msgid "Strand rubrics"
 msgstr "Rubricas da trilha"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:38
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:40
 #, elixir-autogen, elixir-format
 msgid "You can click the assessment card to view more details about it."
 msgstr "Você pode clicar no card da avaliação para ver mais detalhes."
@@ -2754,17 +2756,17 @@ msgstr "Você pode clicar no card do momento para ver mais detalhes, incluindo i
 msgid "Final assessment not available yet"
 msgstr "A avaliação final ainda não está disponível"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:31
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:33
 #, elixir-autogen, elixir-format
 msgid "Goals assessment entries"
 msgstr "Registros da avaliação de objetivos"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:54
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:91
 #, elixir-autogen, elixir-format
 msgid "Goals without assessment entries"
 msgstr "Objetivos sem registros de avaliação"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:49
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:58
 #, elixir-autogen, elixir-format
 msgid "No assessment entries for this strand yet"
 msgstr "Nenhum registro de avaliação para esta trilha ainda"
@@ -2779,7 +2781,7 @@ msgstr "Rubrica de diferenciação"
 msgid "Add students to report card to track entries"
 msgstr "Adicione estudantes ao report card para acompanhar os registros"
 
-#: lib/lanttern_web/components/reporting_components.ex:397
+#: lib/lanttern_web/components/reporting_components.ex:403
 #, elixir-autogen, elixir-format
 msgid "No strands with moments assessment linked to this report card"
 msgstr "Nenhuma trilha com avaliações nos momentos vinculada a este report card"
@@ -2848,3 +2850,28 @@ msgstr "Avaliação final"
 #, elixir-autogen, elixir-format
 msgid "Layers (moments)"
 msgstr "Camadas (momentos)"
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:76
+#, elixir-autogen, elixir-format
+msgid "In the context of"
+msgstr "No contexto de"
+
+#: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:83
+#, elixir-autogen, elixir-format
+msgid "Learning evidences"
+msgstr "Evidências de aprendizagem"
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:82
+#, elixir-autogen, elixir-format
+msgid "View assessment details"
+msgstr "Ver detalhes da avaliação"
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:265
+#, elixir-autogen, elixir-format
+msgid "With learning evidences"
+msgstr "Possui evidências de aprendizagem"
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:64
+#, elixir-autogen, elixir-format
+msgid "All strand evidences"
+msgstr "Todas as evidências da trilha"

--- a/test/lanttern/assessments_test.exs
+++ b/test/lanttern/assessments_test.exs
@@ -872,10 +872,10 @@ defmodule Lanttern.AssessmentsTest do
     test "list_strand_goals_for_student/2 returns the list of strand goals with student assessments" do
       #      | moment_1 | moment_2 | moment_3 |
       # ---------------------------------------
-      # ci_1 |    2     |    1     |    1     | (no entry in m1 pos 2 and m3. has goal evidence)
+      # ci_1 |    2     |    1     |    1     | (no entry in m1 pos 2 and m3)
       # ci_2 |    -     |    1     |    -     |
       # ci_3 |    -     |    -     |    -     | (no entry for goal)
-      # ci_4 |    1     |    -     |    -     | (no entry for goal. has evidence in m1 entry)
+      # ci_4 |    1     |    -     |    -     | (no entry for goal)
 
       strand = LearningContextFixtures.strand_fixture()
 
@@ -1059,27 +1059,6 @@ defmodule Lanttern.AssessmentsTest do
           ordinal_value_id: ordinal_value.id
         })
 
-      # add evidences to goal entry 1 and ci_4_m1 entry
-      current_user = %{current_profile: IdentityFixtures.teacher_profile_fixture()}
-
-      params = %{
-        "name" => "attachment name",
-        "link" => "https://somesite.com",
-        "is_external" => true
-      }
-
-      Assessments.create_assessment_point_entry_evidence(
-        current_user,
-        entry_1.id,
-        params
-      )
-
-      Assessments.create_assessment_point_entry_evidence(
-        current_user,
-        entry_ci_4_m_1.id,
-        params
-      )
-
       # extra entry for different student (test student join)
       _other_entry =
         assessment_point_entry_fixture(%{
@@ -1089,10 +1068,10 @@ defmodule Lanttern.AssessmentsTest do
         })
 
       assert [
-               {expected_ap_1, expected_entry_1, [expected_ci_1_m_1_1, expected_ci_1_m_2], true},
-               {expected_ap_2, expected_entry_2, [expected_ci_2_m_2], false},
-               {expected_ap_3, nil, [], false},
-               {expected_ap_4, nil, [expected_ci_4_m_1], true}
+               {expected_ap_1, expected_entry_1, [expected_ci_1_m_1_1, expected_ci_1_m_2]},
+               {expected_ap_2, expected_entry_2, [expected_ci_2_m_2]},
+               {expected_ap_3, nil, []},
+               {expected_ap_4, nil, [expected_ci_4_m_1]}
              ] = Assessments.list_strand_goals_for_student(student.id, strand.id)
 
       assert expected_ap_1.id == assessment_point_1.id

--- a/test/lanttern/reporting_test.exs
+++ b/test/lanttern/reporting_test.exs
@@ -682,9 +682,12 @@ defmodule Lanttern.ReportingTest do
     alias Lanttern.AssessmentsFixtures
     alias Lanttern.CurriculaFixtures
     alias Lanttern.GradingFixtures
+    alias Lanttern.IdentityFixtures
     alias Lanttern.LearningContextFixtures
     alias Lanttern.SchoolsFixtures
     alias Lanttern.TaxonomyFixtures
+
+    alias Lanttern.Assessments
 
     test "list_student_report_card_strand_reports_and_entries/1 returns the list of the strands in the report with the student assessment point entries" do
       report_card = report_card_fixture()
@@ -1135,6 +1138,8 @@ defmodule Lanttern.ReportingTest do
           scale_id: o_scale.id
         })
 
+      # entries
+
       assessment_point_1_1_entry =
         AssessmentsFixtures.assessment_point_entry_fixture(%{
           student_id: student.id,
@@ -1162,6 +1167,22 @@ defmodule Lanttern.ReportingTest do
           scale_type: o_scale.type,
           ordinal_value_id: ov_2.id
         })
+
+      # add evidences to entry 1_1
+      current_user = %{current_profile: IdentityFixtures.teacher_profile_fixture()}
+
+      params = %{
+        "name" => "attachment name",
+        "link" => "https://somesite.com",
+        "is_external" => true
+      }
+
+      {:ok, evidence} =
+        Assessments.create_assessment_point_entry_evidence(
+          current_user,
+          assessment_point_1_1_entry.id,
+          params
+        )
 
       # other strand goal with same curriculum item
       # to test filtering
@@ -1202,6 +1223,7 @@ defmodule Lanttern.ReportingTest do
       assert expected_entry_1_1.id == assessment_point_1_1_entry.id
       assert expected_entry_1_1.scale == o_scale
       assert expected_entry_1_1.ordinal_value == ov_1
+      assert expected_entry_1_1.evidences == [evidence]
 
       assert expected_entry_1_2.id == assessment_point_1_2_entry.id
       assert expected_assessment_point_1_2.id == assessment_point_1_2.id


### PR DESCRIPTION
all assessment evidences (moments and goals) are now displayed in strand reports.

resolves #202 