### PR TITLE
moment cards templates

### DIFF
--- a/lib/lanttern/personalization.ex
+++ b/lib/lanttern/personalization.ex
@@ -14,7 +14,7 @@ defmodule Lanttern.Personalization do
 
   alias Lanttern.Personalization.ProfileSettings
 
-  @valid_permissions ["wcd", "school_management"]
+  @valid_permissions ["wcd", "school_management", "content_management"]
 
   @doc """
   Get profile settings.

--- a/lib/lanttern/repo_helpers.ex
+++ b/lib/lanttern/repo_helpers.ex
@@ -114,8 +114,17 @@ defmodule Lanttern.RepoHelpers do
 
   @doc """
   Set the position in attrs for new entries, based on existing items in schema.
+
+  Skip if position already present in attrs.
   """
   @spec set_position_in_attrs(Ecto.Queryable.t(), attrs :: map()) :: map()
+  def set_position_in_attrs(_queryable, %{position: position} = attrs) when is_integer(position),
+    do: attrs
+
+  def set_position_in_attrs(_queryable, %{"position" => position} = attrs)
+      when is_integer(position),
+      do: attrs
+
   def set_position_in_attrs(queryable, attrs) do
     position =
       from(

--- a/lib/lanttern/school_config.ex
+++ b/lib/lanttern/school_config.ex
@@ -4,6 +4,7 @@ defmodule Lanttern.SchoolConfig do
   """
 
   import Ecto.Query, warn: false
+  import Lanttern.RepoHelpers
   alias Lanttern.Repo
 
   alias Lanttern.SchoolConfig.MomentCardTemplate
@@ -11,20 +12,56 @@ defmodule Lanttern.SchoolConfig do
   @doc """
   Returns the list of moment_cards_templates.
 
+  ### Options:
+
+  - `:school_id` – filter result by provided school id
+
   ## Examples
 
       iex> list_moment_cards_templates()
       [%MomentCardTemplate{}, ...]
 
   """
-  def list_moment_cards_templates do
-    Repo.all(MomentCardTemplate)
+  def list_moment_cards_templates(opts \\ []) do
+    from(
+      mct in MomentCardTemplate,
+      order_by: mct.position
+    )
+    |> apply_list_moment_cards_templates_opts(opts)
+    |> Repo.all()
   end
+
+  defp apply_list_moment_cards_templates_opts(queryable, []), do: queryable
+
+  defp apply_list_moment_cards_templates_opts(queryable, [{:school_id, school_id} | opts]) do
+    from(
+      mct in queryable,
+      where: mct.school_id == ^school_id
+    )
+    |> apply_list_moment_cards_templates_opts(opts)
+  end
+
+  defp apply_list_moment_cards_templates_opts(queryable, [_ | opts]),
+    do: apply_list_moment_cards_templates_opts(queryable, opts)
 
   @doc """
   Gets a single moment_card_template.
 
-  Raises `Ecto.NoResultsError` if the Moment card template does not exist.
+  Returns `nil` if the Moment card template does not exist.
+
+  ## Examples
+
+      iex> get_moment_card_template(123)
+      %MomentCardTemplate{}
+
+      iex> get_moment_card_template(456)
+      nil
+
+  """
+  def get_moment_card_template(id), do: Repo.get(MomentCardTemplate, id)
+
+  @doc """
+  Same as get_moment_card_template/1, but raises `Ecto.NoResultsError` if the Moment card template does not exist.
 
   ## Examples
 
@@ -33,7 +70,6 @@ defmodule Lanttern.SchoolConfig do
 
       iex> get_moment_card_template!(456)
       ** (Ecto.NoResultsError)
-
   """
   def get_moment_card_template!(id), do: Repo.get!(MomentCardTemplate, id)
 
