### PR TITLE
moment cards student visualization

### DIFF
--- a/lib/lanttern/attachments.ex
+++ b/lib/lanttern/attachments.ex
@@ -86,7 +86,7 @@ defmodule Lanttern.Attachments do
       as: :moment_card_attachment,
       where: mca.moment_card_id == ^moment_card_id,
       order_by: mca.position,
-      preload: [moment_card_attachment: mca]
+      select: %{a | is_shared: mca.shared_with_students}
     )
     |> maybe_filter_by_shared_with_student(Keyword.get(opts, :shared_with_student))
     |> apply_list_attachments_opts(opts)

--- a/lib/lanttern/attachments/attachment.ex
+++ b/lib/lanttern/attachments/attachment.ex
@@ -43,6 +43,9 @@ defmodule Lanttern.Attachments.Attachment do
     field :description, :string
     field :is_external, :boolean, default: false
 
+    # used in the context of moment card attachments
+    field :is_shared, :boolean, virtual: true
+
     belongs_to :owner, Profile
 
     has_one :note_attachment, NoteAttachment

--- a/lib/lanttern/learning_context.ex
+++ b/lib/lanttern/learning_context.ex
@@ -17,6 +17,7 @@ defmodule Lanttern.LearningContext do
   alias Lanttern.LearningContext.Moment
   alias Lanttern.LearningContext.MomentCard
   alias Lanttern.LearningContext.MomentCardAttachment
+  alias Lanttern.LearningContextLog
 
   @doc """
   Returns the list of strands ordered alphabetically.
@@ -810,6 +811,10 @@ defmodule Lanttern.LearningContext do
   @doc """
   Creates a moment_card.
 
+  ## Options:
+
+  - `:log_profile_id` - logs the operation, linked to given profile
+
   ## Examples
 
       iex> create_moment_card(%{field: value})
@@ -819,11 +824,12 @@ defmodule Lanttern.LearningContext do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_moment_card(attrs \\ %{}) do
+  def create_moment_card(attrs \\ %{}, opts \\ []) do
     %MomentCard{}
     |> MomentCard.changeset(attrs)
     |> set_moment_card_position()
     |> Repo.insert()
+    |> LearningContextLog.maybe_create_moment_card_log("CREATE", opts)
   end
 
   # skip if not valid
@@ -859,6 +865,10 @@ defmodule Lanttern.LearningContext do
   @doc """
   Updates a moment_card.
 
+  ## Options:
+
+  - `:log_profile_id` - logs the operation, linked to given profile
+
   ## Examples
 
       iex> update_moment_card(moment_card, %{field: new_value})
@@ -868,10 +878,11 @@ defmodule Lanttern.LearningContext do
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_moment_card(%MomentCard{} = moment_card, attrs) do
+  def update_moment_card(%MomentCard{} = moment_card, attrs, opts \\ []) do
     moment_card
     |> MomentCard.changeset(attrs)
     |> Repo.update()
+    |> LearningContextLog.maybe_create_moment_card_log("UPDATE", opts)
   end
 
   @doc """
@@ -917,6 +928,10 @@ defmodule Lanttern.LearningContext do
   After the whole operation, in case of success, we trigger a request for deleting
   the attachments from the cloud (if they are internal).
 
+  ## Options:
+
+  - `:log_profile_id` - logs the operation, linked to given profile
+
   ## Examples
 
       iex> delete_moment_card(moment_card)