@@ -50,6 +86,26 @@ defmodule Lanttern.SchoolConfig do
 
   """
   def create_moment_card_template(attrs \\ %{}) do
+    queryable =
+      case attrs do
+        %{school_id: school_id} ->
+          from(
+            mct in MomentCardTemplate,
+            where: mct.school_id == ^school_id
+          )
+
+        %{"school_id" => school_id} ->
+          from(
+            mct in MomentCardTemplate,
+            where: mct.school_id == ^school_id
+          )
+
+        _ ->
+          MomentCardTemplate
+      end
+
+    attrs = set_position_in_attrs(queryable, attrs)
+
     %MomentCardTemplate{}
     |> MomentCardTemplate.changeset(attrs)
     |> Repo.insert()

--- a/lib/lanttern/school_config.ex
+++ b/lib/lanttern/school_config.ex
@@ -157,4 +157,18 @@ defmodule Lanttern.SchoolConfig do
   def change_moment_card_template(%MomentCardTemplate{} = moment_card_template, attrs \\ %{}) do
     MomentCardTemplate.changeset(moment_card_template, attrs)
   end
+
+  @doc """
+  Update moment cards templates positions based on ids list order.
+
+  ## Examples
+
+  iex> update_moment_cards_templates_positions([3, 2, 1])
+  :ok
+
+  """
+  @spec update_moment_cards_templates_positions(moment_cards_templates_ids :: [pos_integer()]) ::
+          :ok | {:error, String.t()}
+  def update_moment_cards_templates_positions(moment_cards_templates_ids),
+    do: update_positions(MomentCardTemplate, moment_cards_templates_ids)
 end

--- a/lib/lanttern/school_config.ex
+++ b/lib/lanttern/school_config.ex
@@ -1,0 +1,104 @@
+defmodule Lanttern.SchoolConfig do
+  @moduledoc """
+  The SchoolConfig context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Lanttern.Repo
+
+  alias Lanttern.SchoolConfig.MomentCardTemplate
+
+  @doc """
+  Returns the list of moment_cards_templates.
+
+  ## Examples
+
+      iex> list_moment_cards_templates()
+      [%MomentCardTemplate{}, ...]
+
+  """
+  def list_moment_cards_templates do
+    Repo.all(MomentCardTemplate)
+  end
+
+  @doc """
+  Gets a single moment_card_template.
+
+  Raises `Ecto.NoResultsError` if the Moment card template does not exist.
+
+  ## Examples
+
+      iex> get_moment_card_template!(123)
+      %MomentCardTemplate{}
+
+      iex> get_moment_card_template!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_moment_card_template!(id), do: Repo.get!(MomentCardTemplate, id)
+
+  @doc """
+  Creates a moment_card_template.
+
+  ## Examples
+
+      iex> create_moment_card_template(%{field: value})
+      {:ok, %MomentCardTemplate{}}
+
+      iex> create_moment_card_template(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_moment_card_template(attrs \\ %{}) do
+    %MomentCardTemplate{}
+    |> MomentCardTemplate.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a moment_card_template.
+
+  ## Examples
+
+      iex> update_moment_card_template(moment_card_template, %{field: new_value})
+      {:ok, %MomentCardTemplate{}}
+
+      iex> update_moment_card_template(moment_card_template, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_moment_card_template(%MomentCardTemplate{} = moment_card_template, attrs) do
+    moment_card_template
+    |> MomentCardTemplate.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a moment_card_template.
+
+  ## Examples
+
+      iex> delete_moment_card_template(moment_card_template)
+      {:ok, %MomentCardTemplate{}}
+
+      iex> delete_moment_card_template(moment_card_template)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_moment_card_template(%MomentCardTemplate{} = moment_card_template) do
+    Repo.delete(moment_card_template)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking moment_card_template changes.
+
+  ## Examples
+
+      iex> change_moment_card_template(moment_card_template)
+      %Ecto.Changeset{data: %MomentCardTemplate{}}
+
+  """
+  def change_moment_card_template(%MomentCardTemplate{} = moment_card_template, attrs \\ %{}) do
+    MomentCardTemplate.changeset(moment_card_template, attrs)
+  end
+end

--- a/lib/lanttern/school_config/moment_card_template.ex
+++ b/lib/lanttern/school_config/moment_card_template.ex
@@ -1,4 +1,8 @@
 defmodule Lanttern.SchoolConfig.MomentCardTemplate do
+  @moduledoc """
+  The `MomentCardTemplate` schema
+  """
+
   use Ecto.Schema
   import Ecto.Changeset
 

--- a/lib/lanttern/school_config/moment_card_template.ex
+++ b/lib/lanttern/school_config/moment_card_template.ex
@@ -1,0 +1,36 @@
+defmodule Lanttern.SchoolConfig.MomentCardTemplate do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Lanttern.Schools.School
+
+  @type t :: %__MODULE__{
+          id: pos_integer(),
+          name: String.t(),
+          template: String.t(),
+          instructions: String.t() | nil,
+          position: non_neg_integer(),
+          school: School.t() | Ecto.Association.NotLoaded.t(),
+          school_id: pos_integer(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "moment_cards_templates" do
+    field :name, :string
+    field :template, :string
+    field :instructions, :string
+    field :position, :integer, default: 0
+
+    belongs_to :school, School
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(moment_card_template, attrs) do
+    moment_card_template
+    |> cast(attrs, [:name, :template, :instructions, :position, :school_id])
+    |> validate_required([:name, :template, :position, :school_id])
+  end
+end

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -1622,6 +1622,22 @@ defmodule LantternWeb.CoreComponents do
   end
 
   @doc """
+  Util for ScrollToTop hook implementation.
+  """
+  attr :id, :string, required: true
+  attr :overlay_id, :string, required: true
+
+  def scroll_to_top(assigns) do
+    ~H"""
+    <div
+      id={@id}
+      phx-hook="ScrollToTop"
+      data-scroll-to-selector={"##{@overlay_id} *[aria-modal=true]"}
+    />
+    """
+  end
+
+  @doc """
   Renders a spinner.
   """
   attr :class, :any, default: nil

--- a/lib/lanttern_web/helpers/personalization_helpers.ex
+++ b/lib/lanttern_web/helpers/personalization_helpers.ex
@@ -8,7 +8,8 @@ defmodule LantternWeb.PersonalizationHelpers do
 
   @permission_to_option_map %{
     "wcd" => "WCD",
-    "school_management" => "School management"
+    "school_management" => "School management",
+    "content_management" => "Content management"
   }
 
   @doc """

--- a/lib/lanttern_web/live/pages/school/school_live.html.heex
+++ b/lib/lanttern_web/live/pages/school/school_live.html.heex
@@ -10,9 +10,6 @@
       <:tab patch={~p"/school/students"} is_current={@live_action == :manage_students}>
         <%= gettext("All students") %>
       </:tab>
-      <:tab patch={~p"/school/cycles"} is_current={@live_action == :manage_cycles}>
-        <%= gettext("Cycles") %>
-      </:tab>
     </.neo_tabs>
   </div>
 </.header_nav>
@@ -31,13 +28,5 @@
   current_user={@current_user}
   params={@params}
   live_action={@live_action}
-  is_school_manager={@is_school_manager}
-/>
-<.live_component
-  :if={@live_action == :manage_cycles}
-  module={CyclesComponent}
-  id={:school_classes}
-  current_user={@current_user}
-  params={@params}
   is_school_manager={@is_school_manager}
 />

--- a/lib/lanttern_web/live/pages/school_config/cycles_component.ex
+++ b/lib/lanttern_web/live/pages/school_config/cycles_component.ex
@@ -1,4 +1,4 @@
-defmodule LantternWeb.SchoolLive.CyclesComponent do
+defmodule LantternWeb.SchoolConfigLive.CyclesComponent do
   use LantternWeb, :live_component
 
   alias Lanttern.Schools
@@ -12,7 +12,11 @@ defmodule LantternWeb.SchoolLive.CyclesComponent do
     ~H"""
     <div>
       <div :if={@is_school_manager} class="flex justify-end gap-6 p-4">
-        <.action type="link" patch={~p"/school/cycles?new=true"} icon_name="hero-plus-circle-mini">
+        <.action
+          type="link"
+          patch={~p"/school_config/cycles?new=true"}
+          icon_name="hero-plus-circle-mini"
+        >
           <%= gettext("Add cycle") %>
         </.action>
       </div>
@@ -50,7 +54,7 @@ defmodule LantternWeb.SchoolLive.CyclesComponent do
                 size="sm"
                 theme="ghost"
                 rounded
-                patch={~p"/school/cycles?edit=#{cycle.id}"}
+                patch={~p"/school_config/cycles?edit=#{cycle.id}"}
               />
             </:action>
           </.data_grid>
@@ -68,7 +72,7 @@ defmodule LantternWeb.SchoolLive.CyclesComponent do
         id="cycle-form-overlay"
         cycle={@cycle}
         title={@cycle_form_overlay_title}
-        on_cancel={JS.patch(~p"/school/cycles")}
+        on_cancel={JS.patch(~p"/school_config/cycles")}
         notify_component={@myself}
       />
     </div>
@@ -86,7 +90,7 @@ defmodule LantternWeb.SchoolLive.CyclesComponent do
   def update(%{action: {CycleFormOverlayComponent, {:created, _cycle}}}, socket) do
     nav_opts = [
       put_flash: {:info, gettext("Cycle created successfully")},
-      push_navigate: [to: ~p"/school/cycles"]
+      push_navigate: [to: ~p"/school_config/cycles"]
     ]
 
     {:ok, delegate_navigation(socket, nav_opts)}
@@ -95,7 +99,7 @@ defmodule LantternWeb.SchoolLive.CyclesComponent do
   def update(%{action: {CycleFormOverlayComponent, {:updated, cycle}}}, socket) do
     nav_opts = [
       put_flash: {:info, gettext("Cycle updated successfully")},
-      push_navigate: [to: ~p"/school/cycles"]
+      push_navigate: [to: ~p"/school_config/cycles"]
     ]
 
     socket =
@@ -109,7 +113,7 @@ defmodule LantternWeb.SchoolLive.CyclesComponent do
   def update(%{action: {CycleFormOverlayComponent, {:deleted, cycle}}}, socket) do
     nav_opts = [
       put_flash: {:info, gettext("Cycle deleted successfully")},
-      push_patch: [to: ~p"/school/cycles"]
+      push_patch: [to: ~p"/school_config/cycles"]
     ]
 
     socket =

--- a/lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex
+++ b/lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex
@@ -1,0 +1,119 @@
+defmodule LantternWeb.SchoolConfigLive.MomentCardsTemplatesComponent do
+  use LantternWeb, :live_component
+
+  # alias Lanttern.Schools
+  # alias Lanttern.Schools.Cycle
+
+  # # shared components
+  # alias LantternWeb.Schools.CycleFormOverlayComponent
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      tbd
+    </div>
+    """
+  end
+
+  # # lifecycle
+
+  # @impl true
+  # def mount(socket) do
+  #   {:ok, assign(socket, :initialized, false)}
+  # end
+
+  # @impl true
+  # def update(%{action: {CycleFormOverlayComponent, {:created, _cycle}}}, socket) do
+  #   nav_opts = [
+  #     put_flash: {:info, gettext("Cycle created successfully")},
+  #     push_navigate: [to: ~p"/school/cycles"]
+  #   ]
+
+  #   {:ok, delegate_navigation(socket, nav_opts)}
+  # end
+
+  # def update(%{action: {CycleFormOverlayComponent, {:updated, cycle}}}, socket) do
+  #   nav_opts = [
+  #     put_flash: {:info, gettext("Cycle updated successfully")},
+  #     push_navigate: [to: ~p"/school/cycles"]
+  #   ]
+
+  #   socket =
+  #     socket
+  #     |> delegate_navigation(nav_opts)
+  #     |> stream_insert(:cycles, cycle)
+
+  #   {:ok, socket}
+  # end
+
+  # def update(%{action: {CycleFormOverlayComponent, {:deleted, cycle}}}, socket) do
+  #   nav_opts = [
+  #     put_flash: {:info, gettext("Cycle deleted successfully")},
+  #     push_patch: [to: ~p"/school/cycles"]
+  #   ]
+
+  #   socket =
+  #     socket
+  #     |> delegate_navigation(nav_opts)
+  #     |> stream_delete(:cycles, cycle)
+
+  #   {:ok, socket}
+  # end
+
+  # def update(assigns, socket) do
+  #   socket =
+  #     socket
+  #     |> assign(assigns)
+  #     |> initialize()
+  #     |> assign_cycle()
+
+  #   {:ok, socket}
+  # end
+
+  # defp initialize(%{assigns: %{initialized: false}} = socket) do
+  #   socket
+  #   |> stream_cycles()
+  #   |> assign(:initialized, true)
+  # end
+
+  # defp initialize(socket), do: socket
+
+  # defp stream_cycles(socket) do
+  #   school_id = socket.assigns.current_user.current_profile.school_id
+
+  #   cycles =
+  #     Schools.list_cycles_and_subcycles(schools_ids: [school_id])
+  #     |> Enum.flat_map(&[%{&1 | subcycles: nil} | &1.subcycles])
+
+  #   socket
+  #   |> stream(:cycles, cycles)
+  #   |> assign(:has_cycles, length(cycles) > 0)
+  # end
+
+  # defp assign_cycle(%{assigns: %{is_school_manager: false}} = socket),
+  #   do: assign(socket, :cycle, nil)
+
+  # defp assign_cycle(%{assigns: %{params: %{"new" => "true"}}} = socket) do
+  #   cycle = %Cycle{
+  #     school_id: socket.assigns.current_user.current_profile.school_id
+  #   }
+
+  #   socket
+  #   |> assign(:cycle, cycle)
+  #   |> assign(:cycle_form_overlay_title, gettext("Create cycle"))
+  # end
+
+  # defp assign_cycle(%{assigns: %{params: %{"edit" => cycle_id}}} = socket) do
+  #   cycle =
+  #     Schools.get_cycle(cycle_id,
+  #       check_permissions_for_user: socket.assigns.current_user
+  #     )
+
+  #   socket
+  #   |> assign(:cycle, cycle)
+  #   |> assign(:cycle_form_overlay_title, gettext("Edit cycle"))
+  # end
+
+  # defp assign_cycle(socket), do: assign(socket, :cycle, nil)
+end

--- a/lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex
+++ b/lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex
@@ -1,37 +1,96 @@
 defmodule LantternWeb.SchoolConfigLive.MomentCardsTemplatesComponent do
+  @moduledoc """
+  ### Supported attrs/assigns
+
+  - `is_content_manager` (required, bool)
+  """
   use LantternWeb, :live_component
 
-  # alias Lanttern.Schools
-  # alias Lanttern.Schools.Cycle
+  alias Lanttern.SchoolConfig
+  alias Lanttern.SchoolConfig.MomentCardTemplate
 
-  # # shared components
-  # alias LantternWeb.Schools.CycleFormOverlayComponent
+  # shared components
+  alias LantternWeb.SchoolConfig.MomentCardTemplateOverlayComponent
 
   @impl true
   def render(assigns) do
     ~H"""
     <div>
-      tbd
+      <.action_bar class="flex items-center justify-between gap-4">
+        <p>
+          <%= gettext("Templates for new moment cards") %>
+        </p>
+        <.action
+          :if={@is_content_manager}
+          type="link"
+          patch={~p"/school_config/moment_cards_templates?new=true"}
+          icon_name="hero-plus-circle-mini"
+        >
+          <%= gettext("Add card template") %>
+        </.action>
+      </.action_bar>
+      <%= if @templates_count == 0 do %>
+        <div class="p-4">
+          <.card_base class="p-10">
+            <.empty_state><%= gettext("No templates created yet") %></.empty_state>
+          </.card_base>
+        </div>
+      <% else %>
+        <.responsive_grid phx-update="stream" id="moment-cards-templates" class="p-4" is_full_width>
+          <.card_base :for={{dom_id, template} <- @streams.templates} id={dom_id} class="p-6">
+            <.link
+              patch={~p"/school_config/moment_cards_templates?id=#{template.id}"}
+              class="font-display font-black text-xl hover:text-ltrn-subtle"
+            >
+              <%= template.name %>
+            </.link>
+            <div class="mt-6 line-clamp-6">
+              <.markdown text={template.template} />
+            </div>
+          </.card_base>
+        </.responsive_grid>
+      <% end %>
+      <.live_component
+        :if={@template}
+        module={MomentCardTemplateOverlayComponent}
+        moment_card_template={@template}
+        id="moment-card-template-overlay"
+        on_cancel={JS.patch(~p"/school_config/moment_cards_templates")}
+        allow_edit={@is_content_manager}
+        notify_component={@myself}
+      />
     </div>
     """
   end
 
-  # # lifecycle
+  # lifecycle
 
-  # @impl true
-  # def mount(socket) do
-  #   {:ok, assign(socket, :initialized, false)}
-  # end
+  @impl true
+  def mount(socket) do
+    {:ok, assign(socket, :initialized, false)}
+  end
 
-  # @impl true
-  # def update(%{action: {CycleFormOverlayComponent, {:created, _cycle}}}, socket) do
-  #   nav_opts = [
-  #     put_flash: {:info, gettext("Cycle created successfully")},
-  #     push_navigate: [to: ~p"/school/cycles"]
-  #   ]
+  @impl true
+  def update(%{action: {MomentCardTemplateOverlayComponent, {:created, template}}}, socket) do
+    socket =
+      socket
+      |> stream_insert(:templates, template)
+      |> assign(:templates_count, socket.assigns.templates_count + 1)
 
-  #   {:ok, delegate_navigation(socket, nav_opts)}
-  # end
+    {:ok, socket}
+  end
+
+  def update(%{action: {MomentCardTemplateOverlayComponent, {:updated, template}}}, socket),
+    do: {:ok, stream_insert(socket, :templates, template)}
+
+  def update(%{action: {MomentCardTemplateOverlayComponent, {:deleted, template}}}, socket) do
+    socket =
+      socket
+      |> stream_delete(:templates, template)
+      |> assign(:templates_count, socket.assigns.templates_count - 1)
+
+    {:ok, socket}
+  end
 
   # def update(%{action: {CycleFormOverlayComponent, {:updated, cycle}}}, socket) do
   #   nav_opts = [
@@ -61,59 +120,53 @@ defmodule LantternWeb.SchoolConfigLive.MomentCardsTemplatesComponent do
   #   {:ok, socket}
   # end
 
-  # def update(assigns, socket) do
-  #   socket =
-  #     socket
-  #     |> assign(assigns)
-  #     |> initialize()
-  #     |> assign_cycle()
+  def update(assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> initialize()
+      |> assign_template()
 
-  #   {:ok, socket}
-  # end
+    {:ok, socket}
+  end
 
-  # defp initialize(%{assigns: %{initialized: false}} = socket) do
-  #   socket
-  #   |> stream_cycles()
-  #   |> assign(:initialized, true)
-  # end
+  defp initialize(%{assigns: %{initialized: false}} = socket) do
+    socket
+    |> stream_templates()
+    |> assign(:initialized, true)
+  end
 
-  # defp initialize(socket), do: socket
+  defp initialize(socket), do: socket
 
-  # defp stream_cycles(socket) do
-  #   school_id = socket.assigns.current_user.current_profile.school_id
+  defp stream_templates(socket) do
+    school_id = socket.assigns.current_user.current_profile.school_id
 
-  #   cycles =
-  #     Schools.list_cycles_and_subcycles(schools_ids: [school_id])
-  #     |> Enum.flat_map(&[%{&1 | subcycles: nil} | &1.subcycles])
+    templates =
+      SchoolConfig.list_moment_cards_templates(schools_ids: [school_id])
 
-  #   socket
-  #   |> stream(:cycles, cycles)
-  #   |> assign(:has_cycles, length(cycles) > 0)
-  # end
+    socket
+    |> stream(:templates, templates)
+    |> assign(:templates_count, length(templates))
+  end
 
-  # defp assign_cycle(%{assigns: %{is_school_manager: false}} = socket),
-  #   do: assign(socket, :cycle, nil)
+  defp assign_template(
+         %{assigns: %{params: %{"new" => "true"}, is_content_manager: true}} = socket
+       ) do
+    template = %MomentCardTemplate{
+      school_id: socket.assigns.current_user.current_profile.school_id
+    }
 
-  # defp assign_cycle(%{assigns: %{params: %{"new" => "true"}}} = socket) do
-  #   cycle = %Cycle{
-  #     school_id: socket.assigns.current_user.current_profile.school_id
-  #   }
+    socket
+    |> assign(:template, template)
+  end
 
-  #   socket
-  #   |> assign(:cycle, cycle)
-  #   |> assign(:cycle_form_overlay_title, gettext("Create cycle"))
-  # end
+  defp assign_template(%{assigns: %{params: %{"id" => id}}} = socket) do
+    template =
+      SchoolConfig.get_moment_card_template(id)
 
-  # defp assign_cycle(%{assigns: %{params: %{"edit" => cycle_id}}} = socket) do
-  #   cycle =
-  #     Schools.get_cycle(cycle_id,
-  #       check_permissions_for_user: socket.assigns.current_user
-  #     )
+    socket
+    |> assign(:template, template)
+  end
 
-  #   socket
-  #   |> assign(:cycle, cycle)
-  #   |> assign(:cycle_form_overlay_title, gettext("Edit cycle"))
-  # end
-
-  # defp assign_cycle(socket), do: assign(socket, :cycle, nil)
+  defp assign_template(socket), do: assign(socket, :template, nil)
 end

--- a/lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex
+++ b/lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex
@@ -56,7 +56,7 @@ defmodule LantternWeb.SchoolConfigLive.MomentCardsTemplatesComponent do
             >
               <%= template.name %>
             </.link>
-            <div class="mt-6 line-clamp-6">
+            <div class="mt-6 line-clamp-4">
               <.markdown text={template.template} />
             </div>
           </.card_base>

--- a/lib/lanttern_web/live/pages/school_config/school_config_live.ex
+++ b/lib/lanttern_web/live/pages/school_config/school_config_live.ex
@@ -1,9 +1,9 @@
-defmodule LantternWeb.SchoolLive do
+defmodule LantternWeb.SchoolConfigLive do
   use LantternWeb, :live_view
 
   # view components
-  alias __MODULE__.StudentsComponent
-  alias __MODULE__.ClassesComponent
+  alias __MODULE__.CyclesComponent
+  alias __MODULE__.MomentCardsTemplatesComponent
 
   # lifecycle
 
@@ -12,6 +12,7 @@ defmodule LantternWeb.SchoolLive do
     socket =
       socket
       |> assign_is_school_manager()
+      |> assign_is_content_manager()
       |> assign(:page_title, socket.assigns.current_user.current_profile.school_name)
 
     {:ok, socket}
@@ -22,6 +23,13 @@ defmodule LantternWeb.SchoolLive do
       "school_management" in socket.assigns.current_user.current_profile.permissions
 
     assign(socket, :is_school_manager, is_school_manager)
+  end
+
+  defp assign_is_content_manager(socket) do
+    is_content_manager =
+      "content_management" in socket.assigns.current_user.current_profile.permissions
+
+    assign(socket, :is_content_manager, is_content_manager)
   end
 
   @impl true

--- a/lib/lanttern_web/live/pages/school_config/school_config_live.html.heex
+++ b/lib/lanttern_web/live/pages/school_config/school_config_live.html.heex
@@ -1,0 +1,34 @@
+<.header_nav current_user={@current_user}>
+  <:title>
+    <%= gettext("%{school} config", school: @current_user.current_profile.school_name) %>
+  </:title>
+  <div class="px-4">
+    <.neo_tabs>
+      <:tab patch={~p"/school_config/cycles"} is_current={@live_action == :manage_cycles}>
+        <%= gettext("Cycles") %>
+      </:tab>
+      <:tab
+        patch={~p"/school_config/moment_cards_templates"}
+        is_current={@live_action == :manage_moment_cards_templates}
+      >
+        <%= gettext("Templates") %>
+      </:tab>
+    </.neo_tabs>
+  </div>
+</.header_nav>
+<.live_component
+  :if={@live_action == :manage_cycles}
+  module={CyclesComponent}
+  id={:school_cycles}
+  current_user={@current_user}
+  params={@params}
+  is_school_manager={@is_school_manager}
+/>
+<.live_component
+  :if={@live_action == :manage_moment_cards_templates}
+  module={MomentCardsTemplatesComponent}
+  id={:school_moment_cards_templates}
+  current_user={@current_user}
+  params={@params}
+  is_content_manager={@is_content_manager}
+/>

--- a/lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex
+++ b/lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex
@@ -64,6 +64,7 @@ defmodule LantternWeb.MomentLive.CardsComponent do
         moment_card={@moment_card}
         id="moment-card-overlay"
         on_cancel={JS.patch(~p"/strands/moment/#{@moment}/cards")}
+        current_user={@current_user}
         allow_edit
         notify_component={@myself}
       />

--- a/lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex
+++ b/lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex
@@ -7,7 +7,7 @@ defmodule LantternWeb.MomentLive.CardsComponent do
   import Lanttern.Utils, only: [swap: 3]
 
   # shared components
-  alias LantternWeb.LearningContext.MomentCardFormComponent
+  alias LantternWeb.LearningContext.MomentCardOverlayComponent
 
   @impl true
   def render(assigns) do
@@ -17,86 +17,92 @@ defmodule LantternWeb.MomentLive.CardsComponent do
         <p>
           <%= gettext("Use cards to add an extra layer of organization to moments") %>
         </p>
-        <.action
-          type="link"
-          patch={~p"/strands/moment/#{@moment}/cards?new=true"}
-          icon_name="hero-plus-circle-mini"
-        >
-          <%= gettext("New moment card") %>
-        </.action>
+        <div class="flex gap-4">
+          <.action
+            :if={@moment_cards_count > 1}
+            type="link"
+            patch={~p"/strands/moment/#{@moment}/cards?reorder=true"}
+            icon_name="hero-arrows-up-down-mini"
+          >
+            <%= gettext("Reorder") %>
+          </.action>
+          <.action
+            type="link"
+            patch={~p"/strands/moment/#{@moment}/cards?new=true"}
+            icon_name="hero-plus-circle-mini"
+          >
+            <%= gettext("New moment card") %>
+          </.action>
+        </div>
       </.action_bar>
-      <.responsive_container class="py-10">
-        <%= if @moment_cards_length == 0 do %>
+      <%= if @moment_cards_count == 0 do %>
+        <div class="p-4">
           <.card_base class="p-10">
             <.empty_state><%= gettext("No cards for this moment yet") %></.empty_state>
           </.card_base>
-        <% else %>
-          <div id="moment-cards" phx-update="stream">
-            <.sortable_card
-              :for={{dom_id, {moment_card, i}} <- @streams.indexed_moment_cards}
-              class="mt-6"
-              id={dom_id}
-              is_move_up_disabled={i == 0}
-              on_move_up={
-                JS.push("swap_card_position", value: %{from: i, to: i - 1}, target: @myself)
-              }
-              is_move_down_disabled={i + 1 == @moment_cards_length}
-              on_move_down={
-                JS.push("swap_card_position", value: %{from: i, to: i - 1}, target: @myself)
-              }
-            >
-              <div class="flex items-center gap-4">
-                <h5 class="font-display font-bold text-sm">
-                  <%= moment_card.name %>
-                </h5>
-                <.action
-                  type="link"
-                  patch={~p"/strands/moment/#{@moment}/cards?edit=#{moment_card.id}"}
-                  icon_name="hero-pencil-mini"
-                  theme="subtle"
-                >
-                  <%= gettext("Edit") %>
-                </.action>
-              </div>
-              <.markdown text={moment_card.description} class="mt-4" />
-            </.sortable_card>
-          </div>
-        <% end %>
-      </.responsive_container>
-      <.slide_over
+        </div>
+      <% else %>
+        <.responsive_grid id="moment-cards" phx-update="stream" class="p-4" is_full_width>
+          <.card_base :for={{dom_id, moment_card} <- @streams.moment_cards} id={dom_id} class="p-6">
+            <h5 class="font-display font-black text-base">
+              <.link
+                patch={~p"/strands/moment/#{@moment}/cards?moment_card_id=#{moment_card.id}"}
+                class="font-display font-black text-xl hover:text-ltrn-subtle"
+              >
+                <%= moment_card.name %>
+              </.link>
+            </h5>
+            <div class="mt-4 line-clamp-4">
+              <.markdown text={moment_card.description} />
+            </div>
+          </.card_base>
+        </.responsive_grid>
+      <% end %>
+      <.live_component
         :if={@moment_card}
-        id="moment-card-form-overlay"
-        show={true}
+        module={MomentCardOverlayComponent}
+        moment_card={@moment_card}
+        id="moment-card-overlay"
+        on_cancel={JS.patch(~p"/strands/moment/#{@moment}/cards")}
+        allow_edit
+        notify_component={@myself}
+      />
+      <.slide_over
+        :if={@is_reordering}
+        show
+        id="moment-cards-order-overlay"
         on_cancel={JS.patch(~p"/strands/moment/#{@moment}/cards")}
       >
-        <:title><%= gettext("Moment card") %></:title>
-        <.live_component
-          module={MomentCardFormComponent}
-          id={@moment_card.id || :new}
-          notify_component={@myself}
-          moment_card={@moment_card}
-          navigate={~p"/strands/moment/#{@moment}/cards"}
-        />
-        <:actions_left :if={@moment_card.id}>
-          <.button
-            type="button"
-            theme="ghost"
-            phx-click="delete_card"
-            phx-target={@myself}
-            data-confirm={gettext("Are you sure?")}
+        <:title><%= gettext("Moment cards order") %></:title>
+        <ol>
+          <li
+            :for={{moment_card, i} <- @sortable_moment_cards}
+            id={"sortable-moment-card-#{moment_card.id}"}
+            class="mb-4"
           >
-            <%= gettext("Delete") %>
-          </.button>
-        </:actions_left>
+            <.sortable_card
+              is_move_up_disabled={i == 0}
+              on_move_up={
+                JS.push("set_moment_card_position", value: %{from: i, to: i - 1}, target: @myself)
+              }
+              is_move_down_disabled={i + 1 == @moment_cards_count}
+              on_move_down={
+                JS.push("set_moment_card_position", value: %{from: i, to: i + 1}, target: @myself)
+              }
+            >
+              <%= "#{i + 1}. #{moment_card.name}" %>
+            </.sortable_card>
+          </li>
+        </ol>
         <:actions>
           <.button
             type="button"
             theme="ghost"
-            phx-click={JS.exec("data-cancel", to: "#moment-card-form-overlay")}
+            phx-click={JS.exec("data-cancel", to: "#moment-cards-order-overlay")}
           >
             <%= gettext("Cancel") %>
           </.button>
-          <.button type="submit" form="moment-card-form" phx-disable-with={gettext("Saving...")}>
+          <.button type="button" phx-click="save_order" phx-target={@myself}>
             <%= gettext("Save") %>
           </.button>
         </:actions>
@@ -122,12 +128,39 @@ defmodule LantternWeb.MomentLive.CardsComponent do
   end
 
   @impl true
+  def update(%{action: {MomentCardOverlayComponent, {:created, moment_card}}}, socket) do
+    socket =
+      socket
+      |> stream_insert(:moment_cards, moment_card)
+      |> assign(:moment_cards_count, socket.assigns.moment_cards_count + 1)
+      |> assign(:moment_cards_ids, [moment_card.id | socket.assigns.moment_cards_ids])
+
+    {:ok, socket}
+  end
+
+  def update(%{action: {MomentCardOverlayComponent, {:updated, moment_card}}}, socket),
+    do: {:ok, stream_insert(socket, :moment_cards, moment_card)}
+
+  def update(%{action: {MomentCardOverlayComponent, {:deleted, moment_card}}}, socket) do
+    socket =
+      socket
+      |> stream_delete(:moment_cards, moment_card)
+      |> assign(:moment_cards_count, socket.assigns.moment_cards_count - 1)
+      |> assign(
+        :moment_cards_ids,
+        Enum.filter(socket.assigns.moment_cards_ids, &(&1 != moment_card.id))
+      )
+
+    {:ok, socket}
+  end
+
   def update(assigns, socket) do
     socket =
       socket
       |> assign(assigns)
       |> initialize()
       |> assign_moment_card()
+      |> assign_sortable_moment_cards()
 
     {:ok, socket}
   end
@@ -145,15 +178,15 @@ defmodule LantternWeb.MomentLive.CardsComponent do
       LearningContext.list_moment_cards(moments_ids: [socket.assigns.moment.id])
 
     socket
-    |> stream(:indexed_moment_cards, Enum.with_index(moment_cards), reset: true)
-    |> assign(:moment_cards_length, length(moment_cards))
+    |> stream(:moment_cards, moment_cards)
+    |> assign(:moment_cards_count, length(moment_cards))
     |> assign(:moment_cards_ids, Enum.map(moment_cards, & &1.id))
   end
 
   defp assign_moment_card(%{assigns: %{params: %{"new" => "true"}}} = socket),
     do: assign(socket, :moment_card, %MomentCard{moment_id: socket.assigns.moment.id})
 
-  defp assign_moment_card(%{assigns: %{params: %{"edit" => binary_id}}} = socket) do
+  defp assign_moment_card(%{assigns: %{params: %{"moment_card_id" => binary_id}}} = socket) do
     with {id, _} <- Integer.parse(binary_id),
          true <- id in socket.assigns.moment_cards_ids,
          %MomentCard{} = moment_card <- LearningContext.get_moment_card(id) do
@@ -166,36 +199,47 @@ defmodule LantternWeb.MomentLive.CardsComponent do
   defp assign_moment_card(socket),
     do: assign(socket, :moment_card, nil)
 
+  defp assign_sortable_moment_cards(%{assigns: %{params: %{"reorder" => "true"}}} = socket) do
+    moment_cards =
+      LearningContext.list_moment_cards(moments_ids: [socket.assigns.moment.id])
+      # remove unnecessary fields to save memory
+      |> Enum.map(&%MomentCard{id: &1.id, name: &1.name})
+
+    socket
+    |> assign(:sortable_moment_cards, Enum.with_index(moment_cards))
+    |> assign(:is_reordering, true)
+  end
+
+  defp assign_sortable_moment_cards(socket), do: assign(socket, :is_reordering, false)
+
   # event handlers
 
   @impl true
-  def handle_event("delete_card", _params, socket) do
-    case LearningContext.delete_moment_card(socket.assigns.moment_card) do
-      {:ok, _moment_card} ->
-        socket =
-          socket
-          |> push_navigate(to: ~p"/strands/moment/#{socket.assigns.moment}/cards")
-          |> put_flash(:info, gettext("Moment card deleted"))
+  def handle_event("set_moment_card_position", %{"from" => i, "to" => j}, socket) do
+    sortable_moment_cards =
+      socket.assigns.sortable_moment_cards
+      |> Enum.map(fn {mc, _i} -> mc end)
+      |> swap(i, j)
+      |> Enum.with_index()
 
-        {:noreply, socket}
-
-      {:error, _changeset} ->
-        # todo: handle error
-        {:noreply, socket}
-    end
+    {:noreply, assign(socket, :sortable_moment_cards, sortable_moment_cards)}
   end
 
-  def handle_event("swap_card_position", %{"from" => i, "to" => j}, socket) do
+  def handle_event("save_order", _, socket) do
     moment_cards_ids =
-      socket.assigns.moment_cards_ids
-      |> swap(i, j)
+      socket.assigns.sortable_moment_cards
+      |> Enum.map(fn {mc, _i} -> mc.id end)
 
     case LearningContext.update_moment_cards_positions(moment_cards_ids) do
       {:ok, _moment_cards} ->
-        {:noreply, stream_moment_cards(socket)}
+        socket =
+          socket
+          |> push_navigate(to: ~p"/strands/moment/#{socket.assigns.moment}/cards")
 
-      {:error, msg} ->
-        {:noreply, put_flash(socket, :error, msg)}
+        {:noreply, socket}
+
+      {:error, _} ->
+        {:noreply, socket}
     end
   end
 end

--- a/lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex
+++ b/lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex
@@ -59,6 +59,7 @@
     id="moment-details-cards"
     moment={@moment}
     params={@params}
+    current_user={@current_user}
   />
   <.live_component
     :if={@live_action == :notes}

--- a/lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex
@@ -5,6 +5,7 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
   ### Supported attrs/assigns
 
   - `moment_card` (required, `%MomentCard{}`)
+  - `current_user` (required, `%User{}`)
   - `on_cancel` (required, function)
   - `allow_edit` (required, boolean)
   - supports `notify` attrs (`notify_parent`, `notify_component`)
@@ -13,99 +14,172 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
   use LantternWeb, :live_component
 
   alias Lanttern.LearningContext
-  # alias Lanttern.SchoolConfig
+  alias Lanttern.LearningContext.MomentCard
+  alias Lanttern.SchoolConfig
 
   @impl true
   def render(assigns) do
     ~H"""
     <div>
       <.modal id={@id} show on_cancel={@on_cancel}>
-        <h5 class="mb-10 font-display font-black text-xl">
+        <h4 class="mb-10 font-display font-black text-xl">
           <%= case {@is_editing, @moment_card} do
-            {true, %{id: nil}} -> gettext("New moment card")
+            {_, %{id: nil}} -> gettext("New moment card")
             {true, _} -> gettext("Edit moment card")
             {false, %{name: name}} -> name
           end %>
-        </h5>
-        <%= if @is_editing && @allow_edit do %>
-          <.scroll_to_top overlay_id={@id} id="form-scroll-top" />
-          <.form
-            :if={@is_editing}
-            id="moment-card-form"
-            for={@form}
-            phx-change="validate"
-            phx-submit="save"
-            phx-target={@myself}
-          >
-            <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
-              <%= gettext("Oops, something went wrong! Please check the errors below.") %>
-            </.error_block>
-            <.input
-              field={@form[:name]}
-              type="text"
-              label={gettext("Name")}
-              class="mb-6"
-              phx-debounce="1500"
-            />
-            <.input
-              field={@form[:description]}
-              type="textarea"
-              label={gettext("Description")}
-              class="mb-1"
-              phx-debounce="1500"
-            />
-            <.markdown_supported class="mb-6" />
-            <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
-              <%= gettext("Oops, something went wrong! Please check the errors above.") %>
-            </.error_block>
-            <div class="flex items-center justify-end gap-6">
-              <.action
-                type="button"
-                theme="subtle"
-                size="md"
-                phx-click={
-                  if(is_nil(@moment_card.id),
-                    do: JS.exec("data-cancel", to: "##{@id}"),
-                    else: JS.push("cancel_edit", target: @myself)
-                  )
-                }
-              >
-                <%= gettext("Cancel") %>
-              </.action>
-              <.action type="submit" theme="primary" size="md" icon_name="hero-check">
-                <%= gettext("Save") %>
-              </.action>
-            </div>
-          </.form>
-        <% else %>
-          <.scroll_to_top overlay_id={@id} id="details-scroll-top" />
-          <.markdown text={@moment_card.description} class="mt-6" />
-          <%= if @is_deleted do %>
-            <.error_block class="mt-10">
-              <%= gettext("This card was deleted") %>
-            </.error_block>
-          <% else %>
-            <div :if={@allow_edit} class="flex justify-between gap-4 mt-10">
-              <.action
-                type="button"
-                icon_name="hero-x-circle-mini"
-                phx-click={JS.push("delete", target: @myself)}
-                theme="subtle"
-                data-confirm={gettext("Are you sure?")}
-              >
-                <%= gettext("Delete") %>
-              </.action>
-              <.action
-                type="button"
-                icon_name="hero-pencil-mini"
-                phx-click={JS.push("edit", target: @myself)}
-              >
-                <%= gettext("Edit card") %>
-              </.action>
-            </div>
-          <% end %>
-        <% end %>
+        </h4>
+        <.main
+          id={@id}
+          is_selecting_template={@is_selecting_template}
+          is_editing={@is_editing}
+          allow_edit={@allow_edit}
+          is_deleted={@is_deleted}
+          templates={@streams.templates}
+          template_instructions={@template_instructions}
+          form={@form}
+          moment_card={@moment_card}
+          myself={@myself}
+        />
       </.modal>
+    </div>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :is_selecting_template, :boolean, required: true
+  attr :is_editing, :boolean, required: true
+  attr :allow_edit, :boolean, required: true
+  attr :is_deleted, :boolean, required: true
+  attr :templates, :any, required: true, doc: "the templates stream"
+  attr :template_instructions, :string, required: true
+  attr :form, :any, required: true
+  attr :moment_card, MomentCard, required: true
+  attr :myself, Phoenix.LiveComponent.CID, required: true
+
+  def main(%{is_selecting_template: true} = assigns) do
+    ~H"""
+    <p><%= gettext("Select a template from the list below to create the card") %></p>
+    <.card_base class="p-4 mt-6">
+      <div class="flex items-center gap-4">
+        <p class="flex-1 font-bold text-base">
+          <%= gettext("Create a new moment card from scratch") %>
+        </p>
+        <.action
+          type="button"
+          icon_name="hero-arrow-right-mini"
+          phx-click={JS.push("select_blank_template", target: @myself)}
+        >
+          <%= gettext("Select") %>
+        </.action>
+      </div>
+    </.card_base>
+    <div id="templates-list" phx-update="stream">
+      <.card_base :for={{dom_id, template} <- @templates} id={dom_id} class="p-4 mt-6">
+        <div class="flex items-center gap-4">
+          <p class="flex-1 font-bold text-base">
+            <%= template.name %>
+          </p>
+          <.action
+            type="button"
+            icon_name="hero-arrow-right-mini"
+            phx-click={
+              JS.push("select_template",
+                value: %{"template" => template.template, "instructions" => template.instructions},
+                target: @myself
+              )
+            }
+          >
+            <%= gettext("Select") %>
+          </.action>
+        </div>
+      </.card_base>
+    </div>
+    """
+  end
+
+  def main(%{is_editing: true, allow_edit: true} = assigns) do
+    ~H"""
+    <.scroll_to_top overlay_id={@id} id="form-scroll-top" />
+    <.form
+      id="moment-card-form"
+      for={@form}
+      phx-change="validate"
+      phx-submit="save"
+      phx-target={@myself}
+    >
+      <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
+        <%= gettext("Oops, something went wrong! Please check the errors below.") %>
+      </.error_block>
+      <.input
+        field={@form[:name]}
+        type="text"
+        label={gettext("Name")}
+        class="mb-6"
+        phx-debounce="1500"
+      />
+      <.input
+        field={@form[:description]}
+        type="textarea"
+        label={gettext("Description")}
+        class="mb-1"
+        phx-debounce="1500"
+      />
+      <.markdown_supported class="mb-6" />
+      <div
+        :if={@template_instructions}
+        class="p-4 border border-ltrn-teacher-accent rounded-sm mb-6 bg-ltrn-teacher-lightest"
+      >
+        <h6 class="font-display font-black font-lg text-ltrn-teacher-dark">
+          <%= gettext("Template instructions") %>
+        </h6>
+        <.markdown text={@template_instructions} class="mt-4" />
+      </div>
+      <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
+        <%= gettext("Oops, something went wrong! Please check the errors above.") %>
+      </.error_block>
+      <div class="flex items-center justify-end gap-6">
+        <.action
+          type="button"
+          theme="subtle"
+          size="md"
+          phx-click={
+            if(is_nil(@moment_card.id),
+              do: JS.exec("data-cancel", to: "##{@id}"),
+              else: JS.push("cancel_edit", target: @myself)
+            )
+          }
+        >
+          <%= gettext("Cancel") %>
+        </.action>
+        <.action type="submit" theme="primary" size="md" icon_name="hero-check">
+          <%= gettext("Save") %>
+        </.action>
+      </div>
+    </.form>
+    """
+  end
+
+  def main(assigns) do
+    ~H"""
+    <.scroll_to_top overlay_id={@id} id="details-scroll-top" />
+    <.markdown text={@moment_card.description} class="mt-6" />
+    <.error_block :if={@is_deleted} class="mt-10">
+      <%= gettext("This card was deleted") %>
+    </.error_block>
+    <div :if={!@is_deleted && @allow_edit} class="flex justify-between gap-4 mt-10">
+      <.action
+        type="button"
+        icon_name="hero-x-circle-mini"
+        phx-click={JS.push("delete", target: @myself)}
+        theme="subtle"
+        data-confirm={gettext("Are you sure?")}
+      >
+        <%= gettext("Delete") %>
+      </.action>
+      <.action type="button" icon_name="hero-pencil-mini" phx-click={JS.push("edit", target: @myself)}>
+        <%= gettext("Edit card") %>
+      </.action>
     </div>
     """
   end
@@ -114,6 +188,9 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
   def mount(socket) do
     socket =
       socket
+      |> assign(:form, nil)
+      |> assign(:template_instructions, nil)
+      |> assign(:is_editing, false)
       |> assign(:is_deleted, false)
       |> assign(:allow_edit, false)
       |> assign(:initialized, false)
@@ -126,20 +203,42 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
     socket =
       socket
       |> assign(assigns)
-      |> assign_initial_is_editing()
-      |> assign(:initialized, false)
+      |> initialize()
 
     {:ok, socket}
   end
 
-  defp assign_initial_is_editing(%{assigns: %{moment_card: %{id: nil}}} = socket) do
+  defp initialize(socket) do
     socket
-    |> assign_form()
-    |> assign(:is_editing, true)
+    |> stream_templates()
+    |> assign(:initialized, true)
   end
 
-  defp assign_initial_is_editing(socket),
-    do: assign(socket, :is_editing, false)
+  defp stream_templates(%{assigns: %{moment_card: %{id: nil}}} = socket) do
+    templates =
+      SchoolConfig.list_moment_cards_templates(
+        school_id: socket.assigns.current_user.current_profile.school_id
+      )
+
+    if templates == [] do
+      # skip template selection if there's no template registered
+      socket
+      |> stream(:templates, [])
+      |> assign(:is_selecting_template, false)
+      |> assign_form()
+      |> assign(:is_editing, true)
+    else
+      socket
+      |> stream(:templates, templates)
+      |> assign(:is_selecting_template, true)
+    end
+  end
+
+  defp stream_templates(socket) do
+    socket
+    |> stream(:templates, [])
+    |> assign(:is_selecting_template, false)
+  end
 
   defp assign_form(socket) do
     changeset = LearningContext.change_moment_card(socket.assigns.moment_card)
@@ -151,6 +250,38 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
   # event handlers
 
   @impl true
+  def handle_event("select_blank_template", _params, socket) do
+    socket =
+      socket
+      |> assign_form()
+      |> assign(:is_selecting_template, false)
+      |> assign(:is_editing, true)
+
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "select_template",
+        %{"template" => template, "instructions" => instructions},
+        socket
+      ) do
+    moment_card =
+      %{
+        socket.assigns.moment_card
+        | description: template
+      }
+
+    socket =
+      socket
+      |> assign(:moment_card, moment_card)
+      |> assign(:template_instructions, instructions)
+      |> assign_form()
+      |> assign(:is_selecting_template, false)
+      |> assign(:is_editing, true)
+
+    {:noreply, socket}
+  end
+
   def handle_event("edit", _, socket) do
     socket =
       socket

--- a/lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex
@@ -1,0 +1,250 @@
+defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
+  @moduledoc """
+  Renders an overlay with `MomentCard` details and editing support.
+
+  ### Supported attrs/assigns
+
+  - `moment_card` (required, `%MomentCard{}`)
+  - `on_cancel` (required, function)
+  - `allow_edit` (required, boolean)
+  - supports `notify` attrs (`notify_parent`, `notify_component`)
+  """
+
+  use LantternWeb, :live_component
+
+  alias Lanttern.LearningContext
+  # alias Lanttern.SchoolConfig
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.modal id={@id} show on_cancel={@on_cancel}>
+        <h5 class="mb-10 font-display font-black text-xl">
+          <%= case {@is_editing, @moment_card} do
+            {true, %{id: nil}} -> gettext("New moment card")
+            {true, _} -> gettext("Edit moment card")
+            {false, %{name: name}} -> name
+          end %>
+        </h5>
+        <%= if @is_editing && @allow_edit do %>
+          <.scroll_to_top overlay_id={@id} id="form-scroll-top" />
+          <.form
+            :if={@is_editing}
+            id="moment-card-form"
+            for={@form}
+            phx-change="validate"
+            phx-submit="save"
+            phx-target={@myself}
+          >
+            <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
+              <%= gettext("Oops, something went wrong! Please check the errors below.") %>
+            </.error_block>
+            <.input
+              field={@form[:name]}
+              type="text"
+              label={gettext("Name")}
+              class="mb-6"
+              phx-debounce="1500"
+            />
+            <.input
+              field={@form[:description]}
+              type="textarea"
+              label={gettext("Description")}
+              class="mb-1"
+              phx-debounce="1500"
+            />
+            <.markdown_supported class="mb-6" />
+            <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
+              <%= gettext("Oops, something went wrong! Please check the errors above.") %>
+            </.error_block>
+            <div class="flex items-center justify-end gap-6">
+              <.action
+                type="button"
+                theme="subtle"
+                size="md"
+                phx-click={
+                  if(is_nil(@moment_card.id),
+                    do: JS.exec("data-cancel", to: "##{@id}"),
+                    else: JS.push("cancel_edit", target: @myself)
+                  )
+                }
+              >
+                <%= gettext("Cancel") %>
+              </.action>
+              <.action type="submit" theme="primary" size="md" icon_name="hero-check">
+                <%= gettext("Save") %>
+              </.action>
+            </div>
+          </.form>
+        <% else %>
+          <.scroll_to_top overlay_id={@id} id="details-scroll-top" />
+          <.markdown text={@moment_card.description} class="mt-6" />
+          <%= if @is_deleted do %>
+            <.error_block class="mt-10">
+              <%= gettext("This card was deleted") %>
+            </.error_block>
+          <% else %>
+            <div :if={@allow_edit} class="flex justify-between gap-4 mt-10">
+              <.action
+                type="button"
+                icon_name="hero-x-circle-mini"
+                phx-click={JS.push("delete", target: @myself)}
+                theme="subtle"
+                data-confirm={gettext("Are you sure?")}
+              >
+                <%= gettext("Delete") %>
+              </.action>
+              <.action
+                type="button"
+                icon_name="hero-pencil-mini"
+                phx-click={JS.push("edit", target: @myself)}
+              >
+                <%= gettext("Edit card") %>
+              </.action>
+            </div>
+          <% end %>
+        <% end %>
+      </.modal>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(socket) do
+    socket =
+      socket
+      |> assign(:is_deleted, false)
+      |> assign(:allow_edit, false)
+      |> assign(:initialized, false)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign_initial_is_editing()
+      |> assign(:initialized, false)
+
+    {:ok, socket}
+  end
+
+  defp assign_initial_is_editing(%{assigns: %{moment_card: %{id: nil}}} = socket) do
+    socket
+    |> assign_form()
+    |> assign(:is_editing, true)
+  end
+
+  defp assign_initial_is_editing(socket),
+    do: assign(socket, :is_editing, false)
+
+  defp assign_form(socket) do
+    changeset = LearningContext.change_moment_card(socket.assigns.moment_card)
+
+    socket
+    |> assign(:form, to_form(changeset))
+  end
+
+  # event handlers
+
+  @impl true
+  def handle_event("edit", _, socket) do
+    socket =
+      socket
+      |> assign_form()
+      |> assign(:is_editing, true)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("cancel_edit", _, socket),
+    do: {:noreply, assign(socket, :is_editing, false)}
+
+  def handle_event("validate", %{"moment_card" => moment_card_params}, socket),
+    do: {:noreply, assign_validated_form(socket, moment_card_params)}
+
+  def handle_event("save", %{"moment_card" => moment_card_params}, socket) do
+    save_moment_card(
+      socket,
+      socket.assigns.moment_card.id,
+      moment_card_params
+    )
+  end
+
+  def handle_event("delete", _, socket) do
+    LearningContext.delete_moment_card(socket.assigns.moment_card)
+    |> case do
+      {:ok, _moment_card} ->
+        # we notify using the assigned moment card
+        notify(__MODULE__, {:deleted, socket.assigns.moment_card}, socket.assigns)
+
+        socket =
+          socket
+          |> assign(:is_deleted, true)
+
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp assign_validated_form(socket, params) do
+    changeset =
+      socket.assigns.moment_card
+      |> LearningContext.change_moment_card(params)
+      |> Map.put(:action, :validate)
+
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp save_moment_card(socket, nil, moment_card_params) do
+    # inject moment id to params
+    moment_card_params =
+      Map.put_new(
+        moment_card_params,
+        "moment_id",
+        socket.assigns.moment_card.moment_id
+      )
+
+    LearningContext.create_moment_card(moment_card_params)
+    |> case do
+      {:ok, moment_card} ->
+        notify(__MODULE__, {:created, moment_card}, socket.assigns)
+
+        socket =
+          socket
+          |> assign(:moment_card, moment_card)
+          |> assign(:is_editing, false)
+
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp save_moment_card(socket, _id, moment_card_params) do
+    LearningContext.update_moment_card(
+      socket.assigns.moment_card,
+      moment_card_params
+    )
+    |> case do
+      {:ok, moment_card} ->
+        notify(__MODULE__, {:updated, moment_card}, socket.assigns)
+
+        socket =
+          socket
+          |> assign(:moment_card, moment_card)
+          |> assign(:is_editing, false)
+
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+end

--- a/lib/lanttern_web/live/shared/menu_component.ex
+++ b/lib/lanttern_web/live/shared/menu_component.ex
@@ -372,6 +372,9 @@ defmodule LantternWeb.MenuComponent do
     LantternWeb.GradesReportsLive => :grades_reports,
     LantternWeb.GradesReportLive => :grades_reports,
 
+    # school config
+    LantternWeb.SchoolConfigLive => :school_config,
+
     # guardian home
     LantternWeb.GuardianHomeLive => :student_report_card,
 
@@ -424,7 +427,12 @@ defmodule LantternWeb.MenuComponent do
         text: gettext("Students records"),
         permission: "wcd"
       },
-      %{profile: "teacher", active: :school, path: ~p"/school", text: gettext("School")},
+      %{
+        profile: "teacher",
+        active: :school,
+        path: ~p"/school",
+        text: gettext("Students and classes")
+      },
       # %{profile: "teacher", active: :rubrics, path: ~p"/rubrics", text: gettext("Rubrics")},
       %{
         profile: "teacher",
@@ -443,6 +451,12 @@ defmodule LantternWeb.MenuComponent do
         active: :grades_reports,
         path: ~p"/grades_reports",
         text: gettext("Grades reports")
+      },
+      %{
+        profile: "teacher",
+        active: :school_config,
+        path: ~p"/school_config/cycles",
+        text: gettext("School config")
       },
       # student
       %{

--- a/lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex
@@ -1,0 +1,259 @@
+defmodule LantternWeb.SchoolConfig.MomentCardTemplateOverlayComponent do
+  @moduledoc """
+  Renders an overlay with `MomentCardTemplate` details and editing support.
+
+  ### Supported attrs/assigns
+
+  - `moment_card_template` (required, `%MomentCardTemplate{}`)
+  - `on_cancel` (required, function)
+  - `allow_edit` (required, boolean)
+  - supports `notify` attrs (`notify_parent`, `notify_component`)
+  """
+
+  use LantternWeb, :live_component
+
+  alias Lanttern.SchoolConfig
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.modal id={@id} show on_cancel={@on_cancel}>
+        <h5 class="mb-10 font-display font-black text-xl">
+          <%= case {@is_editing, @moment_card_template} do
+            {true, %{id: nil}} -> gettext("New moment card template")
+            {true, _} -> gettext("Edit moment card template")
+            {false, %{name: name}} -> name
+          end %>
+        </h5>
+        <%= if @is_editing && @allow_edit do %>
+          <.scroll_to_top overlay_id={@id} id="form-scroll-top" />
+          <.form
+            :if={@is_editing}
+            id="moment-card-template-form"
+            for={@form}
+            phx-change="validate"
+            phx-submit="save"
+            phx-target={@myself}
+          >
+            <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
+              <%= gettext("Oops, something went wrong! Please check the errors below.") %>
+            </.error_block>
+            <.input
+              field={@form[:name]}
+              type="text"
+              label={gettext("Name")}
+              class="mb-6"
+              phx-debounce="1500"
+            />
+            <.input
+              field={@form[:template]}
+              type="textarea"
+              label={gettext("Template")}
+              class="mb-1"
+              phx-debounce="1500"
+            />
+            <.markdown_supported class="mb-6" />
+            <.input
+              field={@form[:instructions]}
+              type="textarea"
+              label={gettext("Additional instructions")}
+              class="mb-1"
+              phx-debounce="1500"
+              show_optional
+            />
+            <.markdown_supported class="mb-6" />
+            <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
+              <%= gettext("Oops, something went wrong! Please check the errors above.") %>
+            </.error_block>
+            <div class="flex items-center justify-end gap-6">
+              <.action
+                type="button"
+                theme="subtle"
+                size="md"
+                phx-click={
+                  if(is_nil(@moment_card_template.id),
+                    do: JS.exec("data-cancel", to: "##{@id}"),
+                    else: JS.push("cancel_edit", target: @myself)
+                  )
+                }
+              >
+                <%= gettext("Cancel") %>
+              </.action>
+              <.action type="submit" theme="primary" size="md" icon_name="hero-check">
+                <%= gettext("Save") %>
+              </.action>
+            </div>
+          </.form>
+        <% else %>
+          <.scroll_to_top overlay_id={@id} id="details-scroll-top" />
+          <.markdown text={@moment_card_template.template} class="mt-6" />
+          <.markdown text={@moment_card_template.instructions} class="mt-6" />
+          <%= if @is_deleted do %>
+            <.error_block class="mt-10">
+              <%= gettext("This template was deleted") %>
+            </.error_block>
+          <% else %>
+            <div :if={@allow_edit} class="flex justify-between gap-4 mt-10">
+              <.action
+                type="button"
+                icon_name="hero-x-circle-mini"
+                phx-click={JS.push("delete", target: @myself)}
+                theme="subtle"
+                data-confirm={gettext("Are you sure?")}
+              >
+                <%= gettext("Delete") %>
+              </.action>
+              <.action
+                type="button"
+                icon_name="hero-pencil-mini"
+                phx-click={JS.push("edit", target: @myself)}
+              >
+                <%= gettext("Edit template") %>
+              </.action>
+            </div>
+          <% end %>
+        <% end %>
+      </.modal>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(socket) do
+    socket =
+      socket
+      |> assign(:is_deleted, false)
+      |> assign(:allow_edit, false)
+      |> assign(:initialized, false)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign_initial_is_editing()
+      |> assign(:initialized, false)
+
+    {:ok, socket}
+  end
+
+  defp assign_initial_is_editing(%{assigns: %{moment_card_template: %{id: nil}}} = socket) do
+    socket
+    |> assign_form()
+    |> assign(:is_editing, true)
+  end
+
+  defp assign_initial_is_editing(socket),
+    do: assign(socket, :is_editing, false)
+
+  defp assign_form(socket) do
+    changeset = SchoolConfig.change_moment_card_template(socket.assigns.moment_card_template)
+
+    socket
+    |> assign(:form, to_form(changeset))
+  end
+
+  # event handlers
+
+  @impl true
+  def handle_event("edit", _, socket) do
+    socket =
+      socket
+      |> assign_form()
+      |> assign(:is_editing, true)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("cancel_edit", _, socket),
+    do: {:noreply, assign(socket, :is_editing, false)}
+
+  def handle_event("validate", %{"moment_card_template" => moment_card_template_params}, socket),
+    do: {:noreply, assign_validated_form(socket, moment_card_template_params)}
+
+  def handle_event("save", %{"moment_card_template" => moment_card_template_params}, socket) do
+    save_moment_card_template(
+      socket,
+      socket.assigns.moment_card_template.id,
+      moment_card_template_params
+    )
+  end
+
+  def handle_event("delete", _, socket) do
+    SchoolConfig.delete_moment_card_template(socket.assigns.moment_card_template)
+    |> case do
+      {:ok, _moment_card_template} ->
+        # we notify using the assigned moment card template
+        notify(__MODULE__, {:deleted, socket.assigns.moment_card_template}, socket.assigns)
+
+        socket =
+          socket
+          |> assign(:is_deleted, true)
+
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp assign_validated_form(socket, params) do
+    changeset =
+      socket.assigns.moment_card_template
+      |> SchoolConfig.change_moment_card_template(params)
+      |> Map.put(:action, :validate)
+
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp save_moment_card_template(socket, nil, moment_card_template_params) do
+    # inject school id to params
+    moment_card_template_params =
+      Map.put_new(
+        moment_card_template_params,
+        "school_id",
+        socket.assigns.moment_card_template.school_id
+      )
+
+    SchoolConfig.create_moment_card_template(moment_card_template_params)
+    |> case do
+      {:ok, moment_card_template} ->
+        notify(__MODULE__, {:created, moment_card_template}, socket.assigns)
+
+        socket =
+          socket
+          |> assign(:moment_card_template, moment_card_template)
+          |> assign(:is_editing, false)
+
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp save_moment_card_template(socket, _id, moment_card_template_params) do
+    SchoolConfig.update_moment_card_template(
+      socket.assigns.moment_card_template,
+      moment_card_template_params
+    )
+    |> case do
+      {:ok, moment_card_template} ->
+        notify(__MODULE__, {:updated, moment_card_template}, socket.assigns)
+
+        socket =
+          socket
+          |> assign(:moment_card_template, moment_card_template)
+          |> assign(:is_editing, false)
+
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+end

--- a/lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex
@@ -143,10 +143,15 @@ defmodule LantternWeb.SchoolConfig.MomentCardTemplateOverlayComponent do
     socket =
       socket
       |> assign(assigns)
-      |> assign_initial_is_editing()
-      |> assign(:initialized, false)
+      |> initialize()
 
     {:ok, socket}
+  end
+
+  defp initialize(socket) do
+    socket
+    |> assign_initial_is_editing()
+    |> assign(:initialized, true)
   end
 
   defp assign_initial_is_editing(%{assigns: %{moment_card_template: %{id: nil}}} = socket) do

--- a/lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex
@@ -23,7 +23,7 @@ defmodule LantternWeb.SchoolConfig.MomentCardTemplateOverlayComponent do
           <%= case {@is_editing, @moment_card_template} do
             {true, %{id: nil}} -> gettext("New moment card template")
             {true, _} -> gettext("Edit moment card template")
-            {false, %{name: name}} -> name
+            {false, %{name: name}} -> gettext("Template: %{template}", template: name)
           end %>
         </h5>
         <%= if @is_editing && @allow_edit do %>
@@ -88,7 +88,15 @@ defmodule LantternWeb.SchoolConfig.MomentCardTemplateOverlayComponent do
         <% else %>
           <.scroll_to_top overlay_id={@id} id="details-scroll-top" />
           <.markdown text={@moment_card_template.template} class="mt-6" />
-          <.markdown text={@moment_card_template.instructions} class="mt-6" />
+          <div
+            :if={@moment_card_template.instructions}
+            class="p-4 border border-ltrn-teacher-accent rounded-sm mt-10 bg-ltrn-teacher-lightest"
+          >
+            <h6 class="font-display font-black font-lg text-ltrn-teacher-dark">
+              <%= gettext("Additional teacher instructions") %>
+            </h6>
+            <.markdown text={@moment_card_template.instructions} class="mt-6" />
+          </div>
           <%= if @is_deleted do %>
             <.error_block class="mt-10">
               <%= gettext("This template was deleted") %>

--- a/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
@@ -243,19 +243,6 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
     """
   end
 
-  attr :id, :string, required: true
-  attr :overlay_id, :string, required: true
-
-  defp scroll_to_top(assigns) do
-    ~H"""
-    <div
-      id={@id}
-      phx-hook="ScrollToTop"
-      data-scroll-to-selector={"##{@overlay_id} *[aria-modal=true]"}
-    />
-    """
-  end
-
   @impl true
   def mount(socket) do
     socket =

--- a/lib/lanttern_web/router.ex
+++ b/lib/lanttern_web/router.ex
@@ -72,7 +72,6 @@ defmodule LantternWeb.Router do
       live "/school", SchoolLive, :show
       live "/school/students", SchoolLive, :manage_students
       live "/school/classes", SchoolLive, :manage_classes
-      live "/school/cycles", SchoolLive, :manage_cycles
 
       live "/school/students/:id", StudentLive, :show
       live "/school/students/:id/report_cards", StudentLive, :report_cards
@@ -129,6 +128,14 @@ defmodule LantternWeb.Router do
       # students records
 
       live "/students_records", StudentsRecordsLive, :index
+
+      # school config
+
+      live "/school_config/cycles", SchoolConfigLive, :manage_cycles
+
+      live "/school_config/moment_cards_templates",
+           SchoolConfigLive,
+           :manage_moment_cards_templates
     end
 
     live_session :authenticated_guardian,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2025.1.10-alpha.40",
+      version: "2025.1.21-alpha.41",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12,8 +12,8 @@ msgid ""
 msgstr ""
 
 #: lib/lanttern_web/components/core_components.ex:770
-#: lib/lanttern_web/components/core_components.ex:1792
-#: lib/lanttern_web/components/core_components.ex:1854
+#: lib/lanttern_web/components/core_components.ex:1808
+#: lib/lanttern_web/components/core_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -25,13 +25,13 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:2
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:433
+#: lib/lanttern_web/live/shared/menu_component.ex:441
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:418
+#: lib/lanttern_web/live/shared/menu_component.ex:421
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -43,7 +43,6 @@ msgid "Rubrics"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:3
-#: lib/lanttern_web/live/shared/menu_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
@@ -56,8 +55,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:419
-#: lib/lanttern_web/live/shared/menu_component.ex:458
+#: lib/lanttern_web/live/shared/menu_component.ex:422
+#: lib/lanttern_web/live/shared/menu_component.ex:472
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr ""
@@ -109,6 +108,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:182
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:120
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:103
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:107
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:176
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:91
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:136
@@ -117,8 +117,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:101
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:117
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:162
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:97
-#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:102
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:104
+#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:103
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:94
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:269
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:114
@@ -128,8 +128,10 @@ msgstr ""
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:64
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:66
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:153
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:51
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:71
@@ -166,6 +168,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:185
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:106
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:110
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:179
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:94
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:139
@@ -174,15 +177,17 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:104
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:120
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:165
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:100
-#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:105
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:107
+#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:161
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:69
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:117
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:67
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:69
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:156
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:53
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:116
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:61
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:74
@@ -213,6 +218,7 @@ msgid "Your starred strands"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:46
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:124
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:43
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:51
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:62
@@ -232,9 +238,11 @@ msgstr ""
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:33
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:31
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:39
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:36
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:35
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:55
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:45
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:44
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:45
@@ -256,8 +264,10 @@ msgstr ""
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:26
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:26
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:22
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:112
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:21
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:27
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:40
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:29
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:26
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
@@ -278,7 +288,6 @@ msgid "Save Strand"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:178
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:99
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:116
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:87
@@ -396,9 +405,10 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:43
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:196
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:108
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:88
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:57
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:178
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:66
@@ -458,12 +468,13 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:194
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:106
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:186
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:86
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:43
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:149
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:55
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:176
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:64
@@ -506,7 +517,6 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:305
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:69
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:233
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:58
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:258
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -533,8 +543,10 @@ msgid "No assessment points for this strand yet"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:27
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:32
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:26
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:45
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "Reorder"
 msgstr ""
@@ -744,7 +756,7 @@ msgid "Curriculum item already added to this strand"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:35
-#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:88
+#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Edit moment"
 msgstr ""
@@ -791,7 +803,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1742
+#: lib/lanttern_web/components/core_components.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -812,7 +824,7 @@ msgid "Save moment"
 msgstr ""
 
 #: lib/lanttern/learning_context.ex:672
-#: lib/lanttern/repo_helpers.ex:182
+#: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:243
@@ -1009,7 +1021,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:9
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:65
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:27
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:31
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:34
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:23
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:25
@@ -1204,7 +1216,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:20
-#: lib/lanttern_web/live/shared/menu_component.ex:445
+#: lib/lanttern_web/live/shared/menu_component.ex:453
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr ""
@@ -1251,11 +1263,6 @@ msgstr ""
 msgid "List of report cards linked to this strand."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:72
-#, elixir-autogen, elixir-format
-msgid "Moment card"
-msgstr ""
-
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:120
 #, elixir-autogen, elixir-format
 msgid "Moment card created successfully"
@@ -1271,7 +1278,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1732
+#: lib/lanttern_web/components/core_components.ex:1748
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1292,7 +1299,7 @@ msgstr ""
 msgid "No assessment point entries for this grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:31
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "No cards for this moment yet"
 msgstr ""
@@ -1407,9 +1414,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:14
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:115
-#: lib/lanttern_web/live/shared/menu_component.ex:439
-#: lib/lanttern_web/live/shared/menu_component.ex:452
-#: lib/lanttern_web/live/shared/menu_component.ex:465
+#: lib/lanttern_web/live/shared/menu_component.ex:447
+#: lib/lanttern_web/live/shared/menu_component.ex:466
+#: lib/lanttern_web/live/shared/menu_component.ex:479
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr ""
@@ -2714,7 +2721,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/students_records/students_records_live.ex:29
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:3
-#: lib/lanttern_web/live/shared/menu_component.ex:424
+#: lib/lanttern_web/live/shared/menu_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "Students records"
 msgstr ""
@@ -3061,7 +3068,7 @@ msgstr ""
 msgid "A grades report for the same cycle and year already exists"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:16
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:20
 #, elixir-autogen, elixir-format
 msgid "Add cycle"
 msgstr ""
@@ -3132,7 +3139,7 @@ msgstr ""
 msgid "Cover image"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:163
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Create cycle"
 msgstr ""
@@ -3145,17 +3152,17 @@ msgstr ""
 #: lib/lanttern_web/live/pages/guardian/guardian_home_live.ex:127
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:127
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:164
-#: lib/lanttern_web/live/shared/menu_component.ex:532
+#: lib/lanttern_web/live/shared/menu_component.ex:546
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:88
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cycle created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:111
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:115
 #, elixir-autogen, elixir-format
 msgid "Cycle deleted successfully"
 msgstr ""
@@ -3165,12 +3172,12 @@ msgstr ""
 msgid "Cycle name"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:97
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:101
 #, elixir-autogen, elixir-format
 msgid "Cycle updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/school_live.html.heex:14
+#: lib/lanttern_web/live/pages/school_config/school_config_live.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Cycles"
 msgstr ""
@@ -3180,8 +3187,8 @@ msgstr ""
 msgid "Delete moment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:48
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:174
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:52
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:178
 #, elixir-autogen, elixir-format
 msgid "Edit cycle"
 msgstr ""
@@ -3206,7 +3213,7 @@ msgstr ""
 msgid "Edit strand to add a cover image"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:42
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:46
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "End at"
@@ -3273,11 +3280,6 @@ msgstr ""
 msgid "Loading profiles"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:178
-#, elixir-autogen, elixir-format
-msgid "Moment card deleted"
-msgstr ""
-
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:22
 #, elixir-autogen, elixir-format
 msgid "Moment of %{strand}"
@@ -3308,7 +3310,8 @@ msgstr ""
 msgid "New grades report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:25
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:34
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "New moment card"
 msgstr ""
@@ -3329,12 +3332,12 @@ msgstr ""
 msgid "No cycle selected"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:24
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:28
 #, elixir-autogen, elixir-format
 msgid "No cycles found in this school."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:61
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "No cycles in this school"
 msgstr ""
@@ -3476,7 +3479,7 @@ msgstr ""
 msgid "Starred strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:39
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:43
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Start at"
@@ -3666,4 +3669,131 @@ msgstr ""
 #: lib/lanttern_web/components/form_components.ex:722
 #, elixir-autogen, elixir-format
 msgid "Upload profile picture"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/school_config_live.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "%{school} config"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:40
+#, elixir-autogen, elixir-format
+msgid "Add card template"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:60
+#, elixir-autogen, elixir-format
+msgid "Additional instructions"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:96
+#, elixir-autogen, elixir-format
+msgid "Additional teacher instructions"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:66
+#, elixir-autogen, elixir-format
+msgid "Create a new moment card from scratch"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:181
+#, elixir-autogen, elixir-format
+msgid "Edit card"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:28
+#, elixir-autogen, elixir-format
+msgid "Edit moment card"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:25
+#, elixir-autogen, elixir-format
+msgid "Edit moment card template"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:120
+#, elixir-autogen, elixir-format
+msgid "Edit template"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Moment cards order"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:80
+#, elixir-autogen, elixir-format
+msgid "Moment cards templates order"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:24
+#, elixir-autogen, elixir-format
+msgid "New moment card template"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:47
+#, elixir-autogen, elixir-format
+msgid "No templates created yet"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:139
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "Oops, something went wrong! Please check the errors above."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/menu_component.ex:459
+#, elixir-autogen, elixir-format
+msgid "School config"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:73
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:93
+#, elixir-autogen, elixir-format
+msgid "Select"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:62
+#, elixir-autogen, elixir-format
+msgid "Select a template from the list below to create the card"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/menu_component.ex:434
+#, elixir-autogen, elixir-format
+msgid "Students and classes"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:52
+#, elixir-autogen, elixir-format
+msgid "Template"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:134
+#, elixir-autogen, elixir-format
+msgid "Template instructions"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:26
+#, elixir-autogen, elixir-format
+msgid "Template: %{template}"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/school_config_live.html.heex:14
+#, elixir-autogen, elixir-format
+msgid "Templates"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:23
+#, elixir-autogen, elixir-format
+msgid "Templates for new moment cards"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:168
+#, elixir-autogen, elixir-format
+msgid "This card was deleted"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:102
+#, elixir-autogen, elixir-format
+msgid "This template was deleted"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: lib/lanttern_web/components/core_components.ex:770
-#: lib/lanttern_web/components/core_components.ex:1792
-#: lib/lanttern_web/components/core_components.ex:1854
+#: lib/lanttern_web/components/core_components.ex:1808
+#: lib/lanttern_web/components/core_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -25,13 +25,13 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:2
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:433
+#: lib/lanttern_web/live/shared/menu_component.ex:441
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:418
+#: lib/lanttern_web/live/shared/menu_component.ex:421
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -43,7 +43,6 @@ msgid "Rubrics"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:3
-#: lib/lanttern_web/live/shared/menu_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr ""
@@ -56,8 +55,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:419
-#: lib/lanttern_web/live/shared/menu_component.ex:458
+#: lib/lanttern_web/live/shared/menu_component.ex:422
+#: lib/lanttern_web/live/shared/menu_component.ex:472
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr ""
@@ -109,6 +108,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:182
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:120
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:103
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:107
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:176
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:91
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:136
@@ -117,8 +117,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:101
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:117
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:162
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:97
-#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:102
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:104
+#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:103
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:94
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:269
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:114
@@ -128,8 +128,10 @@ msgstr ""
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:64
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:66
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:153
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:51
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:71
@@ -166,6 +168,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:185
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:106
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:110
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:179
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:94
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:139
@@ -174,15 +177,17 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:104
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:120
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:165
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:100
-#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:105
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:107
+#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:161
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:69
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:117
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:67
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:69
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:156
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:53
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:116
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:61
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:74
@@ -213,6 +218,7 @@ msgid "Your starred strands"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:46
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:124
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:43
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:51
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:62
@@ -232,9 +238,11 @@ msgstr ""
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:33
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:31
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:39
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:36
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:35
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:55
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:45
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:44
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:45
@@ -256,8 +264,10 @@ msgstr ""
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:26
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:26
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:22
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:112
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:21
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:27
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:40
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:29
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:26
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
@@ -278,7 +288,6 @@ msgid "Save Strand"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:178
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:99
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:116
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:87
@@ -396,9 +405,10 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:43
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:196
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:108
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:88
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:57
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:178
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:66
@@ -458,12 +468,13 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:194
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:106
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:186
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:86
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:43
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:149
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:55
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:176
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:64
@@ -506,7 +517,6 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:305
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:69
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:233
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:58
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:258
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -533,8 +543,10 @@ msgid "No assessment points for this strand yet"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:27
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:32
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:26
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:45
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "Reorder"
 msgstr ""
@@ -744,7 +756,7 @@ msgid "Curriculum item already added to this strand"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:35
-#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:88
+#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Edit moment"
 msgstr ""
@@ -791,7 +803,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1742
+#: lib/lanttern_web/components/core_components.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -812,7 +824,7 @@ msgid "Save moment"
 msgstr ""
 
 #: lib/lanttern/learning_context.ex:672
-#: lib/lanttern/repo_helpers.ex:182
+#: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:243
@@ -1009,7 +1021,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:9
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:65
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:27
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:31
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:34
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:23
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:25
@@ -1204,7 +1216,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:20
-#: lib/lanttern_web/live/shared/menu_component.ex:445
+#: lib/lanttern_web/live/shared/menu_component.ex:453
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr ""
@@ -1251,11 +1263,6 @@ msgstr ""
 msgid "List of report cards linked to this strand."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:72
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Moment card"
-msgstr ""
-
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:120
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Moment card created successfully"
@@ -1271,7 +1278,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1732
+#: lib/lanttern_web/components/core_components.ex:1748
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1292,7 +1299,7 @@ msgstr ""
 msgid "No assessment point entries for this grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:31
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "No cards for this moment yet"
 msgstr ""
@@ -1407,9 +1414,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:14
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:115
-#: lib/lanttern_web/live/shared/menu_component.ex:439
-#: lib/lanttern_web/live/shared/menu_component.ex:452
-#: lib/lanttern_web/live/shared/menu_component.ex:465
+#: lib/lanttern_web/live/shared/menu_component.ex:447
+#: lib/lanttern_web/live/shared/menu_component.ex:466
+#: lib/lanttern_web/live/shared/menu_component.ex:479
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr ""
@@ -2714,7 +2721,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/students_records/students_records_live.ex:29
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:3
-#: lib/lanttern_web/live/shared/menu_component.ex:424
+#: lib/lanttern_web/live/shared/menu_component.ex:427
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Students records"
 msgstr ""
@@ -3061,7 +3068,7 @@ msgstr ""
 msgid "A grades report for the same cycle and year already exists"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:16
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:20
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add cycle"
 msgstr ""
@@ -3132,7 +3139,7 @@ msgstr ""
 msgid "Cover image"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:163
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:167
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create cycle"
 msgstr ""
@@ -3145,17 +3152,17 @@ msgstr ""
 #: lib/lanttern_web/live/pages/guardian/guardian_home_live.ex:127
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:127
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:164
-#: lib/lanttern_web/live/shared/menu_component.ex:532
+#: lib/lanttern_web/live/shared/menu_component.ex:546
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:88
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:92
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cycle created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:111
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:115
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cycle deleted successfully"
 msgstr ""
@@ -3165,12 +3172,12 @@ msgstr ""
 msgid "Cycle name"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:97
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cycle updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/school_live.html.heex:14
+#: lib/lanttern_web/live/pages/school_config/school_config_live.html.heex:8
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cycles"
 msgstr ""
@@ -3180,8 +3187,8 @@ msgstr ""
 msgid "Delete moment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:48
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:174
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:52
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:178
 #, elixir-autogen, elixir-format
 msgid "Edit cycle"
 msgstr ""
@@ -3206,7 +3213,7 @@ msgstr ""
 msgid "Edit strand to add a cover image"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:42
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:46
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "End at"
@@ -3273,11 +3280,6 @@ msgstr ""
 msgid "Loading profiles"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:178
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Moment card deleted"
-msgstr ""
-
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:22
 #, elixir-autogen, elixir-format
 msgid "Moment of %{strand}"
@@ -3308,7 +3310,8 @@ msgstr ""
 msgid "New grades report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:25
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:34
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:27
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New moment card"
 msgstr ""
@@ -3329,12 +3332,12 @@ msgstr ""
 msgid "No cycle selected"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:24
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:28
 #, elixir-autogen, elixir-format
 msgid "No cycles found in this school."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:61
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "No cycles in this school"
 msgstr ""
@@ -3476,7 +3479,7 @@ msgstr ""
 msgid "Starred strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:39
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:43
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Start at"
@@ -3666,4 +3669,131 @@ msgstr ""
 #: lib/lanttern_web/components/form_components.ex:722
 #, elixir-autogen, elixir-format
 msgid "Upload profile picture"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/school_config_live.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "%{school} config"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:40
+#, elixir-autogen, elixir-format
+msgid "Add card template"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:60
+#, elixir-autogen, elixir-format
+msgid "Additional instructions"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:96
+#, elixir-autogen, elixir-format
+msgid "Additional teacher instructions"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:66
+#, elixir-autogen, elixir-format
+msgid "Create a new moment card from scratch"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:181
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Edit card"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:28
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Edit moment card"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:25
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Edit moment card template"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:120
+#, elixir-autogen, elixir-format
+msgid "Edit template"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:77
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Moment cards order"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:80
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Moment cards templates order"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:24
+#, elixir-autogen, elixir-format, fuzzy
+msgid "New moment card template"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:47
+#, elixir-autogen, elixir-format
+msgid "No templates created yet"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:139
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:67
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Oops, something went wrong! Please check the errors above."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/menu_component.ex:459
+#, elixir-autogen, elixir-format, fuzzy
+msgid "School config"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:73
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:93
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Select"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:62
+#, elixir-autogen, elixir-format
+msgid "Select a template from the list below to create the card"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/menu_component.ex:434
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Students and classes"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:52
+#, elixir-autogen, elixir-format
+msgid "Template"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:134
+#, elixir-autogen, elixir-format
+msgid "Template instructions"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:26
+#, elixir-autogen, elixir-format
+msgid "Template: %{template}"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/school_config_live.html.heex:14
+#, elixir-autogen, elixir-format
+msgid "Templates"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:23
+#, elixir-autogen, elixir-format
+msgid "Templates for new moment cards"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:168
+#, elixir-autogen, elixir-format, fuzzy
+msgid "This card was deleted"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:102
+#, elixir-autogen, elixir-format
+msgid "This template was deleted"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n>1);\n"
 
 #: lib/lanttern_web/components/core_components.ex:770
-#: lib/lanttern_web/components/core_components.ex:1792
-#: lib/lanttern_web/components/core_components.ex:1854
+#: lib/lanttern_web/components/core_components.ex:1808
+#: lib/lanttern_web/components/core_components.ex:1870
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Ações"
@@ -25,13 +25,13 @@ msgstr "Ações"
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:2
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:433
+#: lib/lanttern_web/live/shared/menu_component.ex:441
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr "Currículo"
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:418
+#: lib/lanttern_web/live/shared/menu_component.ex:421
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr "Dashboard"
@@ -43,7 +43,6 @@ msgid "Rubrics"
 msgstr "Rubricas"
 
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:3
-#: lib/lanttern_web/live/shared/menu_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "School"
 msgstr "Escola"
@@ -56,8 +55,8 @@ msgstr "Escola"
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:419
-#: lib/lanttern_web/live/shared/menu_component.ex:458
+#: lib/lanttern_web/live/shared/menu_component.ex:422
+#: lib/lanttern_web/live/shared/menu_component.ex:472
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr "Trilhas"
@@ -109,6 +108,7 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:182
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:120
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:103
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:107
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:176
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:91
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:136
@@ -117,8 +117,8 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:101
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:117
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:162
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:97
-#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:102
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:104
+#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:103
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:94
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:269
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:114
@@ -128,8 +128,10 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:64
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:66
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:153
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:51
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:71
@@ -166,6 +168,7 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:185
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:123
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:106
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:110
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:179
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:94
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:139
@@ -174,15 +177,17 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:104
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:120
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:165
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:100
-#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:105
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:107
+#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:161
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:69
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:117
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:67
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:69
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:156
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:53
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:116
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:61
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:74
@@ -213,6 +218,7 @@ msgid "Your starred strands"
 msgstr "Suas trilhas favoritas"
 
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:46
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:124
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:43
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:51
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:62
@@ -232,9 +238,11 @@ msgstr "O arquivo \"%{file}\" é inválido."
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:33
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:31
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:39
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:36
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:35
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:55
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:45
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:44
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:45
@@ -256,8 +264,10 @@ msgstr "Nenhum ano selecionado"
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:26
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:26
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:22
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:112
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:21
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:27
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:40
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:29
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:26
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
@@ -278,7 +288,6 @@ msgid "Save Strand"
 msgstr "Salvar Trilha"
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:178
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:99
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:116
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:87
@@ -396,9 +405,10 @@ msgstr "Não foi possível encontrar a trilha"
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:43
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:196
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:108
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:88
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:57
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:178
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:66
@@ -458,12 +468,13 @@ msgstr "Adicione suas anotações..."
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:194
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:106
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:186
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:86
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:43
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:149
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:55
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:176
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:64
@@ -506,7 +517,6 @@ msgstr "Diferenciação para %{name}"
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:305
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:69
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:233
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:58
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:258
 #, elixir-autogen, elixir-format
 msgid "Edit"
@@ -533,8 +543,10 @@ msgid "No assessment points for this strand yet"
 msgstr "Nenhum ponto de avaliação para esta trilha ainda"
 
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:27
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:32
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:26
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:45
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "Reorder"
 msgstr "Reordenar"
@@ -744,7 +756,7 @@ msgid "Curriculum item already added to this strand"
 msgstr "Item curricular já adicionado à esta trilha"
 
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:35
-#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:88
+#: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:89
 #, elixir-autogen, elixir-format
 msgid "Edit moment"
 msgstr "Editar momento"
@@ -791,7 +803,7 @@ msgstr "Momento atualizado com sucesso"
 msgid "Moments"
 msgstr "Momentos"
 
-#: lib/lanttern_web/components/core_components.ex:1742
+#: lib/lanttern_web/components/core_components.ex:1758
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr "Mover momento para baixo"
@@ -812,7 +824,7 @@ msgid "Save moment"
 msgstr "Salvar momento"
 
 #: lib/lanttern/learning_context.ex:672
-#: lib/lanttern/repo_helpers.ex:182
+#: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:243
@@ -1009,7 +1021,7 @@ msgstr "Item curricular removido"
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:9
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:65
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:27
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:31
 #: lib/lanttern_web/live/pages/student_report_card/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:34
 #: lib/lanttern_web/live/pages/student_report_card/id/student_report_card_live.html.heex:23
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:25
@@ -1204,7 +1216,7 @@ msgstr "Relatório de notas atualizado com sucesso"
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:20
-#: lib/lanttern_web/live/shared/menu_component.ex:445
+#: lib/lanttern_web/live/shared/menu_component.ex:453
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr "Relatórios de notas"
@@ -1251,11 +1263,6 @@ msgstr "Vincular trilha"
 msgid "List of report cards linked to this strand."
 msgstr "Lista de report cards vinculados a esta trilha"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:72
-#, elixir-autogen, elixir-format
-msgid "Moment card"
-msgstr "Card de momento"
-
 #: lib/lanttern_web/live/shared/learning_context/moment_card_form_component.ex:120
 #, elixir-autogen, elixir-format
 msgid "Moment card created successfully"
@@ -1271,7 +1278,7 @@ msgstr "Card de momento atualizado com sucesso"
 msgid "Move down"
 msgstr "Mover para baixo"
 
-#: lib/lanttern_web/components/core_components.ex:1732
+#: lib/lanttern_web/components/core_components.ex:1748
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1292,7 +1299,7 @@ msgstr "Nenhum ponto de avaliação para esta composição de nota"
 msgid "No assessment point entries for this grade composition"
 msgstr "Nenhum ponto de avaliação para esta composição de nota"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:31
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "No cards for this moment yet"
 msgstr "Nenhum card para este momento ainda"
@@ -1407,9 +1414,9 @@ msgstr "Id do report card"
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:14
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:115
-#: lib/lanttern_web/live/shared/menu_component.ex:439
-#: lib/lanttern_web/live/shared/menu_component.ex:452
-#: lib/lanttern_web/live/shared/menu_component.ex:465
+#: lib/lanttern_web/live/shared/menu_component.ex:447
+#: lib/lanttern_web/live/shared/menu_component.ex:466
+#: lib/lanttern_web/live/shared/menu_component.ex:479
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr "Report cards"
@@ -2714,7 +2721,7 @@ msgstr "Status"
 
 #: lib/lanttern_web/live/pages/students_records/students_records_live.ex:29
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:3
-#: lib/lanttern_web/live/shared/menu_component.ex:424
+#: lib/lanttern_web/live/shared/menu_component.ex:427
 #, elixir-autogen, elixir-format
 msgid "Students records"
 msgstr "Registros de estudantes"
@@ -3061,7 +3068,7 @@ msgstr "Um ciclo não pode ser pai de si mesmo"
 msgid "A grades report for the same cycle and year already exists"
 msgstr "Já existe um relatório de notas para o mesmo ciclo e ano"
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:16
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:20
 #, elixir-autogen, elixir-format
 msgid "Add cycle"
 msgstr "Adicionar ciclo"
@@ -3132,7 +3139,7 @@ msgstr "Clique para favoritar a trilha"
 msgid "Cover image"
 msgstr "Imagem de capa"
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:163
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Create cycle"
 msgstr "Criar ciclo"
@@ -3145,17 +3152,17 @@ msgstr "Criar trilha"
 #: lib/lanttern_web/live/pages/guardian/guardian_home_live.ex:127
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:127
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:164
-#: lib/lanttern_web/live/shared/menu_component.ex:532
+#: lib/lanttern_web/live/shared/menu_component.ex:546
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr "Ciclo atual alterado"
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:88
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:92
 #, elixir-autogen, elixir-format
 msgid "Cycle created successfully"
 msgstr "Ciclo criado com sucesso"
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:111
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:115
 #, elixir-autogen, elixir-format
 msgid "Cycle deleted successfully"
 msgstr "Ciclo deletado com sucesso"
@@ -3165,12 +3172,12 @@ msgstr "Ciclo deletado com sucesso"
 msgid "Cycle name"
 msgstr "Nome do ciclo"
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:97
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:101
 #, elixir-autogen, elixir-format
 msgid "Cycle updated successfully"
 msgstr "Ciclo atualizado com sucesso"
 
-#: lib/lanttern_web/live/pages/school/school_live.html.heex:14
+#: lib/lanttern_web/live/pages/school_config/school_config_live.html.heex:8
 #, elixir-autogen, elixir-format
 msgid "Cycles"
 msgstr "Ciclos"
@@ -3180,8 +3187,8 @@ msgstr "Ciclos"
 msgid "Delete moment"
 msgstr "Deletar momento"
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:48
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:174
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:52
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:178
 #, elixir-autogen, elixir-format
 msgid "Edit cycle"
 msgstr "Editar ciclo"
@@ -3206,7 +3213,7 @@ msgstr "Edite o relatório para adiconar uma imagem de capa"
 msgid "Edit strand to add a cover image"
 msgstr "Edite a trilha para adicionar uma imagem de capa"
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:42
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:46
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "End at"
@@ -3273,11 +3280,6 @@ msgstr "Carregando ciclos"
 msgid "Loading profiles"
 msgstr "Carregando perfis"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:178
-#, elixir-autogen, elixir-format
-msgid "Moment card deleted"
-msgstr "Card de momento deletado"
-
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:22
 #, elixir-autogen, elixir-format
 msgid "Moment of %{strand}"
@@ -3308,7 +3310,8 @@ msgstr "Novo item curricular"
 msgid "New grades report"
 msgstr "Novo relatório de notas"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:25
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:34
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "New moment card"
 msgstr "Novo card de momento"
@@ -3329,12 +3332,12 @@ msgstr "Nenhuma turma selecionada"
 msgid "No cycle selected"
 msgstr "Nenhum ciclo selecionado"
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:24
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:28
 #, elixir-autogen, elixir-format
 msgid "No cycles found in this school."
 msgstr "Nenhum ciclo encontrado nesta escola."
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:61
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "No cycles in this school"
 msgstr "Nenhum ciclo nesta escola"
@@ -3476,7 +3479,7 @@ msgstr "Mostrando apenas trilhas favoritas"
 msgid "Starred strand"
 msgstr "Trilha favoritada"
 
-#: lib/lanttern_web/live/pages/school/cycles_component.ex:39
+#: lib/lanttern_web/live/pages/school_config/cycles_component.ex:43
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Start at"
@@ -3667,3 +3670,130 @@ msgstr "Anexos da área da escola"
 #, elixir-autogen, elixir-format
 msgid "Upload profile picture"
 msgstr "Upload de foto de perfil"
+
+#: lib/lanttern_web/live/pages/school_config/school_config_live.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "%{school} config"
+msgstr "Configuração de %{school}"
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:40
+#, elixir-autogen, elixir-format
+msgid "Add card template"
+msgstr "Adicionar template de card"
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:60
+#, elixir-autogen, elixir-format
+msgid "Additional instructions"
+msgstr "Instruções adicionais"
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:96
+#, elixir-autogen, elixir-format
+msgid "Additional teacher instructions"
+msgstr "Instruções adicionais para professores"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:66
+#, elixir-autogen, elixir-format
+msgid "Create a new moment card from scratch"
+msgstr "Criar novo card de momento do zero"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:181
+#, elixir-autogen, elixir-format
+msgid "Edit card"
+msgstr "Editar card"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:28
+#, elixir-autogen, elixir-format
+msgid "Edit moment card"
+msgstr "Editar card de momento"
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:25
+#, elixir-autogen, elixir-format
+msgid "Edit moment card template"
+msgstr "Editar template de card de momento"
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:120
+#, elixir-autogen, elixir-format
+msgid "Edit template"
+msgstr "Editar template"
+
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:77
+#, elixir-autogen, elixir-format
+msgid "Moment cards order"
+msgstr "Ordem dos cards de momento"
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:80
+#, elixir-autogen, elixir-format
+msgid "Moment cards templates order"
+msgstr "Ordem dos templates de cards de momento"
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:24
+#, elixir-autogen, elixir-format
+msgid "New moment card template"
+msgstr "Novo template de card de momento"
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:47
+#, elixir-autogen, elixir-format
+msgid "No templates created yet"
+msgstr "Nenhum template criado ainda"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:139
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "Oops, something went wrong! Please check the errors above."
+msgstr "Oops, algo deu errado! Por favor, confira os erros acima."
+
+#: lib/lanttern_web/live/shared/menu_component.ex:459
+#, elixir-autogen, elixir-format
+msgid "School config"
+msgstr "Configuração da escola"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:73
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:93
+#, elixir-autogen, elixir-format
+msgid "Select"
+msgstr "Selecionar"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:62
+#, elixir-autogen, elixir-format
+msgid "Select a template from the list below to create the card"
+msgstr "Selecione um template da lista abaixo para criar o card"
+
+#: lib/lanttern_web/live/shared/menu_component.ex:434
+#, elixir-autogen, elixir-format
+msgid "Students and classes"
+msgstr "Estudantes e turmas"
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:52
+#, elixir-autogen, elixir-format
+msgid "Template"
+msgstr "Template"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:134
+#, elixir-autogen, elixir-format
+msgid "Template instructions"
+msgstr "Instruções do template"
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:26
+#, elixir-autogen, elixir-format
+msgid "Template: %{template}"
+msgstr "Template: %{template}"
+
+#: lib/lanttern_web/live/pages/school_config/school_config_live.html.heex:14
+#, elixir-autogen, elixir-format
+msgid "Templates"
+msgstr "Templates"
+
+#: lib/lanttern_web/live/pages/school_config/moment_cards_templates_component.ex:23
+#, elixir-autogen, elixir-format
+msgid "Templates for new moment cards"
+msgstr "Templates para novos cards de momento"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:168
+#, elixir-autogen, elixir-format
+msgid "This card was deleted"
+msgstr "Este card foi deletado"
+
+#: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:102
+#, elixir-autogen, elixir-format
+msgid "This template was deleted"
+msgstr "Este template foi deletado"

--- a/priv/repo/migrations/20250120130241_create_moment_cards_templates.exs
+++ b/priv/repo/migrations/20250120130241_create_moment_cards_templates.exs
@@ -1,0 +1,18 @@
+defmodule Lanttern.Repo.Migrations.CreateMomentCardsTemplates do
+  use Ecto.Migration
+
+  def change do
+    create table(:moment_cards_templates) do
+      add :name, :text, null: false
+      add :template, :text, null: false
+      add :instructions, :text
+      add :position, :integer, default: 0, null: false
+      add :school_id, references(:schools, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:moment_cards_templates, [:school_id])
+    create index(:moment_cards_templates, [:position])
+  end
+end

--- a/test/lanttern/personalization_test.exs
+++ b/test/lanttern/personalization_test.exs
@@ -55,9 +55,10 @@ defmodule Lanttern.PersonalizationTest do
     test "list_valid_permissions/0 returns all valid permissions" do
       valid_permissions = Personalization.list_valid_permissions()
 
-      assert length(valid_permissions) == 2
+      assert length(valid_permissions) == 3
       assert "wcd" in valid_permissions
       assert "school_management" in valid_permissions
+      assert "content_management" in valid_permissions
     end
   end
 end

--- a/test/lanttern/school_config_test.exs
+++ b/test/lanttern/school_config_test.exs
@@ -10,9 +10,26 @@ defmodule Lanttern.SchoolConfigTest do
 
     @invalid_attrs %{name: nil, position: nil, template: nil}
 
-    test "list_moment_cards_templates/0 returns all moment_cards_templates" do
-      moment_card_template = moment_card_template_fixture()
-      assert SchoolConfig.list_moment_cards_templates() == [moment_card_template]
+    test "list_moment_cards_templates/1 returns all moment_cards_templates ordered by position" do
+      moment_card_template_2 = moment_card_template_fixture(%{position: 2})
+      moment_card_template_1 = moment_card_template_fixture(%{position: 1})
+
+      assert SchoolConfig.list_moment_cards_templates() == [
+               moment_card_template_1,
+               moment_card_template_2
+             ]
+    end
+
+    test "list_moment_cards_templates/1 with school filter returns all moment_cards_templates filtered by school" do
+      school = Lanttern.SchoolsFixtures.school_fixture()
+      moment_card_template = moment_card_template_fixture(%{school_id: school.id})
+
+      # other fixtures for filter test
+      moment_card_template_fixture()
+
+      assert SchoolConfig.list_moment_cards_templates(school_id: school.id) == [
+               moment_card_template
+             ]
     end
 
     test "get_moment_card_template!/1 returns the moment_card_template with given id" do
@@ -38,6 +55,30 @@ defmodule Lanttern.SchoolConfigTest do
       assert moment_card_template.name == "some name"
       assert moment_card_template.position == 42
       assert moment_card_template.template == "some template"
+    end
+
+    test "created moments cards are ordered automatically" do
+      school = Lanttern.SchoolsFixtures.school_fixture()
+
+      valid_attrs = %{
+        name: "some name",
+        template: "some template",
+        school_id: school.id
+      }
+
+      {:ok, _moment_card_template_1} = SchoolConfig.create_moment_card_template(valid_attrs)
+      {:ok, _moment_card_template_2} = SchoolConfig.create_moment_card_template(valid_attrs)
+      {:ok, _moment_card_template_3} = SchoolConfig.create_moment_card_template(valid_attrs)
+
+      [
+        expected_moment_card_template_1,
+        expected_moment_card_template_2,
+        expected_moment_card_template_3
+      ] = SchoolConfig.list_moment_cards_templates(school_id: school.id)
+
+      assert expected_moment_card_template_1.position == 0
+      assert expected_moment_card_template_2.position == 1
+      assert expected_moment_card_template_3.position == 2
     end
 
     test "create_moment_card_template/1 with invalid data returns error changeset" do

--- a/test/lanttern/school_config_test.exs
+++ b/test/lanttern/school_config_test.exs
@@ -1,0 +1,86 @@
+defmodule Lanttern.SchoolConfigTest do
+  use Lanttern.DataCase
+
+  alias Lanttern.SchoolConfig
+
+  describe "moment_cards_templates" do
+    alias Lanttern.SchoolConfig.MomentCardTemplate
+
+    import Lanttern.SchoolConfigFixtures
+
+    @invalid_attrs %{name: nil, position: nil, template: nil}
+
+    test "list_moment_cards_templates/0 returns all moment_cards_templates" do
+      moment_card_template = moment_card_template_fixture()
+      assert SchoolConfig.list_moment_cards_templates() == [moment_card_template]
+    end
+
+    test "get_moment_card_template!/1 returns the moment_card_template with given id" do
+      moment_card_template = moment_card_template_fixture()
+
+      assert SchoolConfig.get_moment_card_template!(moment_card_template.id) ==
+               moment_card_template
+    end
+
+    test "create_moment_card_template/1 with valid data creates a moment_card_template" do
+      school = Lanttern.SchoolsFixtures.school_fixture()
+
+      valid_attrs = %{
+        name: "some name",
+        position: 42,
+        template: "some template",
+        school_id: school.id
+      }
+
+      assert {:ok, %MomentCardTemplate{} = moment_card_template} =
+               SchoolConfig.create_moment_card_template(valid_attrs)
+
+      assert moment_card_template.name == "some name"
+      assert moment_card_template.position == 42
+      assert moment_card_template.template == "some template"
+    end
+
+    test "create_moment_card_template/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} =
+               SchoolConfig.create_moment_card_template(@invalid_attrs)
+    end
+
+    test "update_moment_card_template/2 with valid data updates the moment_card_template" do
+      moment_card_template = moment_card_template_fixture()
+      update_attrs = %{name: "some updated name", position: 43, template: "some updated template"}
+
+      assert {:ok, %MomentCardTemplate{} = moment_card_template} =
+               SchoolConfig.update_moment_card_template(moment_card_template, update_attrs)
+
+      assert moment_card_template.name == "some updated name"
+      assert moment_card_template.position == 43
+      assert moment_card_template.template == "some updated template"
+    end
+
+    test "update_moment_card_template/2 with invalid data returns error changeset" do
+      moment_card_template = moment_card_template_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               SchoolConfig.update_moment_card_template(moment_card_template, @invalid_attrs)
+
+      assert moment_card_template ==
+               SchoolConfig.get_moment_card_template!(moment_card_template.id)
+    end
+
+    test "delete_moment_card_template/1 deletes the moment_card_template" do
+      moment_card_template = moment_card_template_fixture()
+
+      assert {:ok, %MomentCardTemplate{}} =
+               SchoolConfig.delete_moment_card_template(moment_card_template)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        SchoolConfig.get_moment_card_template!(moment_card_template.id)
+      end
+    end
+
+    test "change_moment_card_template/1 returns a moment_card_template changeset" do
+      moment_card_template = moment_card_template_fixture()
+      assert %Ecto.Changeset{} = SchoolConfig.change_moment_card_template(moment_card_template)
+    end
+  end
+end

--- a/test/lanttern/school_config_test.exs
+++ b/test/lanttern/school_config_test.exs
@@ -11,13 +11,33 @@ defmodule Lanttern.SchoolConfigTest do
     @invalid_attrs %{name: nil, position: nil, template: nil}
 
     test "list_moment_cards_templates/1 returns all moment_cards_templates ordered by position" do
+      moment_card_template_3 = moment_card_template_fixture(%{position: 3})
       moment_card_template_2 = moment_card_template_fixture(%{position: 2})
       moment_card_template_1 = moment_card_template_fixture(%{position: 1})
 
       assert SchoolConfig.list_moment_cards_templates() == [
                moment_card_template_1,
-               moment_card_template_2
+               moment_card_template_2,
+               moment_card_template_3
              ]
+
+      # use same setup to test update_moment_cards_templates_positions/1
+
+      SchoolConfig.update_moment_cards_templates_positions([
+        moment_card_template_2.id,
+        moment_card_template_3.id,
+        moment_card_template_1.id
+      ])
+
+      [
+        expected_moment_card_template_2,
+        expected_moment_card_template_3,
+        expected_moment_card_template_1
+      ] = SchoolConfig.list_moment_cards_templates()
+
+      assert expected_moment_card_template_1.id == moment_card_template_1.id
+      assert expected_moment_card_template_2.id == moment_card_template_2.id
+      assert expected_moment_card_template_3.id == moment_card_template_3.id
     end
 
     test "list_moment_cards_templates/1 with school filter returns all moment_cards_templates filtered by school" do

--- a/test/lanttern_web/live/pages/school_config/school_config_live_test.exs
+++ b/test/lanttern_web/live/pages/school_config/school_config_live_test.exs
@@ -1,0 +1,78 @@
+defmodule LantternWeb.SchoolConfigLiveTest do
+  use LantternWeb.ConnCase
+
+  alias Lanttern.SchoolsFixtures
+
+  @live_view_base_path "/school_config"
+
+  setup [:register_and_log_in_teacher]
+
+  describe "School config live view basic navigation" do
+    test "disconnected and connected mount", %{conn: conn} do
+      conn = get(conn, "#{@live_view_base_path}/cycles")
+
+      school_name = conn.assigns.current_user.current_profile.school_name
+      {:ok, regex} = Regex.compile("<h1 .+>\\s*#{school_name} config\\s*<\/h1>")
+
+      assert html_response(conn, 200) =~ regex
+
+      {:ok, _view, _html} = live(conn)
+    end
+
+    test "list cycles", %{conn: conn, user: user} do
+      school_id = user.current_profile.school_id
+
+      parent_cycle =
+        SchoolsFixtures.cycle_fixture(%{school_id: school_id, name: "parent cycle abc"})
+
+      subcycle =
+        SchoolsFixtures.cycle_fixture(%{
+          school_id: school_id,
+          parent_cycle_id: parent_cycle.id,
+          name: "subcycle abc"
+        })
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/cycles")
+
+      assert view |> has_element?("div", parent_cycle.name)
+      assert view |> has_element?("div", subcycle.name)
+    end
+  end
+
+  describe "Management permissions" do
+    test "allow user with school management permissions to create cycle", context do
+      %{conn: conn} = add_school_management_permissions(context)
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/cycles?new=true")
+
+      assert view |> has_element?("#cycle-form-overlay h2", "Create cycle")
+    end
+
+    test "prevent user without school management permissions to create cycle", %{conn: conn} do
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/cycles?new=true")
+
+      refute view |> has_element?("#cycle-form-overlay h2", "Create cycle")
+    end
+
+    test "allow user with school management permissions to edit cycle", context do
+      %{conn: conn, user: user} = add_school_management_permissions(context)
+      school_id = user.current_profile.school_id
+      cycle = SchoolsFixtures.cycle_fixture(%{school_id: school_id, name: "cycle abc"})
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/cycles?edit=#{cycle.id}")
+
+      assert view |> has_element?("#cycle-form-overlay h2", "Edit cycle")
+    end
+
+    test "prevent user without school management permissions to edit cycle", %{
+      conn: conn,
+      user: user
+    } do
+      school_id = user.current_profile.school_id
+      cycle = SchoolsFixtures.cycle_fixture(%{school_id: school_id, name: "cycle abc"})
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/cycles?edit=#{cycle.id}")
+
+      refute view |> has_element?("#cycle-form-overlay h2", "Edit cycle")
+    end
+  end
+end

--- a/test/lanttern_web/live/pages/strands/moment/id/cards_component_test.exs
+++ b/test/lanttern_web/live/pages/strands/moment/id/cards_component_test.exs
@@ -37,15 +37,12 @@ defmodule LantternWeb.MomentLive.CardsComponentTest do
       attrs =
         %{
           "name" => "new moment card",
-          "description" => "card description abc",
-          "moment_id" => moment.id
+          "description" => "card description abc"
         }
 
       assert view
              |> form("#moment-card-form", moment_card: attrs)
              |> render_submit()
-
-      assert_redirect(view, "#{@live_view_base_path}/#{moment.id}/cards")
 
       {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{moment.id}/cards")
       assert view |> has_element?("h5", "new moment card")
@@ -66,22 +63,24 @@ defmodule LantternWeb.MomentLive.CardsComponentTest do
       assert view |> has_element?("h5", "some card name abc")
       assert view |> has_element?("p", "some card description abc")
 
-      view |> element("#moment-card-#{moment_card.id} a", "Edit") |> render_click()
+      view |> element("#moment_cards-#{moment_card.id} a", moment_card.name) |> render_click()
 
-      assert_patch(view, "#{@live_view_base_path}/#{moment.id}/cards?edit=#{moment_card.id}")
+      assert_patch(
+        view,
+        "#{@live_view_base_path}/#{moment.id}/cards?moment_card_id=#{moment_card.id}"
+      )
+
+      view |> element("#moment-card-overlay button", "Edit card") |> render_click()
 
       attrs =
         %{
           "name" => "updated moment card",
-          "description" => "card description xyz",
-          "moment_id" => moment.id
+          "description" => "card description xyz"
         }
 
       assert view
              |> form("#moment-card-form", moment_card: attrs)
              |> render_submit()
-
-      assert_redirect(view, "#{@live_view_base_path}/#{moment.id}/cards")
 
       {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{moment.id}/cards")
       assert view |> has_element?("h5", "updated moment card")
@@ -102,13 +101,14 @@ defmodule LantternWeb.MomentLive.CardsComponentTest do
       {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{moment.id}/cards")
       assert view |> has_element?("h5", "some card name abc")
 
-      view |> element("#moment-card-#{moment_card.id} a", "Edit") |> render_click()
+      view |> element("#moment_cards-#{moment_card.id} a", moment_card.name) |> render_click()
 
-      assert_patch(view, "#{@live_view_base_path}/#{moment.id}/cards?edit=#{moment_card.id}")
+      assert_patch(
+        view,
+        "#{@live_view_base_path}/#{moment.id}/cards?moment_card_id=#{moment_card.id}"
+      )
 
-      view |> element("#moment-card-form-overlay button", "Delete") |> render_click()
-
-      assert_redirect(view, "#{@live_view_base_path}/#{moment.id}/cards")
+      view |> element("#moment-card-overlay button", "Delete") |> render_click()
 
       {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{moment.id}/cards")
       assert view |> has_element?("p", "No cards for this moment yet")

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -201,12 +201,7 @@ defmodule LantternWeb.ConnCase do
         permissions: ["wcd"]
       })
 
-    # emulate Identity.get_user_by_session_token/1 to preload profile into user
-    user =
-      user
-      |> Map.update!(:current_profile, &%{&1 | permissions: settings.permissions})
-
-    %{conn: log_in_user(conn, user), user: user}
+    emulate_profile_preload(conn, user, settings)
   end
 
   @doc """
@@ -219,6 +214,23 @@ defmodule LantternWeb.ConnCase do
         permissions: ["school_management"]
       })
 
+    emulate_profile_preload(conn, user, settings)
+  end
+
+  @doc """
+  Setup helper that adds content_management permissions to current user profile.
+  """
+  def add_content_management_permissions(%{conn: conn, user: user}) do
+    # add content_management permissions to user
+    {:ok, settings} =
+      Lanttern.Personalization.set_profile_settings(user.current_profile_id, %{
+        permissions: ["content_management"]
+      })
+
+    emulate_profile_preload(conn, user, settings)
+  end
+
+  defp emulate_profile_preload(conn, user, settings) do
     # emulate Identity.get_user_by_session_token/1 to preload profile into user
     user =
       user

--- a/test/support/fixtures/school_config_fixtures.ex
+++ b/test/support/fixtures/school_config_fixtures.ex
@@ -15,7 +15,6 @@ defmodule Lanttern.SchoolConfigFixtures do
       |> Enum.into(%{
         name: "some name",
         template: "some template",
-        position: 42,
         school_id: SchoolsFixtures.maybe_gen_school_id(attrs)
       })
       |> Lanttern.SchoolConfig.create_moment_card_template()

--- a/test/support/fixtures/school_config_fixtures.ex
+++ b/test/support/fixtures/school_config_fixtures.ex
@@ -1,0 +1,25 @@
+defmodule Lanttern.SchoolConfigFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Lanttern.SchoolConfig` context.
+  """
+
+  alias Lanttern.SchoolsFixtures
+
+  @doc """
+  Generate a moment_card_template.
+  """
+  def moment_card_template_fixture(attrs \\ %{}) do
+    {:ok, moment_card_template} =
+      attrs
+      |> Enum.into(%{
+        name: "some name",
+        template: "some template",
+        position: 42,
+        school_id: SchoolsFixtures.maybe_gen_school_id(attrs)
+      })
+      |> Lanttern.SchoolConfig.create_moment_card_template()
+
+    moment_card_template
+  end
+end


### PR DESCRIPTION
this PR adds support to moment cards templates. users with the `content_management` permission can create templates (the initial content of new cards) with optional instructions for teachers (and other content managers) on how to use it.

templates are scoped by school.

<img width="1423" alt="image" src="https://github.com/user-attachments/assets/95b6e3af-bbe6-4e64-a0c5-a2ba0fead002" />

<img width="1424" alt="image" src="https://github.com/user-attachments/assets/bcf7d1ba-ab80-4de5-a1c8-a1c73beb8a8c" />

solves #247 