@@ -926,7 +941,7 @@ defmodule Lanttern.LearningContext do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_moment_card(%MomentCard{} = moment_card) do
+  def delete_moment_card(%MomentCard{} = moment_card, opts \\ []) do
     attachments_query =
       from(
         a in Attachment,
@@ -950,6 +965,7 @@ defmodule Lanttern.LearningContext do
       {:error, _name, value, _changes_so_far} ->
         {:error, value}
     end
+    |> LearningContextLog.maybe_create_moment_card_log("DELETE", opts)
   end
 
   @doc """

--- a/lib/lanttern/learning_context/moment_card.ex
+++ b/lib/lanttern/learning_context/moment_card.ex
@@ -38,6 +38,7 @@ defmodule Lanttern.LearningContext.MomentCard do
     belongs_to :moment, Moment
 
     has_many :moment_card_attachments, MomentCardAttachment
+    has_many :attachments, through: [:moment_card_attachments, :attachment]
 
     timestamps()
   end

--- a/lib/lanttern/learning_context/moment_card.ex
+++ b/lib/lanttern/learning_context/moment_card.ex
@@ -14,10 +14,13 @@ defmodule Lanttern.LearningContext.MomentCard do
           name: String.t(),
           position: non_neg_integer(),
           description: String.t(),
+          teacher_instructions: String.t() | nil,
+          differentiation: String.t() | nil,
+          shared_with_students: boolean(),
           attachments_count: non_neg_integer(),
           moment: Moment.t() | Ecto.Association.NotLoaded.t(),
           moment_id: pos_integer(),
-          moment_card_attachments: [MomentCardAttachment.t()],
+          moment_card_attachments: [MomentCardAttachment.t()] | Ecto.Association.NotLoaded.t(),
           inserted_at: NaiveDateTime.t(),
           updated_at: NaiveDateTime.t()
         }
@@ -26,6 +29,9 @@ defmodule Lanttern.LearningContext.MomentCard do
     field :name, :string
     field :position, :integer, default: 0
     field :description, :string
+    field :teacher_instructions, :string
+    field :differentiation, :string
+    field :shared_with_students, :boolean, default: false
 
     field :attachments_count, :integer, virtual: true, default: 0
 
@@ -39,7 +45,15 @@ defmodule Lanttern.LearningContext.MomentCard do
   @doc false
   def changeset(moment_card, attrs) do
     moment_card
-    |> cast(attrs, [:name, :description, :position, :moment_id])
-    |> validate_required([:name, :description, :position, :moment_id])
+    |> cast(attrs, [
+      :name,
+      :position,
+      :description,
+      :teacher_instructions,
+      :differentiation,
+      :shared_with_students,
+      :moment_id
+    ])
+    |> validate_required([:name, :description, :moment_id])
   end
 end

--- a/lib/lanttern/learning_context_log.ex
+++ b/lib/lanttern/learning_context_log.ex
@@ -1,0 +1,81 @@
+defmodule Lanttern.LearningContextLog do
+  @moduledoc """
+  The LearningContextLog context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Lanttern.Repo
+
+  alias Lanttern.LearningContext.MomentCard
+  alias Lanttern.LearningContextLog.MomentCardLog
+
+  @doc """
+  Creates a moment_card_log.
+
+  ## Examples
+
+      iex> create_moment_card_log(%{field: value})
+      {:ok, %MomentCardLog{}}
+
+      iex> create_moment_card_log(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_moment_card_log(attrs \\ %{}) do
+    %MomentCardLog{}
+    |> MomentCardLog.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Util for create a moment card log.
+
+  Accepts `{:ok, %MomentCard{}}` or `{:error, %Ecto.Changeset{}}` tuple as first arg.
+
+  Always returns the card or tuple as is. The logging process is handled in an async task.
+
+  ### Options:
+
+  - `:log_profile_id` – the profile id used to log the operation. if not present, logging will be skipped
+
+  """
+  @spec maybe_create_moment_card_log(
+          {:ok, MomentCard.t()} | {:error, Ecto.Changeset.t()},
+          operation :: String.t(),
+          opts :: Keyword.t()
+        ) ::
+          {:ok, MomentCard.t()} | {:error, Ecto.Changeset.t()}
+  def maybe_create_moment_card_log(operation_tuple, operation, opts \\ [])
+
+  def maybe_create_moment_card_log({:error, _} = operation_tuple, _, _),
+    do: operation_tuple
+
+  def maybe_create_moment_card_log(
+        {:ok, %MomentCard{} = moment_card} = operation_tuple,
+        operation,
+        opts
+      ) do
+    case Keyword.get(opts, :log_profile_id) do
+      profile_id when not is_nil(profile_id) ->
+        do_create_moment_card_log(moment_card, operation, profile_id)
+        operation_tuple
+
+      _ ->
+        operation_tuple
+    end
+  end
+
+  defp do_create_moment_card_log(moment_card, operation, profile_id) do
+    attrs =
+      moment_card
+      |> Map.from_struct()
+      |> Map.put(:moment_card_id, moment_card.id)
+      |> Map.put(:profile_id, profile_id)
+      |> Map.put(:operation, operation)
+
+    # create the log in a async task (fire and forget)
+    Task.Supervisor.start_child(Lanttern.TaskSupervisor, fn ->
+      create_moment_card_log(attrs)
+    end)
+  end
+end

--- a/lib/lanttern/learning_context_log/moment_card_log.ex
+++ b/lib/lanttern/learning_context_log/moment_card_log.ex
@@ -1,0 +1,53 @@
+defmodule Lanttern.LearningContextLog.MomentCardLog do
+  @moduledoc """
+  The `MomentCardLog` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @schema_prefix "log"
+  schema "moment_cards" do
+    field :moment_card_id, :id
+    field :profile_id, :id
+    field :operation, :string
+
+    field :moment_id, :id
+
+    field :name, :string
+    field :position, :integer
+    field :description, :string
+    field :teacher_instructions, :string
+    field :differentiation, :string
+    field :shared_with_students, :boolean
+
+    timestamps(updated_at: false)
+  end
+
+  @doc false
+  def changeset(student_cycle_info_log, attrs) do
+    student_cycle_info_log
+    |> cast(attrs, [
+      :moment_card_id,
+      :profile_id,
+      :operation,
+      :moment_id,
+      :name,
+      :position,
+      :description,
+      :teacher_instructions,
+      :differentiation,
+      :shared_with_students
+    ])
+    |> validate_required([
+      :moment_card_id,
+      :profile_id,
+      :operation,
+      :moment_id,
+      :name,
+      :position,
+      :description,
+      :shared_with_students
+    ])
+  end
+end

--- a/lib/lanttern/reporting.ex
+++ b/lib/lanttern/reporting.ex
@@ -15,6 +15,7 @@ defmodule Lanttern.Reporting do
   alias Lanttern.Assessments.AssessmentPointEntry
   alias Lanttern.Attachments.Attachment
   alias Lanttern.LearningContext.Moment
+  alias Lanttern.LearningContext.MomentCard
   alias Lanttern.LearningContext.Strand
   alias Lanttern.Schools
   alias Lanttern.Schools.Class
@@ -1308,5 +1309,36 @@ defmodule Lanttern.Reporting do
         }
       end
     )
+  end
+
+  @doc """
+  Returns the list of moment cards shared with student and linked to given moment.
+
+  **Preloaded data:**
+
+  - attachments: list of linked attachments
+
+  ## Examples
+
+      iex> list_moment_cards_and_attachments_shared_with_students(moment_id)
+      [%MomentCard{}, ...]
+
+  """
+  @spec list_moment_cards_and_attachments_shared_with_students(moment_id :: pos_integer()) :: [
+          MomentCard.t()
+        ]
+
+  def list_moment_cards_and_attachments_shared_with_students(moment_id) do
+    from(
+      mc in MomentCard,
+      left_join: mca in assoc(mc, :moment_card_attachments),
+      on: mca.shared_with_students,
+      left_join: a in assoc(mca, :attachment),
+      where: mc.moment_id == ^moment_id,
+      where: mc.shared_with_students,
+      order_by: [asc: mc.position, asc: mca.position],
+      preload: [attachments: a]
+    )
+    |> Repo.all()
   end
 end

--- a/lib/lanttern_web/components/attachments_components.ex
+++ b/lib/lanttern_web/components/attachments_components.ex
@@ -49,6 +49,11 @@ defmodule LantternWeb.AttachmentsComponents do
   attr :on_move_down, :any, default: nil, doc: "function. required when edit is allowed"
   attr :on_edit, :any, default: nil, doc: "function. required when edit is allowed"
   attr :on_remove, :any, default: nil, doc: "function. required when edit is allowed"
+
+  attr :on_toggle_share, :any,
+    default: nil,
+    doc: "function. If present, will render a toggle button based on attachment `is_shared`."
+
   attr :id, :string, default: nil
   attr :class, :any, default: nil
 
@@ -102,6 +107,19 @@ defmodule LantternWeb.AttachmentsComponents do
                 >
                   <%= attachment.name %>
                 </a>
+                <div :if={@on_toggle_share} class="flex items-center gap-2 mt-6">
+                  <.toggle
+                    enabled={attachment.is_shared}
+                    theme="student"
+                    phx-click={@on_toggle_share.(attachment.id, i)}
+                  />
+                  <span :if={attachment.is_shared} class="text-ltrn-student-dark">
+                    <%= gettext("Shared with students and guardians") %>
+                  </span>
+                  <span :if={!attachment.is_shared} class="text-ltrn-subtle">
+                    <%= gettext("Share with students and guardians") %>
+                  </span>
+                </div>
               </div>
             </div>
           </.sortable_card>

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -252,7 +252,10 @@ defmodule LantternWeb.CoreComponents do
     "primary" => "text-ltrn-dark",
     "secondary" => "text-white",
     "cyan" => "text-ltrn-subtle",
-    "dark" => "text-ltrn-lighter"
+    "dark" => "text-ltrn-lighter",
+    "diff" => "text-ltrn-diff-dark",
+    "student" => "text-ltrn-student-dark",
+    "teacher" => "text-ltrn-teacher-dark"
   }
 
   defp badge_icon_theme(theme),

--- a/lib/lanttern_web/components/form_components.ex
+++ b/lib/lanttern_web/components/form_components.ex
@@ -220,6 +220,7 @@ defmodule LantternWeb.FormComponents do
         :if={@label || @custom_label != []}
         for={@id}
         show_optional={@show_optional}
+        help_text={@help_text}
         custom={if @custom_label == [], do: false, else: true}
       >
         <%= @label || render_slot(@custom_label) %>
@@ -287,8 +288,8 @@ defmodule LantternWeb.FormComponents do
 
   def label(assigns) do
     ~H"""
-    <label for={@for} class="block mb-2 text-sm font-bold">
-      <.help_tooltip text={@help_text} class="inline-block font-normal" />
+    <label for={@for} class="flex items-center gap-2 mb-2 text-sm font-bold">
+      <.help_tooltip text={@help_text} class="font-normal" />
       <%= render_slot(@inner_block) %>
     </label>
     """

--- a/lib/lanttern_web/components/reporting_components.ex
+++ b/lib/lanttern_web/components/reporting_components.ex
@@ -316,7 +316,7 @@ defmodule LantternWeb.ReportingComponents do
   def moment_assessment_point_entry(assigns) do
     ~H"""
     <div id={@id} class={@class}>
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-4">
         <.badge :if={@assessment_point.is_differentiation} theme="diff">
           <%= gettext("Diff") %>
         </.badge>

--- a/lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex
+++ b/lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex
@@ -55,8 +55,18 @@ defmodule LantternWeb.MomentLive.CardsComponent do
             <div class="mt-4 line-clamp-4">
               <.markdown text={moment_card.description} />
             </div>
-            <div :if={moment_card.attachments_count > 0} class="mt-4">
-              <.badge icon_name="hero-paper-clip-mini">
+            <div
+              :if={moment_card.shared_with_students || moment_card.attachments_count > 0}
+              class="flex gap-2 mt-4"
+            >
+              <.badge
+                :if={moment_card.shared_with_students}
+                icon_name="hero-users-mini"
+                theme="student"
+              >
+                <%= gettext("Shared") %>
+              </.badge>
+              <.badge :if={moment_card.attachments_count > 0} icon_name="hero-paper-clip-mini">
                 <%= ngettext("1 attachment", "%{count} attachments", moment_card.attachments_count) %>
               </.badge>
             </div>

--- a/lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex
@@ -397,7 +397,9 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
   end
 
   def handle_event("delete", _, socket) do
-    LearningContext.delete_moment_card(socket.assigns.moment_card)
+    LearningContext.delete_moment_card(socket.assigns.moment_card,
+      log_profile_id: socket.assigns.current_user.current_profile_id
+    )
     |> case do
       {:ok, _moment_card} ->
         # we notify using the assigned moment card
@@ -432,7 +434,9 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
         socket.assigns.moment_card.moment_id
       )
 
-    LearningContext.create_moment_card(moment_card_params)
+    LearningContext.create_moment_card(moment_card_params,
+      log_profile_id: socket.assigns.current_user.current_profile_id
+    )
     |> case do
       {:ok, moment_card} ->
         notify(__MODULE__, {:created, moment_card}, socket.assigns)
@@ -452,7 +456,8 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
   defp save_moment_card(socket, _id, moment_card_params) do
     LearningContext.update_moment_card(
       socket.assigns.moment_card,
-      moment_card_params
+      moment_card_params,
+      log_profile_id: socket.assigns.current_user.current_profile_id
     )
     |> case do
       {:ok, moment_card} ->

--- a/lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex
@@ -149,6 +149,41 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
         </h6>
         <.markdown text={@template_instructions} class="mt-4" />
       </div>
+      <div class="p-4 rounded-sm mb-6 bg-ltrn-teacher-lightest">
+        <.input
+          field={@form[:teacher_instructions]}
+          type="textarea"
+          label={gettext("Teacher instructions")}
+          show_optional
+          class="mb-1"
+          phx-debounce="1500"
+        />
+        <.markdown_supported />
+      </div>
+      <div class="p-4 rounded-sm mb-6 bg-ltrn-diff-lightest">
+        <.input
+          field={@form[:differentiation]}
+          type="textarea"
+          label={gettext("Differentiation notes")}
+          show_optional
+          class="mb-1"
+          phx-debounce="1500"
+        />
+        <.markdown_supported />
+      </div>
+      <div class="p-4 rounded-sm mb-6 bg-ltrn-student-lightest">
+        <.input
+          field={@form[:shared_with_students]}
+          type="toggle"
+          theme="student"
+          label={gettext("Share with students and guardians")}
+        />
+        <p class="mt-4">
+          <%= gettext(
+            "If active the card and selected attachments will be displayed for students and guardians in the strand moment details page"
+          ) %>
+        </p>
+      </div>
       <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
         <%= gettext("Oops, something went wrong! Please check the errors above.") %>
       </.error_block>
@@ -178,6 +213,27 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
     ~H"""
     <.scroll_to_top overlay_id={@id} id="details-scroll-top" />
     <.markdown text={@moment_card.description} class="mt-6" />
+    <div :if={@moment_card.teacher_instructions} class="p-4 rounded-sm mt-6 bg-ltrn-teacher-lightest">
+      <p class="mb-4 font-bold text-ltrn-teacher-dark">
+        <%= gettext("Teacher instructions") %>
+      </p>
+      <.markdown text={@moment_card.teacher_instructions} />
+    </div>
+    <div :if={@moment_card.differentiation} class="p-4 rounded-sm mt-6 bg-ltrn-diff-lightest">
+      <p class="mb-4 font-bold text-ltrn-diff-dark">
+        <%= gettext("Differentiation notes") %>
+      </p>
+      <.markdown text={@moment_card.differentiation} />
+    </div>
+    <div
+      :if={@moment_card.shared_with_students}
+      class="flex items-center gap-2 p-4 rounded-sm mt-6 text-ltrn-student-dark bg-ltrn-student-lightest"
+    >
+      <.icon name="hero-users-mini" />
+      <p class="font-bold">
+        <%= gettext("Visible to students and guardians") %>
+      </p>
+    </div>
     <.error_block :if={@is_deleted} class="mt-10">
       <%= gettext("This card was deleted") %>
     </.error_block>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2025.1.22-alpha.42",
+      version: "2025.1.23-alpha.42",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -11,9 +11,9 @@
 msgid ""
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:772
-#: lib/lanttern_web/components/core_components.ex:1812
-#: lib/lanttern_web/components/core_components.ex:1874
+#: lib/lanttern_web/components/core_components.ex:775
+#: lib/lanttern_web/components/core_components.ex:1815
+#: lib/lanttern_web/components/core_components.ex:1877
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Strands"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:905
+#: lib/lanttern_web/components/core_components.ex:908
 #: lib/lanttern_web/components/overlay_components.ex:78
 #: lib/lanttern_web/components/overlay_components.ex:334
 #, elixir-autogen, elixir-format
@@ -99,7 +99,7 @@ msgstr ""
 msgid "Applying filters..."
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:687
+#: lib/lanttern_web/components/form_components.ex:688
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:167
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:118
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:125
@@ -117,18 +117,18 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:101
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:117
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:162
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:109
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:119
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:103
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:94
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:269
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:117
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:150
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:126
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:154
 #: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:59
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:50
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:64
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:167
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:202
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:51
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
@@ -159,7 +159,7 @@ msgstr ""
 msgid "New strand"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:697
+#: lib/lanttern_web/components/form_components.ex:698
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:170
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:121
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:128
@@ -177,14 +177,14 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:104
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:120
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:165
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:112
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:122
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:161
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:69
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:120
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:129
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:67
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:69
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:170
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:205
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
@@ -228,8 +228,8 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:637
-#: lib/lanttern_web/components/form_components.ex:680
+#: lib/lanttern_web/components/form_components.ex:638
+#: lib/lanttern_web/components/form_components.ex:681
 #, elixir-autogen, elixir-format
 msgid "File \"%{file}\" is invalid."
 msgstr ""
@@ -277,7 +277,7 @@ msgstr ""
 msgid "Oops, something went wrong! Please check the errors below."
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:625
+#: lib/lanttern_web/components/form_components.ex:626
 #, elixir-autogen, elixir-format
 msgid "Replace image"
 msgstr ""
@@ -288,7 +288,7 @@ msgid "Save Strand"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:178
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:119
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:128
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:87
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:108
@@ -324,53 +324,53 @@ msgstr ""
 msgid "Strand updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:605
+#: lib/lanttern_web/components/form_components.ex:606
 #, elixir-autogen, elixir-format
 msgid "Upload a cover image file"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:649
+#: lib/lanttern_web/components/form_components.ex:650
 #, elixir-autogen, elixir-format
 msgid "cancel"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:608
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:187
+#: lib/lanttern_web/components/form_components.ex:609
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:191
 #, elixir-autogen, elixir-format
 msgid "or drag and drop here"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:944
+#: lib/lanttern_web/components/core_components.ex:947
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:935
+#: lib/lanttern_web/components/core_components.ex:938
 #, elixir-autogen, elixir-format
 msgid "Error!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:956
+#: lib/lanttern_web/components/core_components.ex:959
 #, elixir-autogen, elixir-format
 msgid "Hang in there while we get back on track"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:777
+#: lib/lanttern_web/components/form_components.ex:778
 #, elixir-autogen, elixir-format
 msgid "Markdown supported"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:934
+#: lib/lanttern_web/components/core_components.ex:937
 #, elixir-autogen, elixir-format
 msgid "Success!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:939
+#: lib/lanttern_web/components/core_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:951
+#: lib/lanttern_web/components/core_components.ex:954
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
@@ -407,7 +407,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:108
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:57
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:192
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:248
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
@@ -455,7 +455,7 @@ msgstr ""
 msgid "Add your notes..."
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:714
+#: lib/lanttern_web/components/form_components.ex:715
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:156
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:107
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:114
@@ -472,7 +472,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:149
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:55
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:190
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:246
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
@@ -508,8 +508,8 @@ msgstr ""
 msgid "Differentiation for %{name}"
 msgstr ""
 
-#: lib/lanttern_web/components/attachments_components.ex:112
-#: lib/lanttern_web/components/core_components.ex:1272
+#: lib/lanttern_web/components/attachments_components.ex:130
+#: lib/lanttern_web/components/core_components.ex:1275
 #: lib/lanttern_web/components/learning_context_components.ex:55
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:44
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:39
@@ -803,7 +803,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1762
+#: lib/lanttern_web/components/core_components.ex:1765
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -823,7 +823,7 @@ msgstr ""
 msgid "Save moment"
 msgstr ""
 
-#: lib/lanttern/learning_context.ex:675
+#: lib/lanttern/learning_context.ex:676
 #: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
@@ -838,6 +838,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:475
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:555
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:556
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:455
 #, elixir-autogen, elixir-format
 msgid "Something went wrong"
 msgstr ""
@@ -857,7 +858,7 @@ msgstr ""
 msgid "Strand has linked moments."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:28
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:29
 #, elixir-autogen, elixir-format
 msgid "Strand moments"
 msgstr ""
@@ -961,7 +962,7 @@ msgstr ""
 msgid "Calculate subject grades"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:610
+#: lib/lanttern_web/components/form_components.ex:611
 #, elixir-autogen, elixir-format
 msgid "Cancel cover removal"
 msgstr ""
@@ -1278,7 +1279,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1752
+#: lib/lanttern_web/components/core_components.ex:1755
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1385,10 +1386,10 @@ msgstr ""
 msgid "Recalculate grade"
 msgstr ""
 
-#: lib/lanttern_web/components/attachments_components.ex:117
+#: lib/lanttern_web/components/attachments_components.ex:135
 #: lib/lanttern_web/components/core_components.ex:211
-#: lib/lanttern_web/components/core_components.ex:1351
-#: lib/lanttern_web/components/form_components.ex:716
+#: lib/lanttern_web/components/core_components.ex:1354
+#: lib/lanttern_web/components/form_components.ex:717
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
 msgid "Remove"
@@ -1800,8 +1801,8 @@ msgstr ""
 msgid "Hey!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1409
-#: lib/lanttern_web/components/core_components.ex:1431
+#: lib/lanttern_web/components/core_components.ex:1412
+#: lib/lanttern_web/components/core_components.ex:1434
 #, elixir-autogen, elixir-format
 msgid "Selected"
 msgstr ""
@@ -1811,7 +1812,7 @@ msgstr ""
 msgid "About grades"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:274
+#: lib/lanttern_web/components/form_components.ex:275
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr ""
@@ -1983,7 +1984,7 @@ msgid "Has footnote"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:408
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:111
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:120
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgstr ""
@@ -2127,54 +2128,54 @@ msgstr ""
 msgid "updated"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:201
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:205
 #, elixir-autogen, elixir-format
 msgid "(e.g. Google Docs)"
 msgstr ""
 
-#: lib/lanttern_web/components/attachments_components.ex:120
+#: lib/lanttern_web/components/attachments_components.ex:138
 #, elixir-autogen, elixir-format
 msgid "Are you sure? This action cannot be undone."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:104
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "Attachment name"
 msgstr ""
 
-#: lib/lanttern_web/components/attachments_components.ex:90
+#: lib/lanttern_web/components/attachments_components.ex:95
 #, elixir-autogen, elixir-format
 msgid "Copy attachment link markdown"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:399
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Error deleting attachment"
 msgstr ""
 
 #: lib/lanttern_web/components/attachments_components.ex:26
-#: lib/lanttern_web/components/attachments_components.ex:94
-#: lib/lanttern_web/components/attachments_components.ex:126
+#: lib/lanttern_web/components/attachments_components.ex:99
+#: lib/lanttern_web/components/attachments_components.ex:144
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:742
+#: lib/lanttern_web/components/form_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "File too large (max. %{file_size}MB)"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:131
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:140
 #, elixir-autogen, elixir-format
 msgid "File upload"
 msgstr ""
 
-#: lib/lanttern/attachments/attachment.ex:73
+#: lib/lanttern/attachments/attachment.ex:76
 #, elixir-autogen, elixir-format
 msgid "Invalid link format"
 msgstr ""
 
-#: lib/lanttern/attachments/attachment.ex:76
+#: lib/lanttern/attachments/attachment.ex:79
 #, elixir-autogen, elixir-format
 msgid "Links should start with \"https://\" or \"http://\""
 msgstr ""
@@ -2184,25 +2185,25 @@ msgstr ""
 msgid "Note's attachments"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:737
+#: lib/lanttern_web/components/form_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Only %{formats} files accepted"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:200
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:204
 #, elixir-autogen, elixir-format
 msgid "Or add a link to an external file"
 msgstr ""
 
 #: lib/lanttern_web/components/attachments_components.ex:28
-#: lib/lanttern_web/components/attachments_components.ex:96
-#: lib/lanttern_web/components/attachments_components.ex:128
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:153
+#: lib/lanttern_web/components/attachments_components.ex:101
+#: lib/lanttern_web/components/attachments_components.ex:146
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:157
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:184
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:188
 #, elixir-autogen, elixir-format
 msgid "Upload a file"
 msgstr ""
@@ -2519,12 +2520,12 @@ msgstr ""
 msgid "Student comment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:30
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:31
 #, elixir-autogen, elixir-format
 msgid "Here you'll find information about the strand learning journey."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:73
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:74
 #, elixir-autogen, elixir-format
 msgid "No moments registered for this strand"
 msgstr ""
@@ -2544,7 +2545,7 @@ msgstr ""
 msgid "You can click the assessment card to view more details about it."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:33
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:34
 #, elixir-autogen, elixir-format
 msgid "You can click the moment card to view more details about it, including information about formative assessment."
 msgstr ""
@@ -3642,7 +3643,7 @@ msgstr ""
 msgid "School area attachments"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:722
+#: lib/lanttern_web/components/form_components.ex:723
 #, elixir-autogen, elixir-format
 msgid "Upload profile picture"
 msgstr ""
@@ -3672,7 +3673,7 @@ msgstr ""
 msgid "Create a new moment card from scratch"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:195
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:251
 #, elixir-autogen, elixir-format
 msgid "Edit card"
 msgstr ""
@@ -3692,7 +3693,7 @@ msgstr ""
 msgid "Edit template"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:82
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:92
 #, elixir-autogen, elixir-format
 msgid "Moment cards order"
 msgstr ""
@@ -3712,7 +3713,7 @@ msgstr ""
 msgid "No templates created yet"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:153
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:188
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Oops, something went wrong! Please check the errors above."
@@ -3764,7 +3765,7 @@ msgstr ""
 msgid "Templates for new moment cards"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:182
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:238
 #, elixir-autogen, elixir-format
 msgid "This card was deleted"
 msgstr ""
@@ -3774,7 +3775,7 @@ msgstr ""
 msgid "This template was deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:60
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "1 attachment"
 msgid_plural "%{count} attachments"
@@ -3804,4 +3805,52 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/students/id/about_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "Student area attachments"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:82
+#, elixir-autogen, elixir-format
+msgid "Assessment points"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:167
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:224
+#, elixir-autogen, elixir-format
+msgid "Differentiation notes"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:182
+#, elixir-autogen, elixir-format
+msgid "If active the card and selected attachments will be displayed for students and guardians in the strand moment details page"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:98
+#, elixir-autogen, elixir-format
+msgid "More about this moment"
+msgstr ""
+
+#: lib/lanttern_web/components/attachments_components.ex:120
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:179
+#, elixir-autogen, elixir-format
+msgid "Share with students and guardians"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "Shared"
+msgstr ""
+
+#: lib/lanttern_web/components/attachments_components.ex:117
+#, elixir-autogen, elixir-format
+msgid "Shared with students and guardians"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:156
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:218
+#, elixir-autogen, elixir-format
+msgid "Teacher instructions"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:234
+#, elixir-autogen, elixir-format
+msgid "Visible to students and guardians"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -11,9 +11,9 @@ msgstr ""
 "Language: en\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: lib/lanttern_web/components/core_components.ex:772
-#: lib/lanttern_web/components/core_components.ex:1812
-#: lib/lanttern_web/components/core_components.ex:1874
+#: lib/lanttern_web/components/core_components.ex:775
+#: lib/lanttern_web/components/core_components.ex:1815
+#: lib/lanttern_web/components/core_components.ex:1877
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -61,7 +61,7 @@ msgstr ""
 msgid "Strands"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:905
+#: lib/lanttern_web/components/core_components.ex:908
 #: lib/lanttern_web/components/overlay_components.ex:78
 #: lib/lanttern_web/components/overlay_components.ex:334
 #, elixir-autogen, elixir-format
@@ -99,7 +99,7 @@ msgstr ""
 msgid "Applying filters..."
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:687
+#: lib/lanttern_web/components/form_components.ex:688
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:167
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:118
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:125
@@ -117,18 +117,18 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:101
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:117
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:162
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:109
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:119
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:103
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:94
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:269
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:117
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:150
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:126
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:154
 #: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:59
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:50
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:64
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:167
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:202
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:51
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
@@ -159,7 +159,7 @@ msgstr ""
 msgid "New strand"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:697
+#: lib/lanttern_web/components/form_components.ex:698
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:170
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:121
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:128
@@ -177,14 +177,14 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:104
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:120
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:165
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:112
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:122
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:161
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:69
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:120
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:129
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:67
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:69
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:170
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:205
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
@@ -228,8 +228,8 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:637
-#: lib/lanttern_web/components/form_components.ex:680
+#: lib/lanttern_web/components/form_components.ex:638
+#: lib/lanttern_web/components/form_components.ex:681
 #, elixir-autogen, elixir-format
 msgid "File \"%{file}\" is invalid."
 msgstr ""
@@ -277,7 +277,7 @@ msgstr ""
 msgid "Oops, something went wrong! Please check the errors below."
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:625
+#: lib/lanttern_web/components/form_components.ex:626
 #, elixir-autogen, elixir-format
 msgid "Replace image"
 msgstr ""
@@ -288,7 +288,7 @@ msgid "Save Strand"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:178
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:119
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:128
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:87
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:108
@@ -324,53 +324,53 @@ msgstr ""
 msgid "Strand updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:605
+#: lib/lanttern_web/components/form_components.ex:606
 #, elixir-autogen, elixir-format
 msgid "Upload a cover image file"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:649
+#: lib/lanttern_web/components/form_components.ex:650
 #, elixir-autogen, elixir-format, fuzzy
 msgid "cancel"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:608
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:187
+#: lib/lanttern_web/components/form_components.ex:609
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:191
 #, elixir-autogen, elixir-format
 msgid "or drag and drop here"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:944
+#: lib/lanttern_web/components/core_components.ex:947
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:935
+#: lib/lanttern_web/components/core_components.ex:938
 #, elixir-autogen, elixir-format
 msgid "Error!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:956
+#: lib/lanttern_web/components/core_components.ex:959
 #, elixir-autogen, elixir-format
 msgid "Hang in there while we get back on track"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:777
+#: lib/lanttern_web/components/form_components.ex:778
 #, elixir-autogen, elixir-format
 msgid "Markdown supported"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:934
+#: lib/lanttern_web/components/core_components.ex:937
 #, elixir-autogen, elixir-format
 msgid "Success!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:939
+#: lib/lanttern_web/components/core_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:951
+#: lib/lanttern_web/components/core_components.ex:954
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr ""
@@ -407,7 +407,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:108
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:57
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:192
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:248
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
@@ -455,7 +455,7 @@ msgstr ""
 msgid "Add your notes..."
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:714
+#: lib/lanttern_web/components/form_components.ex:715
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:156
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:107
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:114
@@ -472,7 +472,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:149
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:55
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:190
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:246
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
@@ -508,8 +508,8 @@ msgstr ""
 msgid "Differentiation for %{name}"
 msgstr ""
 
-#: lib/lanttern_web/components/attachments_components.ex:112
-#: lib/lanttern_web/components/core_components.ex:1272
+#: lib/lanttern_web/components/attachments_components.ex:130
+#: lib/lanttern_web/components/core_components.ex:1275
 #: lib/lanttern_web/components/learning_context_components.ex:55
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:44
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:39
@@ -803,7 +803,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1762
+#: lib/lanttern_web/components/core_components.ex:1765
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -823,7 +823,7 @@ msgstr ""
 msgid "Save moment"
 msgstr ""
 
-#: lib/lanttern/learning_context.ex:675
+#: lib/lanttern/learning_context.ex:676
 #: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
@@ -838,6 +838,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:475
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:555
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:556
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:455
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Something went wrong"
 msgstr ""
@@ -857,7 +858,7 @@ msgstr ""
 msgid "Strand has linked moments."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:28
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:29
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strand moments"
 msgstr ""
@@ -961,7 +962,7 @@ msgstr ""
 msgid "Calculate subject grades"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:610
+#: lib/lanttern_web/components/form_components.ex:611
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Cancel cover removal"
 msgstr ""
@@ -1278,7 +1279,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1752
+#: lib/lanttern_web/components/core_components.ex:1755
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1385,10 +1386,10 @@ msgstr ""
 msgid "Recalculate grade"
 msgstr ""
 
-#: lib/lanttern_web/components/attachments_components.ex:117
+#: lib/lanttern_web/components/attachments_components.ex:135
 #: lib/lanttern_web/components/core_components.ex:211
-#: lib/lanttern_web/components/core_components.ex:1351
-#: lib/lanttern_web/components/form_components.ex:716
+#: lib/lanttern_web/components/core_components.ex:1354
+#: lib/lanttern_web/components/form_components.ex:717
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
 msgid "Remove"
@@ -1800,8 +1801,8 @@ msgstr ""
 msgid "Hey!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1409
-#: lib/lanttern_web/components/core_components.ex:1431
+#: lib/lanttern_web/components/core_components.ex:1412
+#: lib/lanttern_web/components/core_components.ex:1434
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Selected"
 msgstr ""
@@ -1811,7 +1812,7 @@ msgstr ""
 msgid "About grades"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:274
+#: lib/lanttern_web/components/form_components.ex:275
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr ""
@@ -1983,7 +1984,7 @@ msgid "Has footnote"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:408
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:111
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:120
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgstr ""
@@ -2127,54 +2128,54 @@ msgstr ""
 msgid "updated"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:201
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:205
 #, elixir-autogen, elixir-format
 msgid "(e.g. Google Docs)"
 msgstr ""
 
-#: lib/lanttern_web/components/attachments_components.ex:120
+#: lib/lanttern_web/components/attachments_components.ex:138
 #, elixir-autogen, elixir-format
 msgid "Are you sure? This action cannot be undone."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:104
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "Attachment name"
 msgstr ""
 
-#: lib/lanttern_web/components/attachments_components.ex:90
+#: lib/lanttern_web/components/attachments_components.ex:95
 #, elixir-autogen, elixir-format
 msgid "Copy attachment link markdown"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:399
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:403
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error deleting attachment"
 msgstr ""
 
 #: lib/lanttern_web/components/attachments_components.ex:26
-#: lib/lanttern_web/components/attachments_components.ex:94
-#: lib/lanttern_web/components/attachments_components.ex:126
+#: lib/lanttern_web/components/attachments_components.ex:99
+#: lib/lanttern_web/components/attachments_components.ex:144
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:742
+#: lib/lanttern_web/components/form_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "File too large (max. %{file_size}MB)"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:131
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:140
 #, elixir-autogen, elixir-format
 msgid "File upload"
 msgstr ""
 
-#: lib/lanttern/attachments/attachment.ex:73
+#: lib/lanttern/attachments/attachment.ex:76
 #, elixir-autogen, elixir-format
 msgid "Invalid link format"
 msgstr ""
 
-#: lib/lanttern/attachments/attachment.ex:76
+#: lib/lanttern/attachments/attachment.ex:79
 #, elixir-autogen, elixir-format
 msgid "Links should start with \"https://\" or \"http://\""
 msgstr ""
@@ -2184,25 +2185,25 @@ msgstr ""
 msgid "Note's attachments"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:737
+#: lib/lanttern_web/components/form_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Only %{formats} files accepted"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:200
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:204
 #, elixir-autogen, elixir-format
 msgid "Or add a link to an external file"
 msgstr ""
 
 #: lib/lanttern_web/components/attachments_components.ex:28
-#: lib/lanttern_web/components/attachments_components.ex:96
-#: lib/lanttern_web/components/attachments_components.ex:128
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:153
+#: lib/lanttern_web/components/attachments_components.ex:101
+#: lib/lanttern_web/components/attachments_components.ex:146
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:157
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:184
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:188
 #, elixir-autogen, elixir-format
 msgid "Upload a file"
 msgstr ""
@@ -2519,12 +2520,12 @@ msgstr ""
 msgid "Student comment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:30
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:31
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Here you'll find information about the strand learning journey."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:73
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:74
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No moments registered for this strand"
 msgstr ""
@@ -2544,7 +2545,7 @@ msgstr ""
 msgid "You can click the assessment card to view more details about it."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:33
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:34
 #, elixir-autogen, elixir-format
 msgid "You can click the moment card to view more details about it, including information about formative assessment."
 msgstr ""
@@ -3642,7 +3643,7 @@ msgstr ""
 msgid "School area attachments"
 msgstr ""
 
-#: lib/lanttern_web/components/form_components.ex:722
+#: lib/lanttern_web/components/form_components.ex:723
 #, elixir-autogen, elixir-format
 msgid "Upload profile picture"
 msgstr ""
@@ -3672,7 +3673,7 @@ msgstr ""
 msgid "Create a new moment card from scratch"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:195
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:251
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit card"
 msgstr ""
@@ -3692,7 +3693,7 @@ msgstr ""
 msgid "Edit template"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:82
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:92
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Moment cards order"
 msgstr ""
@@ -3712,7 +3713,7 @@ msgstr ""
 msgid "No templates created yet"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:153
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:188
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:67
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Oops, something went wrong! Please check the errors above."
@@ -3764,7 +3765,7 @@ msgstr ""
 msgid "Templates for new moment cards"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:182
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:238
 #, elixir-autogen, elixir-format, fuzzy
 msgid "This card was deleted"
 msgstr ""
@@ -3774,7 +3775,7 @@ msgstr ""
 msgid "This template was deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:60
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:70
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 attachment"
 msgid_plural "%{count} attachments"
@@ -3804,4 +3805,52 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/students/id/about_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "Student area attachments"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:82
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Assessment points"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:167
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:224
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Differentiation notes"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:182
+#, elixir-autogen, elixir-format
+msgid "If active the card and selected attachments will be displayed for students and guardians in the strand moment details page"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:98
+#, elixir-autogen, elixir-format
+msgid "More about this moment"
+msgstr ""
+
+#: lib/lanttern_web/components/attachments_components.ex:120
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:179
+#, elixir-autogen, elixir-format
+msgid "Share with students and guardians"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "Shared"
+msgstr ""
+
+#: lib/lanttern_web/components/attachments_components.ex:117
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Shared with students and guardians"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:156
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:218
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Teacher instructions"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:234
+#, elixir-autogen, elixir-format
+msgid "Visible to students and guardians"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -11,9 +11,9 @@ msgstr ""
 "Language: pt_BR\n"
 "Plural-Forms: nplurals=2; plural=(n>1);\n"
 
-#: lib/lanttern_web/components/core_components.ex:772
-#: lib/lanttern_web/components/core_components.ex:1812
-#: lib/lanttern_web/components/core_components.ex:1874
+#: lib/lanttern_web/components/core_components.ex:775
+#: lib/lanttern_web/components/core_components.ex:1815
+#: lib/lanttern_web/components/core_components.ex:1877
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Ações"
@@ -61,7 +61,7 @@ msgstr "Escola"
 msgid "Strands"
 msgstr "Trilhas"
 
-#: lib/lanttern_web/components/core_components.ex:905
+#: lib/lanttern_web/components/core_components.ex:908
 #: lib/lanttern_web/components/overlay_components.ex:78
 #: lib/lanttern_web/components/overlay_components.ex:334
 #, elixir-autogen, elixir-format
@@ -99,7 +99,7 @@ msgstr "Aplicar filtros"
 msgid "Applying filters..."
 msgstr "Aplicando filtros..."
 
-#: lib/lanttern_web/components/form_components.ex:687
+#: lib/lanttern_web/components/form_components.ex:688
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:167
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:118
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:125
@@ -117,18 +117,18 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:101
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:117
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:162
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:109
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:119
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:103
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:94
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:269
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:117
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:150
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:126
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:154
 #: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:59
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:50
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:64
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:167
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:202
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:51
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
@@ -159,7 +159,7 @@ msgstr "Carregar mais trilhas"
 msgid "New strand"
 msgstr "Nova trilha"
 
-#: lib/lanttern_web/components/form_components.ex:697
+#: lib/lanttern_web/components/form_components.ex:698
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:170
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:121
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:128
@@ -177,14 +177,14 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:104
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:120
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:165
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:112
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:122
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:106
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:161
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:69
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:120
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:129
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:67
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:69
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:170
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:205
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
@@ -228,8 +228,8 @@ msgstr "Suas trilhas favoritas"
 msgid "Description"
 msgstr "Descrição"
 
-#: lib/lanttern_web/components/form_components.ex:637
-#: lib/lanttern_web/components/form_components.ex:680
+#: lib/lanttern_web/components/form_components.ex:638
+#: lib/lanttern_web/components/form_components.ex:681
 #, elixir-autogen, elixir-format
 msgid "File \"%{file}\" is invalid."
 msgstr "O arquivo \"%{file}\" é inválido."
@@ -277,7 +277,7 @@ msgstr "Nenhum ano selecionado"
 msgid "Oops, something went wrong! Please check the errors below."
 msgstr "Oops, algo deu errado! Por favor, confira os erros abaixo."
 
-#: lib/lanttern_web/components/form_components.ex:625
+#: lib/lanttern_web/components/form_components.ex:626
 #, elixir-autogen, elixir-format
 msgid "Replace image"
 msgstr "Alterar imagem"
@@ -288,7 +288,7 @@ msgid "Save Strand"
 msgstr "Salvar Trilha"
 
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:178
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:119
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:128
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:87
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:108
@@ -324,53 +324,53 @@ msgstr "Trilha criada com sucesso"
 msgid "Strand updated successfully"
 msgstr "Trilha atualizada com sucesso"
 
-#: lib/lanttern_web/components/form_components.ex:605
+#: lib/lanttern_web/components/form_components.ex:606
 #, elixir-autogen, elixir-format
 msgid "Upload a cover image file"
 msgstr "Faça o upload de um arquivo de imagem de capa"
 
-#: lib/lanttern_web/components/form_components.ex:649
+#: lib/lanttern_web/components/form_components.ex:650
 #, elixir-autogen, elixir-format
 msgid "cancel"
 msgstr "cancelar"
 
-#: lib/lanttern_web/components/form_components.ex:608
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:187
+#: lib/lanttern_web/components/form_components.ex:609
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:191
 #, elixir-autogen, elixir-format
 msgid "or drag and drop here"
 msgstr "ou arraste e solte aqui"
 
-#: lib/lanttern_web/components/core_components.ex:944
+#: lib/lanttern_web/components/core_components.ex:947
 #, elixir-autogen, elixir-format
 msgid "Attempting to reconnect"
 msgstr "Tentando reconectar"
 
-#: lib/lanttern_web/components/core_components.ex:935
+#: lib/lanttern_web/components/core_components.ex:938
 #, elixir-autogen, elixir-format
 msgid "Error!"
 msgstr "Erro!"
 
-#: lib/lanttern_web/components/core_components.ex:956
+#: lib/lanttern_web/components/core_components.ex:959
 #, elixir-autogen, elixir-format
 msgid "Hang in there while we get back on track"
 msgstr "Aguente firme enquanto nos reconectamos"
 
-#: lib/lanttern_web/components/form_components.ex:777
+#: lib/lanttern_web/components/form_components.ex:778
 #, elixir-autogen, elixir-format
 msgid "Markdown supported"
 msgstr "Suporta Markdown"
 
-#: lib/lanttern_web/components/core_components.ex:934
+#: lib/lanttern_web/components/core_components.ex:937
 #, elixir-autogen, elixir-format
 msgid "Success!"
 msgstr "Sucesso!"
 
-#: lib/lanttern_web/components/core_components.ex:939
+#: lib/lanttern_web/components/core_components.ex:942
 #, elixir-autogen, elixir-format
 msgid "We can't find the internet"
 msgstr "Não conseguimos nos conectar"
 
-#: lib/lanttern_web/components/core_components.ex:951
+#: lib/lanttern_web/components/core_components.ex:954
 #, elixir-autogen, elixir-format
 msgid "Something went wrong!"
 msgstr "Algo deu errado!"
@@ -407,7 +407,7 @@ msgstr "Não foi possível encontrar a trilha"
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:108
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:55
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:57
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:192
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:248
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
@@ -455,7 +455,7 @@ msgstr "Adicionar objetivo da trilha"
 msgid "Add your notes..."
 msgstr "Adicione suas anotações..."
 
-#: lib/lanttern_web/components/form_components.ex:714
+#: lib/lanttern_web/components/form_components.ex:715
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:156
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:107
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:114
@@ -472,7 +472,7 @@ msgstr "Adicione suas anotações..."
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:149
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:55
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:190
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:246
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
@@ -508,8 +508,8 @@ msgstr "Diferenciação"
 msgid "Differentiation for %{name}"
 msgstr "Diferenciação para %{name}"
 
-#: lib/lanttern_web/components/attachments_components.ex:112
-#: lib/lanttern_web/components/core_components.ex:1272
+#: lib/lanttern_web/components/attachments_components.ex:130
+#: lib/lanttern_web/components/core_components.ex:1275
 #: lib/lanttern_web/components/learning_context_components.ex:55
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:44
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:39
@@ -803,7 +803,7 @@ msgstr "Momento atualizado com sucesso"
 msgid "Moments"
 msgstr "Momentos"
 
-#: lib/lanttern_web/components/core_components.ex:1762
+#: lib/lanttern_web/components/core_components.ex:1765
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr "Mover momento para baixo"
@@ -823,7 +823,7 @@ msgstr "Nenhum momento para esta trilha ainda"
 msgid "Save moment"
 msgstr "Salvar momento"
 
-#: lib/lanttern/learning_context.ex:675
+#: lib/lanttern/learning_context.ex:676
 #: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
@@ -838,6 +838,7 @@ msgstr "Salvar momento"
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:475
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:555
 #: lib/lanttern_web/live/shared/assessments/entry_details_component.ex:556
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:455
 #, elixir-autogen, elixir-format
 msgid "Something went wrong"
 msgstr "Algo deu errado"
@@ -857,7 +858,7 @@ msgstr "Trilha com momentos e/ou pontos de avaliação (objetivos) conectados. D
 msgid "Strand has linked moments."
 msgstr "Trilha possui momentos conectados."
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:28
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:29
 #, elixir-autogen, elixir-format
 msgid "Strand moments"
 msgstr "Momentos da trilha"
@@ -961,7 +962,7 @@ msgstr "Calcular notas do estudante"
 msgid "Calculate subject grades"
 msgstr "Calcular notas da disciplina"
 
-#: lib/lanttern_web/components/form_components.ex:610
+#: lib/lanttern_web/components/form_components.ex:611
 #, elixir-autogen, elixir-format
 msgid "Cancel cover removal"
 msgstr "Cancelar remoção da capa"
@@ -1278,7 +1279,7 @@ msgstr "Card de momento atualizado com sucesso"
 msgid "Move down"
 msgstr "Mover para baixo"
 
-#: lib/lanttern_web/components/core_components.ex:1752
+#: lib/lanttern_web/components/core_components.ex:1755
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1385,10 +1386,10 @@ msgstr "Prévia"
 msgid "Recalculate grade"
 msgstr "Recalcular nota"
 
-#: lib/lanttern_web/components/attachments_components.ex:117
+#: lib/lanttern_web/components/attachments_components.ex:135
 #: lib/lanttern_web/components/core_components.ex:211
-#: lib/lanttern_web/components/core_components.ex:1351
-#: lib/lanttern_web/components/form_components.ex:716
+#: lib/lanttern_web/components/core_components.ex:1354
+#: lib/lanttern_web/components/form_components.ex:717
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
 msgid "Remove"
@@ -1800,8 +1801,8 @@ msgstr "Limpar seleção"
 msgid "Hey!"
 msgstr "Olá!"
 
-#: lib/lanttern_web/components/core_components.ex:1409
-#: lib/lanttern_web/components/core_components.ex:1431
+#: lib/lanttern_web/components/core_components.ex:1412
+#: lib/lanttern_web/components/core_components.ex:1434
 #, elixir-autogen, elixir-format
 msgid "Selected"
 msgstr "Selecionado"
@@ -1811,7 +1812,7 @@ msgstr "Selecionado"
 msgid "About grades"
 msgstr "Sobre as notas"
 
-#: lib/lanttern_web/components/form_components.ex:274
+#: lib/lanttern_web/components/form_components.ex:275
 #, elixir-autogen, elixir-format
 msgid "Optional"
 msgstr "Opcional"
@@ -1983,7 +1984,7 @@ msgid "Has footnote"
 msgstr "Possui nota de rodapé"
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:408
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:111
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:120
 #, elixir-autogen, elixir-format
 msgid "Link"
 msgstr "Vincular"
@@ -2127,54 +2128,54 @@ msgstr "Anotações do estudante sobre a trilha"
 msgid "updated"
 msgstr "atualizado"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:201
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:205
 #, elixir-autogen, elixir-format
 msgid "(e.g. Google Docs)"
 msgstr "(por exemplo: Google Docs)"
 
-#: lib/lanttern_web/components/attachments_components.ex:120
+#: lib/lanttern_web/components/attachments_components.ex:138
 #, elixir-autogen, elixir-format
 msgid "Are you sure? This action cannot be undone."
 msgstr "Você tem certeza? Esta ação não pode ser desfeita."
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:104
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "Attachment name"
 msgstr "Nome do anexo"
 
-#: lib/lanttern_web/components/attachments_components.ex:90
+#: lib/lanttern_web/components/attachments_components.ex:95
 #, elixir-autogen, elixir-format
 msgid "Copy attachment link markdown"
 msgstr "Copiar link do anexo em markdown"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:399
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:403
 #, elixir-autogen, elixir-format
 msgid "Error deleting attachment"
 msgstr "Erro ao deletar anexo"
 
 #: lib/lanttern_web/components/attachments_components.ex:26
-#: lib/lanttern_web/components/attachments_components.ex:94
-#: lib/lanttern_web/components/attachments_components.ex:126
+#: lib/lanttern_web/components/attachments_components.ex:99
+#: lib/lanttern_web/components/attachments_components.ex:144
 #, elixir-autogen, elixir-format
 msgid "External link"
 msgstr "Link externo"
 
-#: lib/lanttern_web/components/form_components.ex:742
+#: lib/lanttern_web/components/form_components.ex:743
 #, elixir-autogen, elixir-format
 msgid "File too large (max. %{file_size}MB)"
 msgstr "Arquivo muito grande (máx. %{file_size}MB)"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:131
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:140
 #, elixir-autogen, elixir-format
 msgid "File upload"
 msgstr "Upload de arquivo"
 
-#: lib/lanttern/attachments/attachment.ex:73
+#: lib/lanttern/attachments/attachment.ex:76
 #, elixir-autogen, elixir-format
 msgid "Invalid link format"
 msgstr "Formato do link inválido"
 
-#: lib/lanttern/attachments/attachment.ex:76
+#: lib/lanttern/attachments/attachment.ex:79
 #, elixir-autogen, elixir-format
 msgid "Links should start with \"https://\" or \"http://\""
 msgstr "Links precisam começar com \"https://\" ou \"http://\""
@@ -2184,25 +2185,25 @@ msgstr "Links precisam começar com \"https://\" ou \"http://\""
 msgid "Note's attachments"
 msgstr "Anexos da anotação"
 
-#: lib/lanttern_web/components/form_components.ex:737
+#: lib/lanttern_web/components/form_components.ex:738
 #, elixir-autogen, elixir-format
 msgid "Only %{formats} files accepted"
 msgstr "Apenas arquivos do tipo %{formats} são aceitos"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:200
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:204
 #, elixir-autogen, elixir-format
 msgid "Or add a link to an external file"
 msgstr "Ou adicione um link para um arquivo externo"
 
 #: lib/lanttern_web/components/attachments_components.ex:28
-#: lib/lanttern_web/components/attachments_components.ex:96
-#: lib/lanttern_web/components/attachments_components.ex:128
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:153
+#: lib/lanttern_web/components/attachments_components.ex:101
+#: lib/lanttern_web/components/attachments_components.ex:146
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:157
 #, elixir-autogen, elixir-format
 msgid "Upload"
 msgstr "Upload"
 
-#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:184
+#: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:188
 #, elixir-autogen, elixir-format
 msgid "Upload a file"
 msgstr "Upload de arquivo"
@@ -2519,12 +2520,12 @@ msgstr "Sem registro"
 msgid "Student comment"
 msgstr "Comentário do estudante"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:30
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:31
 #, elixir-autogen, elixir-format
 msgid "Here you'll find information about the strand learning journey."
 msgstr "Aqui você irá encontrar informações sobre a jornada de aprendizagem da trilha."
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:73
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:74
 #, elixir-autogen, elixir-format
 msgid "No moments registered for this strand"
 msgstr "Nenhum momento registrado nesta trilha"
@@ -2544,7 +2545,7 @@ msgstr "Rubricas da trilha"
 msgid "You can click the assessment card to view more details about it."
 msgstr "Você pode clicar no card da avaliação para ver mais detalhes."
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:33
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:34
 #, elixir-autogen, elixir-format
 msgid "You can click the moment card to view more details about it, including information about formative assessment."
 msgstr "Você pode clicar no card de momento para ver mais detalhes, incluindo informações sobre avaliação formativa."
@@ -3642,7 +3643,7 @@ msgstr "Área da escola"
 msgid "School area attachments"
 msgstr "Anexos da área da escola"
 
-#: lib/lanttern_web/components/form_components.ex:722
+#: lib/lanttern_web/components/form_components.ex:723
 #, elixir-autogen, elixir-format
 msgid "Upload profile picture"
 msgstr "Upload de foto de perfil"
@@ -3672,7 +3673,7 @@ msgstr "Instruções adicionais para professores"
 msgid "Create a new moment card from scratch"
 msgstr "Criar novo card de momento do zero"
 
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:195
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:251
 #, elixir-autogen, elixir-format
 msgid "Edit card"
 msgstr "Editar card"
@@ -3692,7 +3693,7 @@ msgstr "Editar template de card de momento"
 msgid "Edit template"
 msgstr "Editar template"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:82
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:92
 #, elixir-autogen, elixir-format
 msgid "Moment cards order"
 msgstr "Ordem dos cards de momento"
@@ -3712,7 +3713,7 @@ msgstr "Novo template de card de momento"
 msgid "No templates created yet"
 msgstr "Nenhum template criado ainda"
 
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:153
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:188
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Oops, something went wrong! Please check the errors above."
@@ -3764,7 +3765,7 @@ msgstr "Templates"
 msgid "Templates for new moment cards"
 msgstr "Templates para novos cards de momento"
 
-#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:182
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:238
 #, elixir-autogen, elixir-format
 msgid "This card was deleted"
 msgstr "Este card foi deletado"
@@ -3774,7 +3775,7 @@ msgstr "Este card foi deletado"
 msgid "This template was deleted"
 msgstr "Este template foi deletado"
 
-#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:60
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "1 attachment"
 msgid_plural "%{count} attachments"
@@ -3805,3 +3806,51 @@ msgstr "Área de estudante"
 #, elixir-autogen, elixir-format
 msgid "Student area attachments"
 msgstr "Anexos da área de estudante"
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:82
+#, elixir-autogen, elixir-format
+msgid "Assessment points"
+msgstr "Pontos de avaliação"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:167
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:224
+#, elixir-autogen, elixir-format
+msgid "Differentiation notes"
+msgstr "Notas sobre diferenciação"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:182
+#, elixir-autogen, elixir-format
+msgid "If active the card and selected attachments will be displayed for students and guardians in the strand moment details page"
+msgstr "Se ativo, o card e os anexos selecionados serão exibidos para estudantes e guardiões na página de detalhes do momento da trilha"
+
+#: lib/lanttern_web/live/shared/reporting/strand_report_moments_component.ex:98
+#, elixir-autogen, elixir-format
+msgid "More about this moment"
+msgstr "Mais sobre este momento"
+
+#: lib/lanttern_web/components/attachments_components.ex:120
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:179
+#, elixir-autogen, elixir-format
+msgid "Share with students and guardians"
+msgstr "Compartilhar com estudantes e guardiões"
+
+#: lib/lanttern_web/live/pages/strands/moment/id/cards_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "Shared"
+msgstr "Compartilhado"
+
+#: lib/lanttern_web/components/attachments_components.ex:117
+#, elixir-autogen, elixir-format
+msgid "Shared with students and guardians"
+msgstr "Compartilhado com estudantes e guardiões"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:156
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:218
+#, elixir-autogen, elixir-format
+msgid "Teacher instructions"
+msgstr "Instruções para professores"
+
+#: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:234
+#, elixir-autogen, elixir-format
+msgid "Visible to students and guardians"
+msgstr "Visível para estudantes e guardiões"

--- a/priv/repo/migrations/20250122163559_add_students_sharing_fields_to_moment_cards.exs
+++ b/priv/repo/migrations/20250122163559_add_students_sharing_fields_to_moment_cards.exs
@@ -1,0 +1,11 @@
+defmodule Lanttern.Repo.Migrations.AddStudentsSharingFieldsToMomentCards do
+  use Ecto.Migration
+
+  def change do
+    alter table(:moment_cards) do
+      add :shared_with_students, :boolean, default: false, null: false
+      add :teacher_instructions, :text
+      add :differentiation, :text
+    end
+  end
+end

--- a/priv/repo/migrations/20250123132842_create_moment_cards_log.exs
+++ b/priv/repo/migrations/20250123132842_create_moment_cards_log.exs
@@ -1,0 +1,31 @@
+defmodule Lanttern.Repo.Migrations.CreateMomentCardsLog do
+  use Ecto.Migration
+
+  @prefix "log"
+
+  def change do
+    create table(:moment_cards, prefix: @prefix) do
+      add :moment_card_id, :bigint, null: false
+      add :profile_id, :bigint, null: false
+      add :operation, :text, null: false
+
+      add :moment_id, :bigint, null: false
+
+      add :name, :text, null: false
+      add :position, :integer, null: false
+      add :description, :text, null: false
+      add :teacher_instructions, :text
+      add :differentiation, :text
+      add :shared_with_students, :boolean, null: false
+
+      timestamps(updated_at: false)
+    end
+
+    create constraint(
+             :moment_cards,
+             :valid_operations,
+             prefix: @prefix,
+             check: "operation IN ('CREATE', 'UPDATE', 'DELETE')"
+           )
+  end
+end

--- a/test/lanttern/attachments_test.exs
+++ b/test/lanttern/attachments_test.exs
@@ -119,7 +119,7 @@ defmodule Lanttern.AttachmentsTest do
           %{"name" => "attachment 2", "link" => "https://somevaliduri.com", "is_external" => true}
         )
 
-      {:ok, family_attachment} =
+      {:ok, shared_attachment} =
         StudentsCycleInfo.create_student_cycle_info_attachment(
           profile.id,
           student_cycle_info.id,
@@ -144,7 +144,7 @@ defmodule Lanttern.AttachmentsTest do
         }
       )
 
-      assert [attachment_1, attachment_2, family_attachment] ==
+      assert [attachment_1, attachment_2, shared_attachment] ==
                Attachments.list_attachments(student_cycle_info_id: student_cycle_info.id)
 
       # use same setup to test update_student_cycle_info_attachments_positions/1 and shared_with_student filtering
@@ -179,7 +179,7 @@ defmodule Lanttern.AttachmentsTest do
           %{"name" => "attachment 2", "link" => "https://somevaliduri.com", "is_external" => true}
         )
 
-      {:ok, family_attachment} =
+      {:ok, shared_attachment} =
         LearningContext.create_moment_card_attachment(
           profile.id,
           moment_card.id,
@@ -204,12 +204,17 @@ defmodule Lanttern.AttachmentsTest do
         }
       )
 
-      [expected_attachment_1, expected_attachment_2, expected_family_attachment] =
+      [expected_attachment_1, expected_attachment_2, expected_shared_attachment] =
         Attachments.list_attachments(moment_card_id: moment_card.id)
 
       assert expected_attachment_1.id == attachment_1.id
       assert expected_attachment_2.id == attachment_2.id
-      assert expected_family_attachment.id == family_attachment.id
+      assert expected_shared_attachment.id == shared_attachment.id
+
+      # expect is_shared is defined in the context of moment card attachments
+      assert expected_attachment_1.is_shared == false
+      assert expected_attachment_2.is_shared == false
+      assert expected_shared_attachment.is_shared
 
       # use same setup to test update_moment_card_attachments_positions/1 and shared_with_students filtering
 

--- a/test/lanttern/learning_context_test.exs
+++ b/test/lanttern/learning_context_test.exs
@@ -900,5 +900,24 @@ defmodule Lanttern.LearningContextTest do
       moment_card = moment_card_fixture()
       assert %Ecto.Changeset{} = LearningContext.change_moment_card(moment_card)
     end
+
+    test "toggle_moment_card_attachment_share/1 returns the updated attachment" do
+      moment_card = moment_card_fixture()
+      profile = IdentityFixtures.teacher_profile_fixture()
+
+      {:ok, attachment} =
+        LearningContext.create_moment_card_attachment(
+          profile.id,
+          moment_card.id,
+          %{"name" => "attachment", "link" => "https://somevaliduri.com"}
+        )
+
+      assert attachment.is_shared == false
+
+      {:ok, attachment} =
+        LearningContext.toggle_moment_card_attachment_share(attachment)
+
+      assert attachment.is_shared
+    end
   end
 end

--- a/test/lanttern/reporting_test.exs
+++ b/test/lanttern/reporting_test.exs
@@ -361,7 +361,10 @@ defmodule Lanttern.ReportingTest do
       report_card_2024 = report_card_fixture(%{school_cycle_id: cycle_2024.id})
 
       student_report_card_2023 =
-        student_report_card_fixture(%{report_card_id: report_card_2023.id, student_id: student.id})
+        student_report_card_fixture(%{
+          report_card_id: report_card_2023.id,
+          student_id: student.id
+        })
 
       student_report_card_2024_q4 =
         student_report_card_fixture(%{
@@ -370,7 +373,10 @@ defmodule Lanttern.ReportingTest do
         })
 
       student_report_card_2024 =
-        student_report_card_fixture(%{report_card_id: report_card_2024.id, student_id: student.id})
+        student_report_card_fixture(%{
+          report_card_id: report_card_2024.id,
+          student_id: student.id
+        })
 
       # extra fixtures for filter testing
       student_report_card_fixture(%{report_card_id: report_card_2023.id})
@@ -759,10 +765,16 @@ defmodule Lanttern.ReportingTest do
       # link student to report cards
 
       student_report_card_2023 =
-        student_report_card_fixture(%{report_card_id: report_card_2023.id, student_id: student.id})
+        student_report_card_fixture(%{
+          report_card_id: report_card_2023.id,
+          student_id: student.id
+        })
 
       student_report_card_2024 =
-        student_report_card_fixture(%{report_card_id: report_card_2024.id, student_id: student.id})
+        student_report_card_fixture(%{
+          report_card_id: report_card_2024.id,
+          student_id: student.id
+        })
 
       # other fixtures for query testing
       other_report_card = report_card_fixture()
@@ -1840,6 +1852,7 @@ defmodule Lanttern.ReportingTest do
     alias Lanttern.AssessmentsFixtures
     alias Lanttern.CurriculaFixtures
     alias Lanttern.GradingFixtures
+    alias Lanttern.LearningContext
     alias Lanttern.LearningContextFixtures
     alias Lanttern.TaxonomyFixtures
 
@@ -1968,6 +1981,46 @@ defmodule Lanttern.ReportingTest do
 
       assert expected_class_1.id == class_1.id
       assert expected_class_2.id == class_2.id
+    end
+
+    test "list_moment_cards_and_attachments_shared_with_students/1 returns all cards and attachments for the given moment" do
+      moment = LearningContextFixtures.moment_fixture()
+
+      moment_card =
+        LearningContextFixtures.moment_card_fixture(%{
+          moment_id: moment.id,
+          shared_with_students: true
+        })
+
+      _not_shared_card =
+        LearningContextFixtures.moment_card_fixture(%{
+          moment_id: moment.id,
+          shared_with_students: false
+        })
+
+      profile = Lanttern.IdentityFixtures.teacher_profile_fixture()
+
+      {:ok, attachment} =
+        LearningContext.create_moment_card_attachment(
+          profile.id,
+          moment_card.id,
+          %{"name" => "attachment", "link" => "https://somevaliduri.com"},
+          true
+        )
+
+      {:ok, _not_shared_attachment} =
+        LearningContext.create_moment_card_attachment(
+          profile.id,
+          moment_card.id,
+          %{"name" => "attachment", "link" => "https://somevaliduri.com"}
+        )
+
+      [expected_card] =
+        Reporting.list_moment_cards_and_attachments_shared_with_students(moment.id)
+
+      assert expected_card.id == moment_card.id
+      [expected_attachment] = expected_card.attachments
+      assert expected_attachment.id == attachment.id
     end
   end
 end


### PR DESCRIPTION
- added support to control which moment cards (and attachments) should be displayed to students and guardians
- added support to teacher instructions and differentiation notes in moment cards

<img width="603" alt="image" src="https://github.com/user-attachments/assets/a1fbd98f-e9d8-4c66-82c7-652520364b08" />

- added moment card info in strand reports

<img width="1437" alt="image" src="https://github.com/user-attachments/assets/bea57356-8c75-434b-a363-d143d69b55af" />

resolves #254 