### PR TITLE
added created by and assignees to student records

### DIFF
--- a/lib/lanttern/personalization/profile_settings.ex
+++ b/lib/lanttern/personalization/profile_settings.ex
@@ -35,6 +35,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
           student_record_types_ids: [pos_integer()],
           student_record_statuses_ids: [pos_integer()],
           student_record_assignees_ids: [pos_integer()],
+          student_record_staff_member_view: String.t(),
           only_starred_strands: boolean(),
           student_info_cycle_id: pos_integer()
         }
@@ -55,6 +56,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
       field :student_record_types_ids, {:array, :id}
       field :student_record_statuses_ids, {:array, :id}
       field :student_record_assignees_ids, {:array, :id}
+      field :student_record_staff_member_view, :string
       field :only_starred_strands, :boolean, default: false
       field :student_info_cycle_id, :id
     end
@@ -90,6 +92,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
       :student_record_types_ids,
       :student_record_statuses_ids,
       :student_record_assignees_ids,
+      :student_record_staff_member_view,
       :only_starred_strands,
       :student_info_cycle_id
     ])
@@ -102,6 +105,12 @@ defmodule Lanttern.Personalization.ProfileSettings do
       if view in ["curriculum", "moment"],
         do: [],
         else: [assessment_group_by: gettext("Invalid assessment group by option")]
+    end)
+    |> validate_change(:student_record_staff_member_view, fn :student_record_staff_member_view,
+                                                             view ->
+      if view in ["owned_by", "assigned_to"],
+        do: [],
+        else: [student_record_staff_member_view: gettext("Invalid view option")]
     end)
   end
 end

--- a/lib/lanttern/personalization/profile_settings.ex
+++ b/lib/lanttern/personalization/profile_settings.ex
@@ -34,6 +34,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
           students_ids: [pos_integer()],
           student_record_types_ids: [pos_integer()],
           student_record_statuses_ids: [pos_integer()],
+          student_record_assignees_ids: [pos_integer()],
           only_starred_strands: boolean(),
           student_info_cycle_id: pos_integer()
         }
@@ -53,6 +54,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
       field :students_ids, {:array, :id}
       field :student_record_types_ids, {:array, :id}
       field :student_record_statuses_ids, {:array, :id}
+      field :student_record_assignees_ids, {:array, :id}
       field :only_starred_strands, :boolean, default: false
       field :student_info_cycle_id, :id
     end
@@ -87,6 +89,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
       :students_ids,
       :student_record_types_ids,
       :student_record_statuses_ids,
+      :student_record_assignees_ids,
       :only_starred_strands,
       :student_info_cycle_id
     ])

--- a/lib/lanttern/personalization/profile_settings.ex
+++ b/lib/lanttern/personalization/profile_settings.ex
@@ -108,7 +108,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
     end)
     |> validate_change(:student_record_staff_member_view, fn :student_record_staff_member_view,
                                                              view ->
-      if view in ["owned_by", "assigned_to"],
+      if view in ["created_by", "assigned_to"],
         do: [],
         else: [student_record_staff_member_view: gettext("Invalid view option")]
     end)

--- a/lib/lanttern/schools.ex
+++ b/lib/lanttern/schools.ex
@@ -952,6 +952,7 @@ defmodule Lanttern.Schools do
   ### Options:
 
   - `:school_id` – filter staff members by school
+  - `:staff_members_ids` – filter staff members by provided ids
   - `:load_email` - boolean, will add the email field based on staff member profile/user
   - `:only_active` - boolean, will return only active staff members
   - `:only_deactivated` - boolean, will return only deactivated staff members
@@ -982,6 +983,15 @@ defmodule Lanttern.Schools do
     from(
       sm in queryable,
       where: sm.school_id == ^school_id
+    )
+    |> apply_list_staff_members_opts(opts)
+  end
+
+  defp apply_list_staff_members_opts(queryable, [{:staff_members_ids, ids} | opts])
+       when is_list(ids) and ids != [] do
+    from(
+      sm in queryable,
+      where: sm.id in ^ids
     )
     |> apply_list_staff_members_opts(opts)
   end

--- a/lib/lanttern/schools.ex
+++ b/lib/lanttern/schools.ex
@@ -1587,7 +1587,7 @@ defmodule Lanttern.Schools do
       [%Class{}, ...]
 
   """
-  @spec list_classes_for_students_in_date(students_ids :: [pos_integer()], date: Date.t()) :: [
+  @spec list_classes_for_students_in_date(students_ids :: [pos_integer()], Date.t()) :: [
           Class.t()
         ]
   def list_classes_for_students_in_date(students_ids, date) do

--- a/lib/lanttern/schools.ex
+++ b/lib/lanttern/schools.ex
@@ -956,6 +956,7 @@ defmodule Lanttern.Schools do
   - `:only_active` - boolean, will return only active staff members
   - `:only_deactivated` - boolean, will return only deactivated staff members
   - `:preloads` – preloads associated data
+  - `:base_query` - used in conjunction with `search_staff_members/2`
 
   ## Examples
 
@@ -964,8 +965,10 @@ defmodule Lanttern.Schools do
 
   """
   def list_staff_members(opts \\ []) do
+    queryable = Keyword.get(opts, :base_query, StaffMember)
+
     from(
-      sm in StaffMember,
+      sm in queryable,
       order_by: sm.name
     )
     |> apply_list_staff_members_opts(opts)
@@ -1004,6 +1007,34 @@ defmodule Lanttern.Schools do
 
   defp apply_list_staff_members_opts(queryable, [_ | opts]),
     do: apply_list_staff_members_opts(queryable, opts)
+
+  @doc """
+  Search staff members by name.
+
+  ## Options:
+
+  View `list_staff_members/1` for `opts`
+
+  ## Examples
+
+      iex> search_staff_members("some name")
+      [%StaffMember{}, ...]
+
+  """
+  @spec search_staff_members(search_term :: binary(), opts :: Keyword.t()) :: [StaffMember.t()]
+  def search_staff_members(search_term, opts \\ []) do
+    ilike_search_term = "%#{search_term}%"
+
+    query =
+      from(
+        sm in StaffMember,
+        where: ilike(sm.name, ^ilike_search_term),
+        order_by: {:asc, fragment("? <<-> ?", ^search_term, sm.name)}
+      )
+
+    [{:base_query, query} | opts]
+    |> list_staff_members()
+  end
 
   @doc """
   Gets a single staff member.

--- a/lib/lanttern/students_records.ex
+++ b/lib/lanttern/students_records.ex
@@ -21,6 +21,8 @@ defmodule Lanttern.StudentsRecords do
   - `:classes_ids` - filter results by classes
   - `:types_ids` - filter results by type
   - `:statuses_ids` - filter results by status
+  - `:owner_id` - filter results by owner
+  - `:assignees_ids` - filter results by assignees
   - `:preloads` - preloads associated data
   - page opts (view `Page.opts()`)
 
@@ -37,6 +39,8 @@ defmodule Lanttern.StudentsRecords do
             classes_ids: [pos_integer()],
             types_ids: [pos_integer()],
             statuses_ids: [pos_integer()],
+            owner_id: pos_integer(),
+            assignees_ids: [pos_integer()],
             preloads: list()
           ]
           | Page.opts()
@@ -96,6 +100,25 @@ defmodule Lanttern.StudentsRecords do
     from(
       sr in queryable,
       where: sr.status_id in ^statuses_ids
+    )
+    |> apply_list_students_records_opts(opts)
+  end
+
+  defp apply_list_students_records_opts(queryable, [{:owner_id, owner_id} | opts])
+       when not is_nil(owner_id) do
+    from(
+      sr in queryable,
+      where: sr.created_by_staff_member_id == ^owner_id
+    )
+    |> apply_list_students_records_opts(opts)
+  end
+
+  defp apply_list_students_records_opts(queryable, [{:assignees_ids, assignees_ids} | opts])
+       when is_list(assignees_ids) and assignees_ids != [] do
+    from(
+      sr in queryable,
+      join: sra in assoc(sr, :assignees_relationships),
+      where: sra.staff_member_id in ^assignees_ids
     )
     |> apply_list_students_records_opts(opts)
   end

--- a/lib/lanttern/students_records/student_record.ex
+++ b/lib/lanttern/students_records/student_record.ex
@@ -14,6 +14,7 @@ defmodule Lanttern.StudentsRecords.StudentRecord do
   alias Lanttern.StudentsRecords.StudentRecordType
   alias Lanttern.Schools.Class
   alias Lanttern.Schools.School
+  alias Lanttern.Schools.StaffMember
   alias Lanttern.Schools.Student
 
   @type t :: %__MODULE__{
@@ -24,6 +25,8 @@ defmodule Lanttern.StudentsRecords.StudentRecord do
           time: Time.t(),
           students: [Student.t()],
           students_ids: [pos_integer()],
+          created_by_staff_member: StaffMember.t(),
+          created_by_staff_member_id: pos_integer(),
           classes: [Class.t()],
           classes_ids: [pos_integer()],
           school_id: pos_integer(),
@@ -45,6 +48,7 @@ defmodule Lanttern.StudentsRecords.StudentRecord do
     field :classes_ids, {:array, :id}, virtual: true
 
     belongs_to :school, School
+    belongs_to :created_by_staff_member, StaffMember
     belongs_to :status, StudentRecordStatus
     belongs_to :type, StudentRecordType
 
@@ -71,10 +75,18 @@ defmodule Lanttern.StudentsRecords.StudentRecord do
       :students_ids,
       :classes_ids,
       :school_id,
+      :created_by_staff_member_id,
       :type_id,
       :status_id
     ])
-    |> validate_required([:description, :date, :school_id, :type_id, :status_id])
+    |> validate_required([
+      :description,
+      :date,
+      :school_id,
+      :created_by_staff_member_id,
+      :type_id,
+      :status_id
+    ])
     |> cast_and_validate_students()
     |> cast_classes()
   end

--- a/lib/lanttern/students_records/student_record_assignee.ex
+++ b/lib/lanttern/students_records/student_record_assignee.ex
@@ -1,0 +1,23 @@
+defmodule Lanttern.StudentsRecords.Assignee do
+  @moduledoc """
+  The `StudentsRecords.Assignee` schema (join table)
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  schema "students_records_assignees" do
+    field :student_record_id, :id, primary_key: true
+    field :school_id, :id
+
+    belongs_to :staff_member, Lanttern.Schools.Student, primary_key: true
+  end
+
+  @doc false
+  def changeset(assignee, attrs) do
+    assignee
+    |> cast(attrs, [:staff_member_id, :student_record_id, :school_id])
+    |> validate_required([:staff_member_id, :student_record_id, :school_id])
+  end
+end

--- a/lib/lanttern/students_records_log/student_record_log.ex
+++ b/lib/lanttern/students_records_log/student_record_log.ex
@@ -11,13 +11,14 @@ defmodule Lanttern.StudentsRecordsLog.StudentRecordLog do
     field :student_record_id, :id
     field :profile_id, :id
     field :operation, :string
-
     field :name, :string
     field :description, :string
     field :date, :date
     field :time, :time
     field :students_ids, {:array, :id}
     field :classes_ids, {:array, :id}
+    field :created_by_staff_member_id, :id
+    field :assignees_ids, {:array, :id}
     field :school_id, :id
     field :type_id, :id
     field :status_id, :id
@@ -38,6 +39,8 @@ defmodule Lanttern.StudentsRecordsLog.StudentRecordLog do
       :time,
       :students_ids,
       :classes_ids,
+      :created_by_staff_member_id,
+      :assignees_ids,
       :school_id,
       :type_id,
       :status_id
@@ -49,6 +52,7 @@ defmodule Lanttern.StudentsRecordsLog.StudentRecordLog do
       :description,
       :date,
       :students_ids,
+      :created_by_staff_member_id,
       :school_id,
       :type_id,
       :status_id

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -1354,7 +1354,12 @@ defmodule LantternWeb.CoreComponents do
       title={if @truncate, do: @person.name}
       {@rest}
     >
-      <.profile_icon profile_name={@person.name} size={@profile_icon_size} theme={@theme} />
+      <.profile_picture
+        profile_name={@person.name}
+        picture_url={Map.get(@person, :profile_picture_url)}
+        size={@profile_icon_size}
+        theme="clean"
+      />
       <%= if @navigate do %>
         <.link
           navigate={@navigate}
@@ -1391,6 +1396,7 @@ defmodule LantternWeb.CoreComponents do
   end
 
   defp person_badge_theme_style("cyan"), do: "text-ltrn-dark bg-ltrn-mesh-cyan"
+  defp person_badge_theme_style("staff"), do: "text-ltrn-teacher-dark bg-ltrn-teacher-lighter"
   defp person_badge_theme_style(_subtle), do: "text-ltrn-subtle bg-ltrn-lighter"
 
   @doc """
@@ -1553,13 +1559,15 @@ defmodule LantternWeb.CoreComponents do
   """
   attr :picture_url, :string, required: true
   attr :profile_name, :string, default: nil, doc: "render initials when there's no image"
+  attr :theme, :string, default: "default", doc: "default | clean"
   attr :size, :string, default: "md", doc: "xs | sm | md | lg | xl | 2xl"
   attr :class, :any, default: nil
 
   def profile_picture(%{picture_url: nil, profile_name: nil} = assigns) do
     ~H"""
     <div class={[
-      "relative shrink-0 flex items-center justify-center rounded-full font-display text-center bg-white overflow-hidden ltrn-bg-profile",
+      "relative shrink-0 flex items-center justify-center rounded-full font-display text-center bg-white overflow-hidden",
+      profile_picture_theme_style(@theme),
       profile_picture_size_style(@size),
       @class
     ]}>
@@ -1575,7 +1583,8 @@ defmodule LantternWeb.CoreComponents do
     ~H"""
     <div
       class={[
-        "relative shrink-0 flex items-center justify-center rounded-full font-display text-center bg-white overflow-hidden ltrn-bg-profile",
+        "relative shrink-0 flex items-center justify-center rounded-full font-display text-center bg-white overflow-hidden",
+        profile_picture_theme_style(@theme),
         profile_picture_size_style(@size),
         @class
       ]}
@@ -1611,6 +1620,9 @@ defmodule LantternWeb.CoreComponents do
 
   defp profile_picture_render_url(picture_url, _md),
     do: object_url_to_render_url(picture_url, width: 80, height: 80)
+
+  defp profile_picture_theme_style("clean"), do: ""
+  defp profile_picture_theme_style(_default), do: "ltrn-bg-profile"
 
   defp profile_picture_size_style("xs"), do: "w-6 h-6 font-bold text-xs"
   defp profile_picture_size_style("sm"), do: "w-8 h-8 font-bold text-xs"

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -1363,9 +1363,9 @@ defmodule LantternWeb.CoreComponents do
       <%= if @navigate do %>
         <.link
           navigate={@navigate}
-          target="_blank"
           class={[
-            "pr-1 font-bold hover:text-ltrn-subtle",
+            "pr-1 font-bold",
+            person_badge_link_theme_style(@theme),
             @text_size,
             @name_w,
             if(@truncate, do: "truncate")
@@ -1398,6 +1398,10 @@ defmodule LantternWeb.CoreComponents do
   defp person_badge_theme_style("cyan"), do: "text-ltrn-dark bg-ltrn-mesh-cyan"
   defp person_badge_theme_style("staff"), do: "text-ltrn-teacher-dark bg-ltrn-teacher-lighter"
   defp person_badge_theme_style(_subtle), do: "text-ltrn-subtle bg-ltrn-lighter"
+
+  defp person_badge_link_theme_style("cyan"), do: "hover:text-ltrn-subtle"
+  defp person_badge_link_theme_style("staff"), do: "hover:text-ltrn-teacher-accent"
+  defp person_badge_link_theme_style(_subtle), do: "hover:text-ltrn-subtle"
 
   @doc """
   Renders a ping.

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -189,7 +189,7 @@ defmodule LantternWeb.CoreComponents do
     <span
       id={@id}
       class={[
-        "inline-flex items-center rounded-sm px-1 py-1 font-mono font-normal text-xs whitespace-nowrap",
+        "inline-flex items-center rounded-sm px-1 py-1 font-mono font-normal text-xs truncate",
         badge_theme(@theme),
         @class
       ]}

--- a/lib/lanttern_web/components/students_records_components.ex
+++ b/lib/lanttern_web/components/students_records_components.ex
@@ -4,17 +4,17 @@ defmodule LantternWeb.StudentsRecordsComponents do
   """
 
   use Phoenix.Component
-  alias Phoenix.LiveView.JS
 
   use Gettext, backend: Lanttern.Gettext
   import LantternWeb.CoreComponents
   import LantternWeb.SchoolsHelpers, only: [class_with_cycle: 2]
 
   @doc """
-  Renders a students records data grid.
+  Renders a students records list.
   """
 
   attr :id, :string, required: true
+  attr :class, :any, default: nil
   attr :stream, :any, required: true
   attr :show_empty_state_message, :boolean, required: true
 
@@ -26,110 +26,76 @@ defmodule LantternWeb.StudentsRecordsComponents do
     required: true,
     doc: "function, will receive student record as arg. Should return route for patch"
 
-  attr :is_students_filter_active, :boolean, required: true
-  attr :on_students_filter, JS, required: true
-  attr :is_classes_filter_active, :boolean, required: true
-  attr :on_classes_filter, JS, required: true
-  attr :is_type_filter_active, :boolean, required: true
-  attr :on_type_filter, JS, required: true
-  attr :is_status_filter_active, :boolean, required: true
-  attr :on_status_filter, JS, required: true
   attr :current_user_or_cycle, :any, required: true
 
-  def students_records_data_grid(assigns) do
+  def students_records_list(%{show_empty_state_message: true} = assigns) do
     ~H"""
-    <.data_grid
-      id={@id}
-      stream={@stream}
-      show_empty_state_message={
-        if @show_empty_state_message,
-          do: gettext("No students records found for selected filters.")
-      }
-    >
-      <:col :let={student_record} label={gettext("Date")} template_col="max-content" class="text-sm">
-        <div class="flex items-center gap-2">
-          <.icon name="hero-calendar-mini" class="w-5 h-5 text-ltrn-subtle" />
-          <%= Timex.format!(student_record.date, "{Mshort} {0D}, {YYYY}") %>
-        </div>
-        <div :if={student_record.time} class="flex items-center gap-2 mt-2">
-          <.icon name="hero-clock-mini" class="w-5 h-5 text-ltrn-subtle" />
-          <%= student_record.time %>
-        </div>
-      </:col>
-      <:col
-        :let={student_record}
-        label={gettext("Students")}
-        template_col="min-content"
-        on_filter={@on_students_filter}
-        filter_is_active={@is_students_filter_active}
+    <div class={@class}>
+      <.empty_state><%= gettext("No students records found for selected filters.") %></.empty_state>
+    </div>
+    """
+  end
+
+  def students_records_list(assigns) do
+    ~H"""
+    <div id={@id} class={@class} phx-update="stream">
+      <.card_base
+        :for={{dom_id, student_record} <- @stream}
+        id={dom_id}
+        class="md:flex md:items-start md:gap-6 p-6 mt-4 first:mt-0"
       >
-        <div class="flex flex-wrap gap-1">
-          <.person_badge
-            :for={student <- student_record.students}
-            person={student}
-            theme="cyan"
-            truncate
-            navigate={@student_navigate.(student)}
-          />
-        </div>
-      </:col>
-      <:col
-        :let={student_record}
-        label={gettext("Classes")}
-        template_col="min-content"
-        on_filter={@on_classes_filter}
-        filter_is_active={@is_classes_filter_active}
-      >
-        <%= if student_record.classes != [] do %>
-          <div class="flex flex-wrap gap-1">
+        <div class="md:w-48">
+          <div class="flex items-center gap-4 md:block">
+            <div class="flex items-center gap-2 text-xs">
+              <.icon name="hero-calendar-mini" class="w-5 h-5 text-ltrn-subtle" />
+              <%= Timex.format!(student_record.date, "{Mshort} {0D}, {YYYY}") %>
+            </div>
+            <div :if={student_record.time} class="flex items-center gap-2 text-xs md:mt-2">
+              <.icon name="hero-clock-mini" class="w-5 h-5 text-ltrn-subtle" />
+              <%= student_record.time %>
+            </div>
+          </div>
+          <div class="flex flex-wrap gap-2 w-full mt-4">
+            <.badge color_map={student_record.status} class="max-w-full">
+              <%= student_record.status.name %>
+            </.badge>
+            <.badge color_map={student_record.type} class="max-w-full">
+              <%= student_record.type.name %>
+            </.badge>
             <.badge :for={class <- student_record.classes}>
               <%= class_with_cycle(class, @current_user_or_cycle) %>
             </.badge>
           </div>
-        <% else %>
-          <.badge>
-            —
-          </.badge>
-        <% end %>
-      </:col>
-      <:col :let={student_record} label={gettext("Record")}>
-        <p :if={student_record.name} class="mb-4 font-display font-black">
-          <%= student_record.name %>
-        </p>
-        <.markdown text={student_record.description} class="line-clamp-3" />
-      </:col>
-      <:col
-        :let={student_record}
-        label={gettext("Type")}
-        template_col="max-content"
-        on_filter={@on_type_filter}
-        filter_is_active={@is_type_filter_active}
-      >
-        <.badge color_map={student_record.type}>
-          <%= student_record.type.name %>
-        </.badge>
-      </:col>
-      <:col
-        :let={student_record}
-        label={gettext("Status")}
-        template_col="max-content"
-        on_filter={@on_status_filter}
-        filter_is_active={@is_status_filter_active}
-      >
-        <.badge color_map={student_record.status}>
-          <%= student_record.status.name %>
-        </.badge>
-      </:col>
-      <:action :let={student_record}>
-        <.action
-          type="link"
-          icon_name="hero-arrow-up-right-mini"
-          patch={@details_patch.(student_record)}
-        >
-          <%= gettext("Details") %>
-        </.action>
-      </:action>
-    </.data_grid>
+        </div>
+        <div class="mt-6 md:mt-0">
+          <div class="flex flex-wrap gap-1">
+            <.person_badge
+              :for={student <- student_record.students}
+              person={student}
+              theme="cyan"
+              truncate
+              navigate={@student_navigate.(student)}
+            />
+          </div>
+          <.link
+            :if={student_record.name}
+            class="block mt-4 font-display font-black hover:text-ltrn-subtle"
+            patch={@details_patch.(student_record)}
+          >
+            <%= student_record.name %>
+          </.link>
+          <.markdown text={student_record.description} class="mt-4 line-clamp-5" />
+          <.action
+            type="link"
+            icon_name="hero-arrow-up-right-mini"
+            patch={@details_patch.(student_record)}
+            class="mt-4"
+          >
+            <%= gettext("View more") %>
+          </.action>
+        </div>
+      </.card_base>
+    </div>
     """
   end
 end

--- a/lib/lanttern_web/components/students_records_components.ex
+++ b/lib/lanttern_web/components/students_records_components.ex
@@ -27,6 +27,10 @@ defmodule LantternWeb.StudentsRecordsComponents do
     required: true,
     doc: "function, will receive student as arg. Should return route for navigate"
 
+  attr :staff_navigate, :any,
+    required: true,
+    doc: "function, will receive staff member id as arg. Should return route for navigate"
+
   attr :details_patch, :any,
     required: true,
     doc: "function, will receive student record as arg. Should return route for patch"
@@ -105,7 +109,12 @@ defmodule LantternWeb.StudentsRecordsComponents do
           <div class="flex items-center gap-4 p-2 rounded-sm bg-ltrn-teacher-lightest">
             <div class="flex items-center gap-2">
               <span class="text-xs text-ltrn-subtle"><%= gettext("Created by") %></span>
-              <.person_badge person={student_record.created_by_staff_member} theme="staff" truncate />
+              <.person_badge
+                person={student_record.created_by_staff_member}
+                theme="staff"
+                navigate={@staff_navigate.(student_record.created_by_staff_member.id)}
+                truncate
+              />
             </div>
             <div :if={student_record.assignees != []} class="flex items-center gap-2">
               <span class="text-xs text-ltrn-subtle"><%= gettext("Assigned to") %></span>
@@ -114,6 +123,7 @@ defmodule LantternWeb.StudentsRecordsComponents do
                   :for={assignee <- student_record.assignees}
                   person={assignee}
                   theme="staff"
+                  navigate={@staff_navigate.(assignee.id)}
                   truncate
                 />
               </div>

--- a/lib/lanttern_web/components/students_records_components.ex
+++ b/lib/lanttern_web/components/students_records_components.ex
@@ -15,7 +15,12 @@ defmodule LantternWeb.StudentsRecordsComponents do
 
   attr :id, :string, required: true
   attr :class, :any, default: nil
-  attr :stream, :any, required: true
+
+  attr :stream, :any,
+    required: true,
+    doc:
+      "stream of students records. Requires `students`, `status`, `type`, `created_by_staff_member`, `assignees` preloads"
+
   attr :show_empty_state_message, :boolean, required: true
 
   attr :student_navigate, :any,
@@ -39,60 +44,76 @@ defmodule LantternWeb.StudentsRecordsComponents do
   def students_records_list(assigns) do
     ~H"""
     <div id={@id} class={@class} phx-update="stream">
-      <.card_base
-        :for={{dom_id, student_record} <- @stream}
-        id={dom_id}
-        class="md:flex md:items-start md:gap-6 p-6 mt-4 first:mt-0"
-      >
-        <div class="md:w-48">
-          <div class="flex items-center gap-4 md:block">
-            <div class="flex items-center gap-2 text-xs">
-              <.icon name="hero-calendar-mini" class="w-5 h-5 text-ltrn-subtle" />
-              <%= Timex.format!(student_record.date, "{Mshort} {0D}, {YYYY}") %>
+      <.card_base :for={{dom_id, student_record} <- @stream} id={dom_id} class="mt-4 first:mt-0">
+        <div class="p-6 md:flex md:items-start md:gap-6">
+          <div class="md:w-48 md:shrink-0">
+            <div class="flex items-center gap-4 md:block">
+              <div class="flex items-center gap-2 text-xs font-bold text-ltrn-subtle">
+                <.icon name="hero-hashtag-mini" class="w-5 h-5" />
+                <%= student_record.id %>
+              </div>
+              <div class="flex items-center gap-2 text-xs md:mt-2">
+                <.icon name="hero-calendar-mini" class="w-5 h-5 text-ltrn-subtle" />
+                <%= Timex.format!(student_record.date, "{Mshort} {0D}, {YYYY}") %>
+              </div>
+              <div :if={student_record.time} class="flex items-center gap-2 text-xs md:mt-2">
+                <.icon name="hero-clock-mini" class="w-5 h-5 text-ltrn-subtle" />
+                <%= student_record.time %>
+              </div>
             </div>
-            <div :if={student_record.time} class="flex items-center gap-2 text-xs md:mt-2">
-              <.icon name="hero-clock-mini" class="w-5 h-5 text-ltrn-subtle" />
-              <%= student_record.time %>
+            <div class="flex flex-wrap gap-2 w-full mt-4">
+              <.badge color_map={student_record.status} class="max-w-full">
+                <%= student_record.status.name %>
+              </.badge>
+              <.badge color_map={student_record.type} class="max-w-full">
+                <%= student_record.type.name %>
+              </.badge>
+              <.badge :for={class <- student_record.classes}>
+                <%= class_with_cycle(class, @current_user_or_cycle) %>
+              </.badge>
             </div>
           </div>
-          <div class="flex flex-wrap gap-2 w-full mt-4">
-            <.badge color_map={student_record.status} class="max-w-full">
-              <%= student_record.status.name %>
-            </.badge>
-            <.badge color_map={student_record.type} class="max-w-full">
-              <%= student_record.type.name %>
-            </.badge>
-            <.badge :for={class <- student_record.classes}>
-              <%= class_with_cycle(class, @current_user_or_cycle) %>
-            </.badge>
+          <div class="mt-6 md:mt-0 md:flex-1">
+            <div class="flex flex-wrap gap-1">
+              <.person_badge
+                :for={student <- student_record.students}
+                person={student}
+                theme="cyan"
+                truncate
+                navigate={@student_navigate.(student)}
+              />
+            </div>
+            <.link
+              :if={student_record.name}
+              class="block mt-4 font-display font-black hover:text-ltrn-subtle"
+              patch={@details_patch.(student_record)}
+            >
+              <%= student_record.name %>
+            </.link>
+            <.markdown text={student_record.description} class="mt-4 line-clamp-5" />
+            <.action
+              type="link"
+              icon_name="hero-arrow-up-right-mini"
+              patch={@details_patch.(student_record)}
+              class="mt-4"
+            >
+              <%= gettext("View more") %>
+            </.action>
           </div>
         </div>
-        <div class="mt-6 md:mt-0">
-          <div class="flex flex-wrap gap-1">
-            <.person_badge
-              :for={student <- student_record.students}
-              person={student}
-              theme="cyan"
-              truncate
-              navigate={@student_navigate.(student)}
-            />
+        <div class="px-2 pb-2">
+          <div class="flex items-center gap-4 p-2 rounded-sm bg-ltrn-teacher-lightest">
+            <div class="flex items-center gap-2">
+              <span class="text-xs text-ltrn-subtle"><%= gettext("Created by") %></span>
+              <.person_badge person={student_record.created_by_staff_member} truncate />
+            </div>
+            <div :if={student_record.assignees != []} class="flex items-center gap-2">
+              <span class="text-xs text-ltrn-subtle"><%= gettext("Assigned to") %></span>
+              <div class="flex items-center gap-2">
+                <.person_badge :for={assignee <- student_record.assignees} person={assignee} truncate />
+              </div>
+            </div>
           </div>
-          <.link
-            :if={student_record.name}
-            class="block mt-4 font-display font-black hover:text-ltrn-subtle"
-            patch={@details_patch.(student_record)}
-          >
-            <%= student_record.name %>
-          </.link>
-          <.markdown text={student_record.description} class="mt-4 line-clamp-5" />
-          <.action
-            type="link"
-            icon_name="hero-arrow-up-right-mini"
-            patch={@details_patch.(student_record)}
-            class="mt-4"
-          >
-            <%= gettext("View more") %>
-          </.action>
         </div>
       </.card_base>
     </div>

--- a/lib/lanttern_web/components/students_records_components.ex
+++ b/lib/lanttern_web/components/students_records_components.ex
@@ -105,12 +105,17 @@ defmodule LantternWeb.StudentsRecordsComponents do
           <div class="flex items-center gap-4 p-2 rounded-sm bg-ltrn-teacher-lightest">
             <div class="flex items-center gap-2">
               <span class="text-xs text-ltrn-subtle"><%= gettext("Created by") %></span>
-              <.person_badge person={student_record.created_by_staff_member} truncate />
+              <.person_badge person={student_record.created_by_staff_member} theme="staff" truncate />
             </div>
             <div :if={student_record.assignees != []} class="flex items-center gap-2">
               <span class="text-xs text-ltrn-subtle"><%= gettext("Assigned to") %></span>
               <div class="flex items-center gap-2">
-                <.person_badge :for={assignee <- student_record.assignees} person={assignee} truncate />
+                <.person_badge
+                  :for={assignee <- student_record.assignees}
+                  person={assignee}
+                  theme="staff"
+                  truncate
+                />
               </div>
             </div>
           </div>

--- a/lib/lanttern_web/helpers/filters_helpers.ex
+++ b/lib/lanttern_web/helpers/filters_helpers.ex
@@ -256,7 +256,7 @@ defmodule LantternWeb.FiltersHelpers do
          [:student_record_staff_member_view | filter_types]
        ) do
     current_student_record_staff_member_view =
-      Map.get(current_filters, :student_record_staff_member_view) || "owned_by"
+      Map.get(current_filters, :student_record_staff_member_view) || "created_by"
 
     socket
     |> assign(:current_student_record_staff_member_view, current_student_record_staff_member_view)

--- a/lib/lanttern_web/helpers/filters_helpers.ex
+++ b/lib/lanttern_web/helpers/filters_helpers.ex
@@ -65,6 +65,10 @@ defmodule LantternWeb.FiltersHelpers do
   - `:selected_student_record_assignees`
   - `:selected_student_record_assignees_ids`
 
+  ### `:student_record_staff_member_view` assigns
+
+  - `:current_student_record_staff_member_view`
+
   ### `:starred_strands`
 
   - `:only_starred_strands`
@@ -242,6 +246,20 @@ defmodule LantternWeb.FiltersHelpers do
     socket
     |> assign(:selected_student_record_assignees_ids, selected_student_record_assignees_ids)
     |> assign(:selected_student_record_assignees, selected_student_record_assignees)
+    |> assign_filter_type(current_user, current_filters, filter_types)
+  end
+
+  defp assign_filter_type(
+         socket,
+         current_user,
+         current_filters,
+         [:student_record_staff_member_view | filter_types]
+       ) do
+    current_student_record_staff_member_view =
+      Map.get(current_filters, :student_record_staff_member_view) || "owned_by"
+
+    socket
+    |> assign(:current_student_record_staff_member_view, current_student_record_staff_member_view)
     |> assign_filter_type(current_user, current_filters, filter_types)
   end
 
@@ -684,7 +702,6 @@ defmodule LantternWeb.FiltersHelpers do
         {@type_to_filter_key_map[type], current_filter_value}
       end)
       |> Enum.into(%{})
-      |> IO.inspect()
 
     apply_save_profile_filters(current_user, attrs, opts)
 

--- a/lib/lanttern_web/helpers/filters_helpers.ex
+++ b/lib/lanttern_web/helpers/filters_helpers.ex
@@ -60,6 +60,11 @@ defmodule LantternWeb.FiltersHelpers do
   - `:selected_student_record_statuses`
   - `:selected_student_record_statuses_ids`
 
+  ### `:student_record_assignees` assigns
+
+  - `:selected_student_record_assignees`
+  - `:selected_student_record_assignees_ids`
+
   ### `:starred_strands`
 
   - `:only_starred_strands`
@@ -217,6 +222,33 @@ defmodule LantternWeb.FiltersHelpers do
          socket,
          current_user,
          current_filters,
+         [:student_record_assignees | filter_types]
+       ) do
+    school_id = current_user.current_profile.school_id
+
+    selected_student_record_assignees_ids =
+      Map.get(current_filters, :student_record_assignees_ids) || []
+
+    selected_student_record_assignees =
+      if selected_student_record_assignees_ids == [] do
+        []
+      else
+        Schools.list_staff_members(
+          school_id: school_id,
+          staff_members_ids: selected_student_record_assignees_ids
+        )
+      end
+
+    socket
+    |> assign(:selected_student_record_assignees_ids, selected_student_record_assignees_ids)
+    |> assign(:selected_student_record_assignees, selected_student_record_assignees)
+    |> assign_filter_type(current_user, current_filters, filter_types)
+  end
+
+  defp assign_filter_type(
+         socket,
+         current_user,
+         current_filters,
          [:starred_strands | filter_types]
        ) do
     socket
@@ -257,6 +289,7 @@ defmodule LantternWeb.FiltersHelpers do
     students: :students_ids,
     student_record_types: :student_record_types_ids,
     student_record_statuses: :student_record_statuses_ids,
+    student_record_assignees: :student_record_assignees_ids,
     starred_strands: :only_starred_strands,
     student_info: :student_info_cycle_id
   }
@@ -270,6 +303,7 @@ defmodule LantternWeb.FiltersHelpers do
     students: :selected_students_ids,
     student_record_types: :selected_student_record_types_ids,
     student_record_statuses: :selected_student_record_statuses_ids,
+    student_record_assignees: :selected_student_record_assignees_ids,
     starred_strands: :only_starred_strands,
     student_info: :student_info_selected_cycle_id
   }
@@ -626,6 +660,7 @@ defmodule LantternWeb.FiltersHelpers do
   - `:students`
   - `:student_record_types`
   - `:student_record_status`
+  - `:student_record_assignees`
   - `:student_info`
 
   ## Examples
@@ -649,6 +684,7 @@ defmodule LantternWeb.FiltersHelpers do
         {@type_to_filter_key_map[type], current_filter_value}
       end)
       |> Enum.into(%{})
+      |> IO.inspect()
 
     apply_save_profile_filters(current_user, attrs, opts)
 

--- a/lib/lanttern_web/live/pages/admin/student_record_live/form_component.ex
+++ b/lib/lanttern_web/live/pages/admin/student_record_live/form_component.ex
@@ -30,6 +30,14 @@ defmodule LantternWeb.Admin.StudentRecordLive.FormComponent do
           class="mb-4"
         />
         <.input
+          field={@form[:created_by_staff_member_id]}
+          type="select"
+          label="Select created by staff member"
+          options={@staff_member_options}
+          prompt="No staff member selected"
+          class="mb-4"
+        />
+        <.input
           field={@form[:students_ids]}
           type="select"
           multiple
@@ -71,6 +79,7 @@ defmodule LantternWeb.Admin.StudentRecordLive.FormComponent do
     socket =
       socket
       |> assign(:school_options, SchoolsHelpers.generate_school_options())
+      |> assign(:staff_member_options, SchoolsHelpers.generate_staff_member_options())
       |> assign(:student_options, SchoolsHelpers.generate_student_options())
       |> assign(:type_options, StudentsRecordsHelpers.generate_student_record_type_options())
       |> assign(:status_options, StudentsRecordsHelpers.generate_student_record_status_options())

--- a/lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex
+++ b/lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex
@@ -1,0 +1,109 @@
+defmodule LantternWeb.StaffMemberLive do
+  use LantternWeb, :live_view
+
+  alias Lanttern.Schools
+  alias Lanttern.Schools.StaffMember
+
+  # page components
+
+  alias __MODULE__.StudentsRecordsComponent
+
+  # shared components
+
+  alias LantternWeb.Schools.StaffMemberFormOverlayComponent
+
+  # lifecycle
+
+  @impl true
+  def mount(params, _session, socket) do
+    socket =
+      socket
+      |> assign_staff_member(params)
+      |> assign_is_school_manager()
+      |> assign_is_wcd()
+      |> assign_is_current_user()
+
+    {:ok, socket}
+  end
+
+  defp assign_staff_member(socket, params) do
+    case Schools.get_staff_member!(params["id"], preloads: :school, load_email: true) do
+      %StaffMember{} = staff_member ->
+        check_if_user_has_access(socket.assigns.current_user, staff_member)
+
+        socket
+        |> assign(:staff_member, staff_member)
+        |> assign(:page_title, staff_member.name)
+
+      _ ->
+        raise(LantternWeb.NotFoundError)
+    end
+  end
+
+  # check if user can view the staff member profile
+  # users can view only staff members from their school
+  defp check_if_user_has_access(current_user, staff_member) do
+    if staff_member.school_id != current_user.current_profile.school_id,
+      do: raise(LantternWeb.NotFoundError)
+  end
+
+  defp assign_is_current_user(socket) do
+    is_current_user =
+      socket.assigns.current_user.current_profile.staff_member_id ==
+        socket.assigns.staff_member.id
+
+    assign(socket, :is_current_user, is_current_user)
+  end
+
+  defp assign_is_wcd(socket) do
+    is_wcd = "wcd" in socket.assigns.current_user.current_profile.permissions
+    assign(socket, :is_wcd, is_wcd)
+  end
+
+  defp assign_is_school_manager(socket) do
+    is_school_manager =
+      "school_management" in socket.assigns.current_user.current_profile.permissions
+
+    assign(socket, :is_school_manager, is_school_manager)
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
+    socket =
+      socket
+      |> assign(:params, params)
+      |> assign_is_editing(params)
+
+    {:noreply, socket}
+  end
+
+  defp assign_is_editing(%{assigns: %{is_school_manager: true}} = socket, %{"edit" => "true"}),
+    do: assign(socket, :is_editing, true)
+
+  defp assign_is_editing(%{assigns: %{is_current_user: true}} = socket, %{"edit" => "true"}),
+    do: assign(socket, :is_editing, true)
+
+  defp assign_is_editing(socket, _params),
+    do: assign(socket, :is_editing, false)
+
+  @impl true
+  def handle_info({StaffMemberFormOverlayComponent, {:updated, _student}}, socket) do
+    socket =
+      socket
+      |> put_flash(:info, gettext("Staff member updated successfully"))
+      |> push_navigate(to: socket.assigns.current_path)
+
+    {:noreply, socket}
+  end
+
+  def handle_info({StaffMemberFormOverlayComponent, {:deleted, _student}}, socket) do
+    socket =
+      socket
+      |> put_flash(:info, gettext("Staff member deleted successfully"))
+      |> push_navigate(to: ~p"/school/staff")
+
+    {:noreply, socket}
+  end
+
+  def handle_info(_, socket), do: socket
+end

--- a/lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex
+++ b/lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex
@@ -1,0 +1,65 @@
+<div>
+  <.header_nav current_user={@current_user}>
+    <:breadcrumb navigate={~p"/school/staff"}>
+      <%= gettext("%{school} staff", school: @staff_member.school.name) %>
+    </:breadcrumb>
+    <:title><%= @staff_member.name %></:title>
+    <div class="flex items-center justify-between gap-4 px-4">
+      <.neo_tabs id="student-nav-tabs">
+        <:tab patch={~p"/school/staff/#{@staff_member}"} is_current={@live_action == :show}>
+          <%= gettext("About") %>
+        </:tab>
+        <:tab
+          :if={@is_wcd}
+          patch={~p"/school/staff/#{@staff_member}/students_records"}
+          is_current={@live_action == :students_records}
+        >
+          <%= gettext("Students records") %>
+        </:tab>
+      </.neo_tabs>
+      <.action
+        :if={@is_school_manager || @is_current_user}
+        type="link"
+        patch={"#{@current_path}?edit=true"}
+        icon_name="hero-pencil-mini"
+      >
+        <%= gettext("Edit staff member") %>
+      </.action>
+    </div>
+  </.header_nav>
+  <.responsive_container :if={@live_action == :show} class="py-10 px-4">
+    <div class="sm:flex sm:items-center sm:gap-6">
+      <.profile_picture
+        class="shadow-lg"
+        picture_url={@staff_member.profile_picture_url}
+        profile_name={@staff_member.name}
+        size="xl"
+      />
+      <div class="mt-6 sm:mt-0">
+        <h2 class="font-display font-black text-2xl">
+          <%= @staff_member.name %>
+        </h2>
+        <p class="mt-2 font-display font-black text-lg text-ltrn-subtle">
+          <%= "#{@staff_member.role} @ #{@staff_member.school.name}" %>
+        </p>
+      </div>
+    </div>
+  </.responsive_container>
+</div>
+<.live_component
+  :if={@live_action == :students_records && @is_wcd}
+  module={StudentsRecordsComponent}
+  id="students-records"
+  staff_member={@staff_member}
+  current_user={@current_user}
+  params={@params}
+/>
+<.live_component
+  :if={@is_editing}
+  module={StaffMemberFormOverlayComponent}
+  id="staff-member-form-overlay"
+  staff_member={@staff_member}
+  title={gettext("Edit staff member")}
+  on_cancel={JS.patch(@current_path)}
+  notify_parent
+/>

--- a/lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex
+++ b/lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex
@@ -36,8 +36,8 @@ defmodule LantternWeb.StaffMemberLive.StudentsRecordsComponent do
           <div class="relative">
             <.action type="button" id="select-view-dropdown-button" icon_name="hero-chevron-down-mini">
               <%= case @current_student_record_staff_member_view do
-                "owned_by" ->
-                  gettext("Owned by %{staff_member}", staff_member: @staff_member_first_name)
+                "created_by" ->
+                  gettext("Created by %{staff_member}", staff_member: @staff_member_first_name)
 
                 "assigned_to" ->
                   gettext("Assigned to %{staff_member}", staff_member: @staff_member_first_name)
@@ -49,9 +49,9 @@ defmodule LantternWeb.StaffMemberLive.StudentsRecordsComponent do
               z_index="30"
             >
               <:item
-                text={gettext("Owned by %{staff_member}", staff_member: @staff_member_first_name)}
+                text={gettext("Created by %{staff_member}", staff_member: @staff_member_first_name)}
                 on_click={
-                  JS.push("set_staff_member_view", value: %{"view" => "owned_by"}, target: @myself)
+                  JS.push("set_staff_member_view", value: %{"view" => "created_by"}, target: @myself)
                 }
               />
               <:item
@@ -349,7 +349,7 @@ defmodule LantternWeb.StaffMemberLive.StudentsRecordsComponent do
         types_ids: types_ids,
         statuses_ids: statuses_ids,
         owner_id:
-          if(socket.assigns.current_student_record_staff_member_view == "owned_by",
+          if(socket.assigns.current_student_record_staff_member_view == "created_by",
             do: socket.assigns.staff_member.id
           ),
         assignees_ids:

--- a/lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex
+++ b/lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex
@@ -9,17 +9,21 @@
 # I don't know if extracting the data grid + filter will work (I tried to do this, but
 # I stopped as soon as I noticed I was adding a lot of complexity to customize to this context)
 
-defmodule LantternWeb.StudentLive.StudentRecordsComponent do
+defmodule LantternWeb.StaffMemberLive.StudentsRecordsComponent do
   use LantternWeb, :live_component
 
+  alias Lanttern.Filters
   alias Lanttern.StudentsRecords
-  alias Lanttern.Schools
-
-  import LantternWeb.FiltersHelpers, only: [assign_user_filters: 2, save_profile_filters: 2]
+  alias Lanttern.Schools.Cycle
 
   # shared components
-  alias LantternWeb.Schools.StaffMemberSearchComponent
+  alias LantternWeb.Schools.StudentSearchComponent
   alias LantternWeb.StudentsRecords.StudentRecordOverlayComponent
+
+  import LantternWeb.FiltersHelpers,
+    only: [assign_user_filters: 2, assign_classes_filter: 2, save_profile_filters: 2]
+
+  import LantternWeb.SchoolsHelpers, only: [class_with_cycle: 2]
   import LantternWeb.StudentsRecordsComponents
 
   @impl true
@@ -29,6 +33,69 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
       <.action_bar class="flex items-center gap-4 p-4">
         <div class="flex-1 flex flex-wrap items-center gap-6">
           <.icon name="hero-funnel-mini" class="text-ltrn-subtle" />
+          <div class="relative">
+            <.action type="button" id="select-view-dropdown-button" icon_name="hero-chevron-down-mini">
+              <%= case @current_student_record_staff_member_view do
+                "owned_by" ->
+                  gettext("Owned by %{staff_member}", staff_member: @staff_member_first_name)
+
+                "assigned_to" ->
+                  gettext("Assigned to %{staff_member}", staff_member: @staff_member_first_name)
+              end %>
+            </.action>
+            <.dropdown_menu
+              id="select-view-dropdown"
+              button_id="select-view-dropdown-button"
+              z_index="30"
+            >
+              <:item
+                text={gettext("Owned by %{staff_member}", staff_member: @staff_member_first_name)}
+                on_click={
+                  JS.push("set_staff_member_view", value: %{"view" => "owned_by"}, target: @myself)
+                }
+              />
+              <:item
+                text={gettext("Assigned to %{staff_member}", staff_member: @staff_member_first_name)}
+                on_click={
+                  JS.push("set_staff_member_view", value: %{"view" => "assigned_to"}, target: @myself)
+                }
+              />
+            </.dropdown_menu>
+          </div>
+          <%= if @selected_students == [] do %>
+            <.action
+              type="button"
+              icon_name="hero-chevron-down-mini"
+              phx-click={JS.push("open_student_search_modal", target: @myself)}
+            >
+              <%= gettext("Student") %>
+            </.action>
+          <% else %>
+            <.badge
+              :for={student <- @selected_students}
+              on_remove={JS.push("remove_student_filter", target: @myself)}
+              theme="primary"
+            >
+              <%= student.name %>
+            </.badge>
+          <% end %>
+          <%= if @selected_classes == [] do %>
+            <.action
+              type="button"
+              icon_name="hero-chevron-down-mini"
+              phx-click={JS.exec("data-show", to: "#students-records-classes-filters-overlay")}
+            >
+              <%= gettext("Classes") %>
+            </.action>
+          <% else %>
+            <.badge
+              :for={class <- @selected_classes}
+              on_remove={JS.push("remove_class_filter", value: %{"id" => class.id})}
+              theme="primary"
+            >
+              <%= class_with_cycle(class, @current_user) %>
+            </.badge>
+          <% end %>
           <%= if @selected_student_record_statuses == [] do %>
             <.action
               type="button"
@@ -63,23 +130,6 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
               <%= type.name %>
             </.badge>
           <% end %>
-          <%= if @selected_student_record_assignees == [] do %>
-            <.action
-              type="button"
-              icon_name="hero-chevron-down-mini"
-              phx-click={JS.push("open_assignee_search_modal", target: @myself)}
-            >
-              <%= gettext("Assignee") %>
-            </.action>
-          <% else %>
-            <.badge
-              :for={assignee <- @selected_student_record_assignees}
-              on_remove={JS.push("remove_assignee_filter", target: @myself)}
-              theme="teacher"
-            >
-              <%= assignee.name %>
-            </.badge>
-          <% end %>
         </div>
         <.action
           type="link"
@@ -101,17 +151,15 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
           id="students-records"
           stream={@streams.students_records}
           show_empty_state_message={@students_records_length == 0}
-          student_navigate={
+          student_navigate={fn student -> ~p"/school/students/#{student}/student_records" end}
+          staff_navigate={
             fn
-              student when student.id != @student.id ->
-                ~p"/school/students/#{student}/student_records"
+              staff_member_id when staff_member_id != @staff_member.id ->
+                ~p"/school/staff/#{staff_member_id}/students_records"
 
               _ ->
                 nil
             end
-          }
-          staff_navigate={
-            fn staff_member_id -> ~p"/school/staff/#{staff_member_id}/students_records" end
           }
           details_patch={fn student_record -> "#{@base_path}?student_record=#{student_record.id}" end}
           current_user_or_cycle={@current_user}
@@ -122,6 +170,33 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
           <%= gettext("Load more records") %>
         </.button>
       </div>
+      <.modal
+        :if={@show_student_search_modal}
+        id="student-search-modal"
+        show
+        on_cancel={JS.push("close_student_search_modal", target: @myself)}
+      >
+        <h5 class="mb-10 font-display font-black text-xl">
+          <%= gettext("Filter records by student") %>
+        </h5>
+        <form>
+          <.live_component
+            module={StudentSearchComponent}
+            id="student-search-modal-search"
+            notify_component={@myself}
+            label={gettext("Type the name of the student")}
+          />
+        </form>
+      </.modal>
+      <.live_component
+        module={LantternWeb.Filters.ClassesFilterOverlayComponent}
+        id="students-records-classes-filters-overlay"
+        current_user={@current_user}
+        title={gettext("Filter students records by class")}
+        navigate={~p"/students_records"}
+        classes={@classes}
+        selected_classes_ids={@selected_classes_ids}
+      />
       <.single_selection_filter_modal
         id="student-record-status-filter-modal"
         title={gettext("Filter students records by status")}
@@ -150,25 +225,6 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
           end
         }
       />
-      <.modal
-        :if={@show_assignee_search_modal}
-        id="assignee-search-modal"
-        show
-        on_cancel={JS.push("close_assignee_search_modal", target: @myself)}
-      >
-        <h5 class="mb-10 font-display font-black text-xl">
-          <%= gettext("Filter records by assignee") %>
-        </h5>
-        <form>
-          <.live_component
-            module={StaffMemberSearchComponent}
-            id="assignee-search-modal-search"
-            notify_component={@myself}
-            label={gettext("Type the name of the assignee")}
-            school_id={@current_user.current_profile.school_id}
-          />
-        </form>
-      </.modal>
       <.live_component
         module={StudentRecordOverlayComponent}
         student_record_id={@student_record_id}
@@ -188,7 +244,6 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
   def mount(socket) do
     socket =
       socket
-      |> assign(:show_assignee_search_modal, false)
       |> assign(:new_record_initial_fields, nil)
       |> assign(:initialized, false)
 
@@ -196,14 +251,14 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
   end
 
   @impl true
-  def update(%{action: {StaffMemberSearchComponent, {:selected, staff_member}}}, socket) do
+  def update(%{action: {StudentSearchComponent, {:selected, student}}}, socket) do
     socket =
       socket
-      |> assign(:selected_student_record_assignees_ids, [staff_member.id])
-      |> save_profile_filters([:student_record_assignees])
-      |> assign_user_filters([:student_record_assignees])
+      |> assign(:selected_students_ids, [student.id])
+      |> save_profile_filters([:students])
+      |> assign_user_filters([:students])
       |> stream_students_records(true)
-      |> assign(:show_assignee_search_modal, false)
+      |> assign(:show_student_search_modal, false)
 
     {:ok, socket}
   end
@@ -247,23 +302,38 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
   defp initialize(%{assigns: %{initialized: false}} = socket) do
     socket
     |> assign_user_filters([
+      :students,
       :student_record_types,
       :student_record_statuses,
-      :student_record_assignees
+      :student_record_staff_member_view
     ])
+    |> apply_assign_classes_filter()
     |> stream_students_records()
+    |> assign(:show_student_search_modal, false)
     |> assign_base_path()
+    |> assign_staff_member_first_name()
     |> assign(:initialized, true)
   end
 
   defp initialize(socket), do: socket
 
+  defp apply_assign_classes_filter(socket) do
+    assign_classes_filter_opts =
+      case socket.assigns.current_user.current_profile do
+        %{current_school_cycle: %Cycle{} = cycle} -> [cycles_ids: [cycle.id]]
+        _ -> []
+      end
+
+    assign_classes_filter(socket, assign_classes_filter_opts)
+  end
+
   defp stream_students_records(socket, reset \\ false) do
     %{
       current_user: %{current_profile: %{school_id: school_id}},
+      selected_students_ids: students_ids,
+      selected_classes_ids: classes_ids,
       selected_student_record_types_ids: types_ids,
-      selected_student_record_statuses_ids: statuses_ids,
-      selected_student_record_assignees_ids: assignees_ids
+      selected_student_record_statuses_ids: statuses_ids
     } = socket.assigns
 
     {keyset, len} =
@@ -274,10 +344,18 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
     page =
       StudentsRecords.list_students_records_page(
         school_id: school_id,
-        students_ids: [socket.assigns.student.id],
+        students_ids: students_ids,
+        classes_ids: classes_ids,
         types_ids: types_ids,
         statuses_ids: statuses_ids,
-        assignees_ids: assignees_ids,
+        owner_id:
+          if(socket.assigns.current_student_record_staff_member_view == "owned_by",
+            do: socket.assigns.staff_member.id
+          ),
+        assignees_ids:
+          if(socket.assigns.current_student_record_staff_member_view == "assigned_to",
+            do: [socket.assigns.staff_member.id]
+          ),
         preloads: [
           :type,
           :status,
@@ -306,14 +384,23 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
   end
 
   defp assign_base_path(socket) do
-    base_path = ~p"/school/students/#{socket.assigns.student}/student_records"
+    base_path = ~p"/school/staff/#{socket.assigns.staff_member}/students_records"
     assign(socket, :base_path, base_path)
   end
 
+  defp assign_staff_member_first_name(socket) do
+    staff_member_first_name =
+      socket.assigns.staff_member.name
+      |> String.split()
+      |> List.first()
+
+    assign(socket, :staff_member_first_name, staff_member_first_name)
+  end
+
   defp assign_student_record_id(%{assigns: %{params: %{"student_record" => "new"}}} = socket) do
-    # build new record initial fields based on current filters
-    students_ids = [socket.assigns.student.id]
-    classes = Schools.list_classes_for_students_in_date(students_ids, Date.utc_today())
+    # # build new record initial fields based on current filters
+    # students_ids = [socket.assigns.staff_member.id]
+    # classes = Schools.list_classes_for_students_in_date(students_ids, Date.utc_today())
 
     type_id =
       case socket.assigns.selected_student_record_types do
@@ -329,8 +416,8 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
 
     new_record_initial_fields =
       %{
-        students: [socket.assigns.student],
-        classes: classes,
+        # students: [socket.assigns.staff_member],
+        # classes: classes,
         type_id: type_id,
         status_id: status_id
       }
@@ -347,6 +434,58 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
     do: assign(socket, :student_record_id, nil)
 
   @impl true
+  def handle_event("set_staff_member_view", %{"view" => view}, socket) do
+    Filters.set_profile_current_filters(
+      socket.assigns.current_user,
+      %{student_record_staff_member_view: view}
+    )
+    |> case do
+      {:ok, _} ->
+        socket =
+          socket
+          |> assign(:current_student_record_staff_member_view, view)
+          |> stream_students_records(true)
+
+        {:noreply, socket}
+
+      {:error, _} ->
+        # do something with error?
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("open_student_search_modal", _, socket),
+    do: {:noreply, assign(socket, :show_student_search_modal, true)}
+
+  def handle_event("close_student_search_modal", _, socket),
+    do: {:noreply, assign(socket, :show_student_search_modal, false)}
+
+  def handle_event("remove_student_filter", _, socket) do
+    socket =
+      socket
+      |> assign(:selected_students_ids, [])
+      |> save_profile_filters([:students])
+      |> assign_user_filters([:students])
+      |> stream_students_records(true)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("remove_class_filter", %{"id" => class_id}, socket) do
+    selected_classes_ids =
+      socket.assigns.selected_classes_ids
+      |> Enum.filter(&(&1 != class_id))
+
+    socket =
+      socket
+      |> assign(:selected_classes_ids, selected_classes_ids)
+      |> save_profile_filters([:classes])
+      |> apply_assign_classes_filter()
+      |> stream_students_records(true)
+
+    {:noreply, socket}
+  end
+
   def handle_event("remove_type_filter", _, socket) do
     socket =
       socket
@@ -364,17 +503,6 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
       |> assign(:selected_student_record_statuses_ids, [])
       |> save_profile_filters([:student_record_statuses])
       |> assign_user_filters([:student_record_statuses])
-      |> stream_students_records(true)
-
-    {:noreply, socket}
-  end
-
-  def handle_event("remove_assignee_filter", _, socket) do
-    socket =
-      socket
-      |> assign(:selected_student_record_assignees_ids, [])
-      |> save_profile_filters([:student_record_assignees])
-      |> assign_user_filters([:student_record_assignees])
       |> stream_students_records(true)
 
     {:noreply, socket}
@@ -407,12 +535,6 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
 
     {:noreply, socket}
   end
-
-  def handle_event("open_assignee_search_modal", _, socket),
-    do: {:noreply, assign(socket, :show_assignee_search_modal, true)}
-
-  def handle_event("close_assignee_search_modal", _, socket),
-    do: {:noreply, assign(socket, :show_assignee_search_modal, false)}
 
   def handle_event("load_more", _, socket),
     do: {:noreply, stream_students_records(socket)}

--- a/lib/lanttern_web/live/pages/school/staff_component.ex
+++ b/lib/lanttern_web/live/pages/school/staff_component.ex
@@ -42,7 +42,12 @@ defmodule LantternWeb.SchoolLive.StaffComponent do
               size="lg"
             />
             <div class="min-w-0 flex-1">
-              <%= staff_member.name %>
+              <.link
+                navigate={~p"/school/staff/#{staff_member}"}
+                class="font-bold hover:text-ltrn-subtle"
+              >
+                <%= staff_member.name %>
+              </.link>
               <div class="text-xs text-ltrn-subtle"><%= staff_member.role %></div>
               <div
                 :if={staff_member.email}

--- a/lib/lanttern_web/live/pages/school/students/id/student_live.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_live.ex
@@ -29,7 +29,7 @@ defmodule LantternWeb.StudentLive do
   end
 
   defp assign_student(socket, params) do
-    case Schools.get_student(params["id"], preloads: [classes: [:cycle, :years]]) do
+    case Schools.get_student(params["id"], preloads: [:school, classes: [:cycle, :years]]) do
       %Student{} = student ->
         check_if_user_has_access(socket.assigns.current_user, student)
 

--- a/lib/lanttern_web/live/pages/school/students/id/student_live.html.heex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_live.html.heex
@@ -1,6 +1,8 @@
 <div>
   <.header_nav current_user={@current_user}>
-    <:breadcrumb navigate={~p"/school/classes"}><%= gettext("School") %></:breadcrumb>
+    <:breadcrumb navigate={~p"/school/students"}>
+      <%= gettext("%{school} students", school: @student.school.name) %>
+    </:breadcrumb>
     <:title><%= @student.name %></:title>
     <div class="flex items-center justify-between gap-4 px-4">
       <.neo_tabs id="student-nav-tabs">

--- a/lib/lanttern_web/live/pages/school/students/id/student_records_component.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_records_component.ex
@@ -219,7 +219,14 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
         students_ids: [socket.assigns.student.id],
         types_ids: types_ids,
         statuses_ids: statuses_ids,
-        preloads: [:type, :status, :students, [classes: :cycle]],
+        preloads: [
+          :type,
+          :status,
+          :students,
+          :created_by_staff_member,
+          :assignees,
+          [classes: :cycle]
+        ],
         first: 50,
         after: keyset
       )
@@ -246,12 +253,8 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
 
   defp assign_student_record_id(%{assigns: %{params: %{"student_record" => "new"}}} = socket) do
     # build new record initial fields based on current filters
-    students_ids = Enum.map(socket.assigns.selected_students, & &1.id)
-
-    classes =
-      (socket.assigns.selected_classes ++
-         Schools.list_classes_for_students_in_date(students_ids, Date.utc_today()))
-      |> Enum.uniq_by(& &1.id)
+    students_ids = [socket.assigns.student.id]
+    classes = Schools.list_classes_for_students_in_date(students_ids, Date.utc_today())
 
     type_id =
       case socket.assigns.selected_student_record_types do
@@ -267,7 +270,7 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
 
     new_record_initial_fields =
       %{
-        students: socket.assigns.selected_students,
+        students: [socket.assigns.student],
         classes: classes,
         type_id: type_id,
         status_id: status_id

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.ex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.ex
@@ -67,7 +67,14 @@ defmodule LantternWeb.StudentsRecordsLive do
         classes_ids: classes_ids,
         types_ids: types_ids,
         statuses_ids: statuses_ids,
-        preloads: [:type, :status, :students, [classes: :cycle]],
+        preloads: [
+          :type,
+          :status,
+          :created_by_staff_member,
+          :assignees,
+          :students,
+          [classes: :cycle]
+        ],
         first: 50,
         after: keyset
       )
@@ -78,7 +85,7 @@ defmodule LantternWeb.StudentsRecordsLive do
       has_next: has_next
     } = page
 
-    len = (len + length(students_records)) |> IO.inspect(label: "length")
+    len = len + length(students_records)
 
     socket
     |> stream(:students_records, students_records, reset: reset)

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.ex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.ex
@@ -68,7 +68,7 @@ defmodule LantternWeb.StudentsRecordsLive do
         types_ids: types_ids,
         statuses_ids: statuses_ids,
         preloads: [:type, :status, :students, [classes: :cycle]],
-        first: 20,
+        first: 50,
         after: keyset
       )
 
@@ -78,7 +78,7 @@ defmodule LantternWeb.StudentsRecordsLive do
       has_next: has_next
     } = page
 
-    len = len + length(students_records)
+    len = (len + length(students_records)) |> IO.inspect(label: "length")
 
     socket
     |> stream(:students_records, students_records, reset: reset)

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.ex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.ex
@@ -12,6 +12,7 @@ defmodule LantternWeb.StudentsRecordsLive do
 
   # shared components
 
+  alias LantternWeb.Schools.StaffMemberSearchComponent
   alias LantternWeb.Schools.StudentSearchComponent
   alias LantternWeb.StudentsRecords.StudentRecordOverlayComponent
   import LantternWeb.SchoolsHelpers, only: [class_with_cycle: 2]
@@ -27,10 +28,16 @@ defmodule LantternWeb.StudentsRecordsLive do
     socket =
       socket
       |> assign(:page_title, gettext("Students records"))
-      |> assign_user_filters([:students, :student_record_types, :student_record_statuses])
+      |> assign_user_filters([
+        :students,
+        :student_record_types,
+        :student_record_statuses,
+        :student_record_assignees
+      ])
       |> apply_assign_classes_filter()
       |> stream_students_records()
       |> assign(:show_student_search_modal, false)
+      |> assign(:show_assignee_search_modal, false)
       |> assign(:new_record_initial_fields, nil)
 
     {:ok, socket}
@@ -52,7 +59,8 @@ defmodule LantternWeb.StudentsRecordsLive do
       selected_students_ids: students_ids,
       selected_classes_ids: classes_ids,
       selected_student_record_types_ids: types_ids,
-      selected_student_record_statuses_ids: statuses_ids
+      selected_student_record_statuses_ids: statuses_ids,
+      selected_student_record_assignees_ids: assignees_ids
     } = socket.assigns
 
     {keyset, len} =
@@ -67,6 +75,7 @@ defmodule LantternWeb.StudentsRecordsLive do
         classes_ids: classes_ids,
         types_ids: types_ids,
         statuses_ids: statuses_ids,
+        assignees_ids: assignees_ids,
         preloads: [
           :type,
           :status,
@@ -187,6 +196,17 @@ defmodule LantternWeb.StudentsRecordsLive do
     {:noreply, socket}
   end
 
+  def handle_event("remove_assignee_filter", _, socket) do
+    socket =
+      socket
+      |> assign(:selected_student_record_assignees_ids, [])
+      |> save_profile_filters([:student_record_assignees])
+      |> assign_user_filters([:student_record_assignees])
+      |> stream_students_records(true)
+
+    {:noreply, socket}
+  end
+
   def handle_event("open_student_search_modal", _, socket),
     do: {:noreply, assign(socket, :show_student_search_modal, true)}
 
@@ -221,6 +241,12 @@ defmodule LantternWeb.StudentsRecordsLive do
     {:noreply, socket}
   end
 
+  def handle_event("open_assignee_search_modal", _, socket),
+    do: {:noreply, assign(socket, :show_assignee_search_modal, true)}
+
+  def handle_event("close_assignee_search_modal", _, socket),
+    do: {:noreply, assign(socket, :show_assignee_search_modal, false)}
+
   def handle_event("load_more", _, socket),
     do: {:noreply, stream_students_records(socket)}
 
@@ -235,6 +261,18 @@ defmodule LantternWeb.StudentsRecordsLive do
       |> assign_user_filters([:students])
       |> stream_students_records(true)
       |> assign(:show_student_search_modal, false)
+
+    {:noreply, socket}
+  end
+
+  def handle_info({StaffMemberSearchComponent, {:selected, staff_member}}, socket) do
+    socket =
+      socket
+      |> assign(:selected_student_record_assignees_ids, [staff_member.id])
+      |> save_profile_filters([:student_record_assignees])
+      |> assign_user_filters([:student_record_assignees])
+      |> stream_students_records(true)
+      |> assign(:show_assignee_search_modal, false)
 
     {:noreply, socket}
   end

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.html.heex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.html.heex
@@ -1,88 +1,104 @@
-<div>
-  <.header_nav current_user={@current_user}>
-    <:title><%= gettext("Students records") %></:title>
-    <div class="flex items-center gap-4 p-4">
-      <p class="flex-1 flex flex-wrap gap-2">
-        <%= ngettext(
-          "Showing 1 result for",
-          "Showing %{count} results for",
-          @students_records_length
-        ) %>
-        <%= if @selected_students != [] do %>
-          <.badge
-            :for={student <- @selected_students}
-            on_remove={JS.push("remove_student_filter")}
-            theme="primary"
-          >
-            <%= student.name %>
-          </.badge>
-        <% else %>
-          <.badge><%= gettext("all students") %></.badge>
-        <% end %>
-        ,
-        <%= if @selected_classes != [] do %>
-          <.badge
-            :for={class <- @selected_classes}
-            on_remove={JS.push("remove_class_filter", value: %{"id" => class.id})}
-            theme="primary"
-          >
-            <%= class_with_cycle(class, @current_user) %>
-          </.badge>
-        <% else %>
-          <.badge><%= gettext("all classes") %></.badge>
-        <% end %>,
-        <%= if @selected_student_record_types != [] do %>
-          <.badge
-            :for={type <- @selected_student_record_types}
-            color_map={type}
-            on_remove={JS.push("remove_type_filter")}
-          >
-            <%= type.name %>
-          </.badge>
-        <% else %>
-          <.badge><%= gettext("all student record types") %></.badge>
-        <% end %>
-        <%= gettext("and") %>
-        <%= if @selected_student_record_statuses != [] do %>
-          <.badge
-            :for={status <- @selected_student_record_statuses}
-            color_map={status}
-            on_remove={JS.push("remove_status_filter")}
-          >
-            <%= status.name %>
-          </.badge>
-        <% else %>
-          <.badge><%= gettext("all statuses") %></.badge>
-        <% end %>
-      </p>
-      <.action
-        type="link"
-        patch={~p"/students_records?student_record=new"}
-        icon_name="hero-plus-circle-mini"
-      >
-        <%= gettext("New student record") %>
-      </.action>
+<.header_nav current_user={@current_user}>
+  <:title><%= gettext("Students records") %></:title>
+  <div class="flex items-center gap-4 p-4">
+    <div class="flex-1 flex flex-wrap items-center gap-6">
+      <%= if @selected_students == [] do %>
+        <.action
+          type="button"
+          icon_name="hero-chevron-down-mini"
+          phx-click={JS.push("open_student_search_modal")}
+        >
+          <%= gettext("All students") %>
+        </.action>
+      <% else %>
+        <.badge
+          :for={student <- @selected_students}
+          on_remove={JS.push("remove_student_filter")}
+          theme="primary"
+        >
+          <%= student.name %>
+        </.badge>
+      <% end %>
+      <%= if @selected_classes == [] do %>
+        <.action
+          type="button"
+          icon_name="hero-chevron-down-mini"
+          phx-click={JS.exec("data-show", to: "#students-records-classes-filters-overlay")}
+        >
+          <%= gettext("All classes") %>
+        </.action>
+      <% else %>
+        <.badge
+          :for={class <- @selected_classes}
+          on_remove={JS.push("remove_class_filter", value: %{"id" => class.id})}
+          theme="primary"
+        >
+          <%= class_with_cycle(class, @current_user) %>
+        </.badge>
+      <% end %>
+      <%= if @selected_student_record_statuses == [] do %>
+        <.action
+          type="button"
+          icon_name="hero-chevron-down-mini"
+          phx-click={JS.exec("data-show", to: "#student-record-statuses-filter-modal")}
+        >
+          <%= gettext("All statuses") %>
+        </.action>
+      <% else %>
+        <.badge
+          :for={status <- @selected_student_record_statuses}
+          color_map={status}
+          on_remove={JS.push("remove_status_filter")}
+        >
+          <%= status.name %>
+        </.badge>
+      <% end %>
+      <%= if @selected_student_record_types == [] do %>
+        <.action
+          type="button"
+          icon_name="hero-chevron-down-mini"
+          phx-click={JS.exec("data-show", to: "#student-record-types-filter-modal")}
+        >
+          <%= gettext("All types") %>
+        </.action>
+      <% else %>
+        <.badge
+          :for={type <- @selected_student_record_types}
+          color_map={type}
+          on_remove={JS.push("remove_type_filter")}
+        >
+          <%= type.name %>
+        </.badge>
+      <% end %>
     </div>
-  </.header_nav>
-</div>
-<.students_records_data_grid
-  id="students-records"
-  stream={@streams.students_records}
-  show_empty_state_message={@students_records_length == 0}
-  student_navigate={fn student -> ~p"/school/students/#{student}/student_records" end}
-  details_patch={
-    fn student_record -> ~p"/students_records?student_record=#{student_record.id}" end
-  }
-  is_students_filter_active={@selected_students_ids != []}
-  on_students_filter={JS.push("open_student_search_modal")}
-  is_classes_filter_active={@selected_classes_ids != []}
-  on_classes_filter={JS.exec("data-show", to: "#students-records-classes-filters-overlay")}
-  is_type_filter_active={@selected_student_record_types_ids != []}
-  on_type_filter={JS.exec("data-show", to: "#student-record-types-filter-modal")}
-  is_status_filter_active={@selected_student_record_statuses_ids != []}
-  on_status_filter={JS.exec("data-show", to: "#student-record-statuses-filter-modal")}
-  current_user_or_cycle={@current_user}
-/>
+    <.action
+      type="link"
+      patch={~p"/students_records?student_record=new"}
+      icon_name="hero-plus-circle-mini"
+    >
+      <%= gettext("New student record") %>
+    </.action>
+  </div>
+</.header_nav>
+<p :if={@students_records_length > 0} class="p-4 text-center">
+  <%= ngettext(
+    "Showing 1 result for selected filters",
+    "Showing %{count} results for selected filters",
+    @students_records_length
+  ) %>
+</p>
+<.responsive_container class="p-4">
+  <.students_records_list
+    id="students-records"
+    stream={@streams.students_records}
+    show_empty_state_message={@students_records_length == 0}
+    student_navigate={fn student -> ~p"/school/students/#{student}/student_records" end}
+    details_patch={
+      fn student_record -> ~p"/students_records?student_record=#{student_record.id}" end
+    }
+    current_user_or_cycle={@current_user}
+  />
+</.responsive_container>
 <div :if={@has_next} class="flex justify-center pb-10">
   <.button theme="ghost" phx-click="load_more" class="mt-6">
     <%= gettext("Load more records") %>

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.html.heex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.html.heex
@@ -2,13 +2,14 @@
   <:title><%= gettext("Students records") %></:title>
   <div class="flex items-center gap-4 p-4">
     <div class="flex-1 flex flex-wrap items-center gap-6">
+      <.icon name="hero-funnel-mini" class="text-ltrn-subtle" />
       <%= if @selected_students == [] do %>
         <.action
           type="button"
           icon_name="hero-chevron-down-mini"
           phx-click={JS.push("open_student_search_modal")}
         >
-          <%= gettext("All students") %>
+          <%= gettext("Student") %>
         </.action>
       <% else %>
         <.badge
@@ -25,7 +26,7 @@
           icon_name="hero-chevron-down-mini"
           phx-click={JS.exec("data-show", to: "#students-records-classes-filters-overlay")}
         >
-          <%= gettext("All classes") %>
+          <%= gettext("Classes") %>
         </.action>
       <% else %>
         <.badge
@@ -40,9 +41,9 @@
         <.action
           type="button"
           icon_name="hero-chevron-down-mini"
-          phx-click={JS.exec("data-show", to: "#student-record-statuses-filter-modal")}
+          phx-click={JS.exec("data-show", to: "#student-record-status-filter-modal")}
         >
-          <%= gettext("All statuses") %>
+          <%= gettext("Status") %>
         </.action>
       <% else %>
         <.badge
@@ -57,9 +58,9 @@
         <.action
           type="button"
           icon_name="hero-chevron-down-mini"
-          phx-click={JS.exec("data-show", to: "#student-record-types-filter-modal")}
+          phx-click={JS.exec("data-show", to: "#student-record-type-filter-modal")}
         >
-          <%= gettext("All types") %>
+          <%= gettext("Type") %>
         </.action>
       <% else %>
         <.badge
@@ -68,6 +69,23 @@
           on_remove={JS.push("remove_type_filter")}
         >
           <%= type.name %>
+        </.badge>
+      <% end %>
+      <%= if @selected_student_record_assignees == [] do %>
+        <.action
+          type="button"
+          icon_name="hero-chevron-down-mini"
+          phx-click={JS.push("open_assignee_search_modal")}
+        >
+          <%= gettext("Assignee") %>
+        </.action>
+      <% else %>
+        <.badge
+          :for={assignee <- @selected_student_record_assignees}
+          on_remove={JS.push("remove_assignee_filter")}
+          theme="teacher"
+        >
+          <%= assignee.name %>
         </.badge>
       <% end %>
     </div>
@@ -132,7 +150,7 @@
   selected_classes_ids={@selected_classes_ids}
 />
 <.single_selection_filter_modal
-  id="student-record-types-filter-modal"
+  id="student-record-type-filter-modal"
   title={gettext("Filter students records by type")}
   use_color_map_as_active
   items={@student_record_types}
@@ -141,12 +159,12 @@
   on_select={
     fn id ->
       JS.push("filter_by_type", value: %{"id" => id})
-      |> JS.exec("data-cancel", to: "#student-record-types-filter-modal")
+      |> JS.exec("data-cancel", to: "#student-record-type-filter-modal")
     end
   }
 />
 <.single_selection_filter_modal
-  id="student-record-statuses-filter-modal"
+  id="student-record-status-filter-modal"
   title={gettext("Filter students records by status")}
   use_color_map_as_active
   items={@student_record_statuses}
@@ -155,10 +173,29 @@
   on_select={
     fn id ->
       JS.push("filter_by_status", value: %{"id" => id})
-      |> JS.exec("data-cancel", to: "#student-record-statuses-filter-modal")
+      |> JS.exec("data-cancel", to: "#student-record-status-filter-modal")
     end
   }
 />
+<.modal
+  :if={@show_assignee_search_modal}
+  id="assignee-search-modal"
+  show
+  on_cancel={JS.push("close_assignee_search_modal")}
+>
+  <h5 class="mb-10 font-display font-black text-xl">
+    <%= gettext("Filter records by assignee") %>
+  </h5>
+  <form>
+    <.live_component
+      module={StaffMemberSearchComponent}
+      id="assignee-search-modal-search"
+      notify_parent
+      label={gettext("Type the name of the assignee")}
+      school_id={@current_user.current_profile.school_id}
+    />
+  </form>
+</.modal>
 <.live_component
   module={StudentRecordOverlayComponent}
   student_record_id={@student_record_id}

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.html.heex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.html.heex
@@ -111,6 +111,9 @@
     stream={@streams.students_records}
     show_empty_state_message={@students_records_length == 0}
     student_navigate={fn student -> ~p"/school/students/#{student}/student_records" end}
+    staff_navigate={
+      fn staff_member_id -> ~p"/school/staff/#{staff_member_id}/students_records" end
+    }
     details_patch={
       fn student_record -> ~p"/students_records?student_record=#{student_record.id}" end
     }

--- a/lib/lanttern_web/live/shared/menu_component.ex
+++ b/lib/lanttern_web/live/shared/menu_component.ex
@@ -58,18 +58,9 @@ defmodule LantternWeb.MenuComponent do
             size="lg"
             class="mb-4"
           />
-          <div class="flex items-center gap-2">
-            <p class="font-black text-4xl text-ltrn-dark">
-              <%= @current_user.current_profile.name %>
-            </p>
-            <.link
-              :if={@current_user.current_profile.type == "staff"}
-              navigate={~p"/school/staff?edit=#{@current_user.current_profile.staff_member_id}"}
-              class="flex items-center justify-center rounded-full text-ltrn-subtle hover:text-ltrn-dark"
-            >
-              <.icon name="hero-pencil-mini" />
-            </.link>
-          </div>
+          <p class="font-black text-4xl text-ltrn-dark">
+            <%= @current_user.current_profile.name %>
+          </p>
           <div id="profile-select" class="group mt-2">
             <button
               type="button"
@@ -164,6 +155,14 @@ defmodule LantternWeb.MenuComponent do
           </div>
           <nav class="mt-10">
             <ul class="font-bold text-lg text-ltrn-subtle leading-loose">
+              <li :if={@current_user.current_profile.type == "staff"}>
+                <.link
+                  href={~p"/school/staff/#{@current_user.current_profile.staff_member}"}
+                  class="flex items-center gap-2 hover:text-ltrn-dark"
+                >
+                  <%= gettext("My area") %>
+                </.link>
+              </li>
               <li :if={@current_user.is_root_admin}>
                 <.link href={~p"/admin"} class="flex items-center gap-2 hover:text-ltrn-dark">
                   <%= gettext("Admin") %>

--- a/lib/lanttern_web/live/shared/schools/staff_member_search_component.ex
+++ b/lib/lanttern_web/live/shared/schools/staff_member_search_component.ex
@@ -83,8 +83,6 @@ defmodule LantternWeb.Schools.StaffMemberSearchComponent do
 
   @impl true
   def mount(socket) do
-    IO.inspect(socket, label: "socket in component ")
-
     socket =
       socket
       |> assign(:label, nil)

--- a/lib/lanttern_web/live/shared/schools/staff_member_search_component.ex
+++ b/lib/lanttern_web/live/shared/schools/staff_member_search_component.ex
@@ -83,11 +83,13 @@ defmodule LantternWeb.Schools.StaffMemberSearchComponent do
 
   @impl true
   def mount(socket) do
+    IO.inspect(socket, label: "socket in component ")
+
     socket =
       socket
       |> assign(:label, nil)
       |> assign(:class, nil)
-      |> assign(:search_opts, [])
+      |> assign(:school_id, nil)
       |> assign(:refocus_on_select, "false")
       |> stream(:results, [])
 
@@ -99,10 +101,11 @@ defmodule LantternWeb.Schools.StaffMemberSearchComponent do
   @impl true
   def handle_event("search", params, socket) do
     query = Map.get(params, "#{socket.assigns.id}-query", "")
+    search_opts = if socket.assigns.school_id, do: [school_id: socket.assigns.school_id], else: []
     # search when more than 3 characters were typed
     results =
       if String.length(query) > 3,
-        do: Schools.search_staff_members(query, socket.assigns.search_opts),
+        do: Schools.search_staff_members(query, search_opts),
         else: []
 
     results_simplified = Enum.map(results, fn s -> %{id: s.id} end)

--- a/lib/lanttern_web/live/shared/schools/staff_member_search_component.ex
+++ b/lib/lanttern_web/live/shared/schools/staff_member_search_component.ex
@@ -1,6 +1,6 @@
-defmodule LantternWeb.Schools.StudentSearchComponent do
+defmodule LantternWeb.Schools.StaffMemberSearchComponent do
   @moduledoc """
-  Renders a `Student` search component
+  Renders a `StaffMember` search component
   """
 
   use LantternWeb, :live_component
@@ -23,7 +23,7 @@ defmodule LantternWeb.Schools.StudentSearchComponent do
           class="peer pr-10"
           role="combobox"
           autocomplete="off"
-          aria-controls="student-search-controls"
+          aria-controls="staff-member-search-controls"
           aria-expanded="false"
           phx-hook="Autocomplete"
           phx-change="search"
@@ -45,7 +45,7 @@ defmodule LantternWeb.Schools.StudentSearchComponent do
             "absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md bg-white py-1 text-base shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none sm:text-sm hidden",
             "peer-aria-expanded:block"
           ]}
-          id="student-search-controls"
+          id="staff-member-search-controls"
           role="listbox"
           phx-update="stream"
         >
@@ -87,6 +87,7 @@ defmodule LantternWeb.Schools.StudentSearchComponent do
       socket
       |> assign(:label, nil)
       |> assign(:class, nil)
+      |> assign(:search_opts, [])
       |> assign(:refocus_on_select, "false")
       |> stream(:results, [])
 
@@ -101,7 +102,7 @@ defmodule LantternWeb.Schools.StudentSearchComponent do
     # search when more than 3 characters were typed
     results =
       if String.length(query) > 3,
-        do: Schools.search_students(query),
+        do: Schools.search_staff_members(query, socket.assigns.search_opts),
         else: []
 
     results_simplified = Enum.map(results, fn s -> %{id: s.id} end)
@@ -117,7 +118,7 @@ defmodule LantternWeb.Schools.StudentSearchComponent do
   end
 
   def handle_event("autocomplete_result_select", %{"id" => id}, socket) do
-    selected = Schools.get_student!(id)
+    selected = Schools.get_staff_member!(id)
 
     notify(
       __MODULE__,

--- a/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
@@ -66,6 +66,19 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
               />
             </div>
             <div class="mb-6">
+              <.label><%= gettext("Status") %></.label>
+              <.badge_button_picker
+                id="student-record-status-select"
+                on_select={&JS.push("select_status", value: %{"id" => &1}, target: @myself)}
+                items={@statuses}
+                selected_ids={[@selected_status_id]}
+                use_color_map_as_active
+              />
+              <div :if={@form.source.action in [:insert, :update]}>
+                <.error :for={{msg, _} <- @form[:status_id].errors}><%= msg %></.error>
+              </div>
+            </div>
+            <div class="mb-6">
               <.label><%= gettext("Record type") %></.label>
               <.badge_button_picker
                 id="student-record-type-select"
@@ -123,19 +136,6 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
               <p class="mb-6 font-bold text-ltrn-teacher-dark">
                 <%= gettext("Internal student record tracking") %>
               </p>
-              <div class="mb-6">
-                <.label><%= gettext("Status") %></.label>
-                <.badge_button_picker
-                  id="student-record-status-select"
-                  on_select={&JS.push("select_status", value: %{"id" => &1}, target: @myself)}
-                  items={@statuses}
-                  selected_ids={[@selected_status_id]}
-                  use_color_map_as_active
-                />
-                <div :if={@form.source.action in [:insert, :update]}>
-                  <.error :for={{msg, _} <- @form[:status_id].errors}><%= msg %></.error>
-                </div>
-              </div>
               <div>
                 <.live_component
                   module={StaffMemberSearchComponent}

--- a/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
@@ -519,6 +519,14 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
   end
 
   defp save_student_record(socket, nil, student_record_params) do
+    # when creating student record, inject current user as creator
+    student_record_params =
+      student_record_params
+      |> Map.put(
+        "created_by_staff_member_id",
+        socket.assigns.current_user.current_profile.staff_member_id
+      )
+
     StudentsRecords.create_student_record(
       student_record_params,
       log_profile_id: socket.assigns.current_user.current_profile_id

--- a/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
@@ -167,15 +167,15 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
               </div>
               <div class="flex items-center gap-4">
                 <div class="flex items-center gap-2">
-                  <span><%= gettext("Type") %>:</span>
-                  <.badge color_map={@student_record.type}>
-                    <%= @student_record.type.name %>
-                  </.badge>
-                </div>
-                <div class="flex items-center gap-2">
                   <span><%= gettext("Status") %>:</span>
                   <.badge color_map={@student_record.status}>
                     <%= @student_record.status.name %>
+                  </.badge>
+                </div>
+                <div class="flex items-center gap-2">
+                  <span><%= gettext("Type") %>:</span>
+                  <.badge color_map={@student_record.type}>
+                    <%= @student_record.type.name %>
                   </.badge>
                 </div>
               </div>

--- a/lib/lanttern_web/router.ex
+++ b/lib/lanttern_web/router.ex
@@ -82,6 +82,9 @@ defmodule LantternWeb.Router do
       live "/school/students/:id/grades_reports", StudentLive, :grades_reports
       live "/school/students/:id/student_records", StudentLive, :student_records
 
+      live "/school/staff/:id", StaffMemberLive, :show
+      live "/school/staff/:id/students_records", StaffMemberLive, :students_records
+
       live "/assessment_points/:id", AssessmentPointLive, :show
       live "/assessment_points/:id/edit", AssessmentPointLive, :edit
       live "/assessment_points/:id/rubrics", AssessmentPointLive, :rubrics

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12,8 +12,8 @@ msgid ""
 msgstr ""
 
 #: lib/lanttern_web/components/core_components.ex:771
-#: lib/lanttern_web/components/core_components.ex:1872
-#: lib/lanttern_web/components/core_components.ex:1934
+#: lib/lanttern_web/components/core_components.ex:1888
+#: lib/lanttern_web/components/core_components.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -25,13 +25,13 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:2
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:441
+#: lib/lanttern_web/live/shared/menu_component.ex:440
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:420
+#: lib/lanttern_web/live/shared/menu_component.ex:419
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -42,11 +42,6 @@ msgstr ""
 msgid "Rubrics"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:3
-#, elixir-autogen, elixir-format
-msgid "School"
-msgstr ""
-
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:20
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:3
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:2
@@ -55,8 +50,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:422
-#: lib/lanttern_web/live/shared/menu_component.ex:466
+#: lib/lanttern_web/live/shared/menu_component.ex:421
+#: lib/lanttern_web/live/shared/menu_component.ex:465
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr ""
@@ -68,13 +63,13 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:181
+#: lib/lanttern_web/live/shared/menu_component.ex:180
 #, elixir-autogen, elixir-format
 msgid "Language:"
 msgstr ""
 
 #: lib/lanttern_web/controllers/privacy_policy_html/accept_policy.html.heex:25
-#: lib/lanttern_web/live/shared/menu_component.ex:174
+#: lib/lanttern_web/live/shared/menu_component.ex:173
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -137,7 +132,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:96
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:71
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:40
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:147
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:174
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -194,7 +189,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:105
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:43
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:150
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
@@ -225,7 +220,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:51
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:62
 #: lib/lanttern_web/live/shared/reporting/strand_report_form_component.ex:55
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:129
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:130
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
@@ -248,7 +243,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:44
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:45
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:46
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
@@ -275,8 +270,8 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:26
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:35
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:40
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:135
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:41
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:162
 #, elixir-autogen, elixir-format
 msgid "Oops, something went wrong! Please check the errors below."
 msgstr ""
@@ -379,7 +374,8 @@ msgstr ""
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:8
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:10
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:10
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "About"
@@ -417,7 +413,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:226
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:272
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
@@ -484,7 +480,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:64
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:224
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:270
 #, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
@@ -809,7 +805,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1822
+#: lib/lanttern_web/components/core_components.ex:1838
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -901,8 +897,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:13
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:34
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Showing 1 result for"
 msgid_plural "Showing %{count} results for"
@@ -1034,7 +1028,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:25
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:49
 #: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:49
-#: lib/lanttern_web/live/shared/menu_component.ex:130
+#: lib/lanttern_web/live/shared/menu_component.ex:121
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:37
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:39
 #, elixir-autogen, elixir-format
@@ -1222,8 +1216,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:2
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:20
-#: lib/lanttern_web/live/shared/menu_component.ex:453
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:22
+#: lib/lanttern_web/live/shared/menu_component.ex:452
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr ""
@@ -1285,7 +1279,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1812
+#: lib/lanttern_web/components/core_components.ex:1828
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1394,7 +1388,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/attachments_components.ex:135
 #: lib/lanttern_web/components/core_components.ex:207
-#: lib/lanttern_web/components/core_components.ex:1382
+#: lib/lanttern_web/components/core_components.ex:1387
 #: lib/lanttern_web/components/form_components.ex:718
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
@@ -1419,11 +1413,11 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:3
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:22
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:14
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:16
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:115
-#: lib/lanttern_web/live/shared/menu_component.ex:447
-#: lib/lanttern_web/live/shared/menu_component.ex:460
-#: lib/lanttern_web/live/shared/menu_component.ex:473
+#: lib/lanttern_web/live/shared/menu_component.ex:446
+#: lib/lanttern_web/live/shared/menu_component.ex:459
+#: lib/lanttern_web/live/shared/menu_component.ex:472
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr ""
@@ -1559,11 +1553,10 @@ msgstr ""
 msgid "Student report card deleted"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:61
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:11
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:101
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:187
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:102
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:218
 #, elixir-autogen, elixir-format
 msgid "Students"
 msgstr ""
@@ -1591,9 +1584,11 @@ msgstr ""
 msgid "The parent cycle grade is calculated based on it's children cycles. E.g. 2024 grade is based on 2024 Q1, Q2, Q3, and Q4 grades."
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:103
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:122
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:55
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:63
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:42
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:170
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:207
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr ""
@@ -1633,7 +1628,6 @@ msgid "all years"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:23
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
@@ -1808,8 +1802,8 @@ msgstr ""
 msgid "Hey!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1440
-#: lib/lanttern_web/components/core_components.ex:1462
+#: lib/lanttern_web/components/core_components.ex:1450
+#: lib/lanttern_web/components/core_components.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Selected"
 msgstr ""
@@ -1863,7 +1857,7 @@ msgstr ""
 
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:11
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:212
+#: lib/lanttern_web/live/shared/menu_component.ex:211
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
 msgstr ""
@@ -1905,7 +1899,7 @@ msgstr ""
 msgid "Privacy policy and terms of service"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:220
+#: lib/lanttern_web/live/shared/menu_component.ex:219
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr ""
@@ -2221,11 +2215,13 @@ msgstr ""
 msgid "Attachments"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:96
+#: lib/lanttern/personalization/profile_settings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Invalid assessment view"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:71
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:12
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:398
 #, elixir-autogen, elixir-format
 msgid "Student"
@@ -2387,7 +2383,7 @@ msgstr ""
 msgid "Goals assessment"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:101
+#: lib/lanttern/personalization/profile_settings.ex:107
 #, elixir-autogen, elixir-format
 msgid "Invalid assessment group by option"
 msgstr ""
@@ -2607,12 +2603,13 @@ msgstr ""
 msgid "No teacher assessment"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:78
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:8
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:88
 #: lib/lanttern_web/live/pages/school/students_component.ex:63
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:29
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:51
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:119
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:203
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:120
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:234
 #, elixir-autogen, elixir-format
 msgid "Classes"
 msgstr ""
@@ -2667,108 +2664,94 @@ msgstr ""
 msgid "All strand evidences"
 msgstr ""
 
-#: lib/lanttern/students_records/student_record.ex:91
+#: lib/lanttern/students_records/student_record.ex:112
 #, elixir-autogen, elixir-format
 msgid "At least 1 student is required"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:49
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:54
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:26
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "Edit student record"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:110
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:98
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:180
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Filter records by student"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:74
+#: lib/lanttern/personalization/profile_settings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Invalid permissions"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:100
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:88
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:170
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:122
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Load more records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:74
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:63
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:139
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:89
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "New student record"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:46
+#: lib/lanttern_web/components/students_records_components.ex:43
 #, elixir-autogen, elixir-format
 msgid "No students records found for selected filters."
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:95
-#, elixir-autogen, elixir-format
-msgid "Record"
-msgstr ""
-
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:68
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Record type"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:114
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:84
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:176
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:105
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:38
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:46
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:69
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:29
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:3
-#: lib/lanttern_web/live/shared/menu_component.ex:427
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:17
+#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:30
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:2
+#: lib/lanttern_web/live/shared/menu_component.ex:426
 #, elixir-autogen, elixir-format
 msgid "Students records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:117
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:105
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:187
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Type the name of the student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:55
-#, elixir-autogen, elixir-format
-msgid "all statuses"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:43
-#, elixir-autogen, elixir-format
-msgid "all student record types"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:20
-#, elixir-autogen, elixir-format
-msgid "all students"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:146
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:134
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:202
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:127
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Filter students records by status"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:132
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:120
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:216
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:141
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Filter students records by type"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:61
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "Time"
 msgstr ""
@@ -2995,8 +2978,8 @@ msgstr ""
 msgid "Edit class"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:36
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:76
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:38
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:78
 #: lib/lanttern_web/live/pages/school/students_component.ex:77
 #: lib/lanttern_web/live/pages/school/students_component.ex:109
 #: lib/lanttern_web/live/pages/school/students_component.ex:318
@@ -3052,7 +3035,6 @@ msgid "Students in this class"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/students_component.ex:35
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "all classes"
 msgstr ""
@@ -3082,7 +3064,7 @@ msgstr ""
 msgid "Add cycle"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:169
+#: lib/lanttern_web/live/shared/menu_component.ex:168
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
@@ -3156,7 +3138,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/guardian/guardian_home_live.ex:127
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:127
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:164
-#: lib/lanttern_web/live/shared/menu_component.ex:540
+#: lib/lanttern_web/live/shared/menu_component.ex:539
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr ""
@@ -3202,7 +3184,7 @@ msgstr ""
 msgid "Edit note"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:233
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:279
 #, elixir-autogen, elixir-format
 msgid "Edit record"
 msgstr ""
@@ -3274,12 +3256,12 @@ msgstr ""
 msgid "Link students from %{year} to this report card"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:140
+#: lib/lanttern_web/live/shared/menu_component.ex:131
 #, elixir-autogen, elixir-format
 msgid "Loading cycles"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:95
+#: lib/lanttern_web/live/shared/menu_component.ex:86
 #, elixir-autogen, elixir-format
 msgid "Loading profiles"
 msgstr ""
@@ -3331,7 +3313,7 @@ msgstr ""
 msgid "No class selected"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:131
+#: lib/lanttern_web/live/shared/menu_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "No cycle selected"
 msgstr ""
@@ -3346,7 +3328,7 @@ msgstr ""
 msgid "No cycles in this school"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:160
+#: lib/lanttern_web/live/shared/menu_component.ex:151
 #, elixir-autogen, elixir-format
 msgid "No cycles registered"
 msgstr ""
@@ -3540,33 +3522,28 @@ msgstr ""
 msgid "Link strand to report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:125
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:113
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:195
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Filter students records by class"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:129
-#, elixir-autogen, elixir-format
-msgid "Details"
-msgstr ""
-
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:27
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:28
 #, elixir-autogen, elixir-format
 msgid "Student record detail"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:238
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:284
 #, elixir-autogen, elixir-format
 msgid "Student record not found"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:27
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "Student records"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:215
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:261
 #, elixir-autogen, elixir-format
 msgid "This record was deleted"
 msgstr ""
@@ -3609,7 +3586,7 @@ msgstr ""
 msgid "Check the student and school relationship"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:59
+#: lib/lanttern_web/live/pages/school/staff_component.ex:64
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Edit cycle profile picture"
@@ -3875,7 +3852,9 @@ msgstr ""
 msgid "Cancel remove"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:161
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:26
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:62
+#: lib/lanttern_web/live/pages/school/staff_component.ex:166
 #, elixir-autogen, elixir-format
 msgid "Edit staff member"
 msgstr ""
@@ -3906,7 +3885,7 @@ msgstr ""
 msgid "Lanttern user email"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:149
+#: lib/lanttern_web/live/pages/school/staff_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "New staff member"
 msgstr ""
@@ -3926,7 +3905,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:434
+#: lib/lanttern_web/live/shared/menu_component.ex:433
 #, elixir-autogen, elixir-format
 msgid "School management"
 msgstr ""
@@ -3936,12 +3915,13 @@ msgstr ""
 msgid "Staff"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:93
+#: lib/lanttern_web/live/pages/school/staff_component.ex:98
 #, elixir-autogen, elixir-format
 msgid "Staff member created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:94
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:93
+#: lib/lanttern_web/live/pages/school/staff_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Staff member updated successfully"
 msgstr ""
@@ -3973,7 +3953,7 @@ msgstr ""
 msgid "No deactivated staff members found"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:95
+#: lib/lanttern_web/live/pages/school/staff_component.ex:100
 #, elixir-autogen, elixir-format
 msgid "Staff member deactivated successfully"
 msgstr ""
@@ -3981,4 +3961,96 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/staff_component.ex:18
 #, elixir-autogen, elixir-format
 msgid "View deactivated staff members"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:4
+#, elixir-autogen, elixir-format
+msgid "%{school} staff"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:4
+#, elixir-autogen, elixir-format
+msgid "%{school} students"
+msgstr ""
+
+#: lib/lanttern_web/components/students_records_components.ex:120
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:253
+#, elixir-autogen, elixir-format
+msgid "Assigned to"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:43
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:58
+#, elixir-autogen, elixir-format
+msgid "Assigned to %{staff_member}"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:72
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:80
+#, elixir-autogen, elixir-format
+msgid "Assignee"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:144
+#, elixir-autogen, elixir-format
+msgid "Assignees"
+msgstr ""
+
+#: lib/lanttern_web/components/students_records_components.ex:111
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:249
+#, elixir-autogen, elixir-format
+msgid "Created by"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:160
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:190
+#, elixir-autogen, elixir-format
+msgid "Filter records by assignee"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:137
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:246
+#, elixir-autogen, elixir-format
+msgid "Internal student record tracking"
+msgstr ""
+
+#: lib/lanttern/personalization/profile_settings.ex:113
+#, elixir-autogen, elixir-format
+msgid "Invalid view option"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/menu_component.ex:163
+#, elixir-autogen, elixir-format
+msgid "My area"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:143
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:93
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:102
+#, elixir-autogen, elixir-format
+msgid "Showing 1 result for selected filters"
+msgid_plural "Showing %{count} results for selected filters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:102
+#, elixir-autogen, elixir-format
+msgid "Staff member deleted successfully"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:167
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:197
+#, elixir-autogen, elixir-format
+msgid "Type the name of the assignee"
+msgstr ""
+
+#: lib/lanttern_web/components/students_records_components.ex:104
+#, elixir-autogen, elixir-format
+msgid "View more"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:40
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:52
+#, elixir-autogen, elixir-format
+msgid "Created by %{staff_member}"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: lib/lanttern_web/components/core_components.ex:771
-#: lib/lanttern_web/components/core_components.ex:1872
-#: lib/lanttern_web/components/core_components.ex:1934
+#: lib/lanttern_web/components/core_components.ex:1888
+#: lib/lanttern_web/components/core_components.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -25,13 +25,13 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:2
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:441
+#: lib/lanttern_web/live/shared/menu_component.ex:440
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:420
+#: lib/lanttern_web/live/shared/menu_component.ex:419
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -42,11 +42,6 @@ msgstr ""
 msgid "Rubrics"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:3
-#, elixir-autogen, elixir-format
-msgid "School"
-msgstr ""
-
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:20
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:3
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:2
@@ -55,8 +50,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:422
-#: lib/lanttern_web/live/shared/menu_component.ex:466
+#: lib/lanttern_web/live/shared/menu_component.ex:421
+#: lib/lanttern_web/live/shared/menu_component.ex:465
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr ""
@@ -68,13 +63,13 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:181
+#: lib/lanttern_web/live/shared/menu_component.ex:180
 #, elixir-autogen, elixir-format
 msgid "Language:"
 msgstr ""
 
 #: lib/lanttern_web/controllers/privacy_policy_html/accept_policy.html.heex:25
-#: lib/lanttern_web/live/shared/menu_component.ex:174
+#: lib/lanttern_web/live/shared/menu_component.ex:173
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -137,7 +132,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:96
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:71
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:40
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:147
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:174
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -194,7 +189,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:105
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:43
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:150
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
@@ -225,7 +220,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:51
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:62
 #: lib/lanttern_web/live/shared/reporting/strand_report_form_component.ex:55
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:129
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:130
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
@@ -248,7 +243,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:44
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:45
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:46
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr ""
@@ -275,8 +270,8 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:26
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:35
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:40
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:135
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:41
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:162
 #, elixir-autogen, elixir-format
 msgid "Oops, something went wrong! Please check the errors below."
 msgstr ""
@@ -379,7 +374,8 @@ msgstr ""
 msgid "Something went wrong!"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:8
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:10
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:10
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "About"
@@ -417,7 +413,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:226
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:272
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
@@ -484,7 +480,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:64
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:224
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:270
 #, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
@@ -809,7 +805,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1822
+#: lib/lanttern_web/components/core_components.ex:1838
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -901,8 +897,6 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:13
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:34
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Showing 1 result for"
 msgid_plural "Showing %{count} results for"
@@ -1034,7 +1028,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:25
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:49
 #: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:49
-#: lib/lanttern_web/live/shared/menu_component.ex:130
+#: lib/lanttern_web/live/shared/menu_component.ex:121
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:37
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:39
 #, elixir-autogen, elixir-format
@@ -1222,8 +1216,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:2
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:20
-#: lib/lanttern_web/live/shared/menu_component.ex:453
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:22
+#: lib/lanttern_web/live/shared/menu_component.ex:452
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr ""
@@ -1285,7 +1279,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1812
+#: lib/lanttern_web/components/core_components.ex:1828
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1394,7 +1388,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/attachments_components.ex:135
 #: lib/lanttern_web/components/core_components.ex:207
-#: lib/lanttern_web/components/core_components.ex:1382
+#: lib/lanttern_web/components/core_components.ex:1387
 #: lib/lanttern_web/components/form_components.ex:718
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
@@ -1419,11 +1413,11 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:3
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:22
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:14
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:16
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:115
-#: lib/lanttern_web/live/shared/menu_component.ex:447
-#: lib/lanttern_web/live/shared/menu_component.ex:460
-#: lib/lanttern_web/live/shared/menu_component.ex:473
+#: lib/lanttern_web/live/shared/menu_component.ex:446
+#: lib/lanttern_web/live/shared/menu_component.ex:459
+#: lib/lanttern_web/live/shared/menu_component.ex:472
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr ""
@@ -1559,11 +1553,10 @@ msgstr ""
 msgid "Student report card deleted"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:61
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:11
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:101
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:187
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:102
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:218
 #, elixir-autogen, elixir-format
 msgid "Students"
 msgstr ""
@@ -1591,9 +1584,11 @@ msgstr ""
 msgid "The parent cycle grade is calculated based on it's children cycles. E.g. 2024 grade is based on 2024 Q1, Q2, Q3, and Q4 grades."
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:103
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:122
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:55
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:63
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:42
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:170
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:207
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr ""
@@ -1633,7 +1628,6 @@ msgid "all years"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:23
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr ""
@@ -1808,8 +1802,8 @@ msgstr ""
 msgid "Hey!"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1440
-#: lib/lanttern_web/components/core_components.ex:1462
+#: lib/lanttern_web/components/core_components.ex:1450
+#: lib/lanttern_web/components/core_components.ex:1472
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Selected"
 msgstr ""
@@ -1863,7 +1857,7 @@ msgstr ""
 
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:11
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:212
+#: lib/lanttern_web/live/shared/menu_component.ex:211
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
 msgstr ""
@@ -1905,7 +1899,7 @@ msgstr ""
 msgid "Privacy policy and terms of service"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:220
+#: lib/lanttern_web/live/shared/menu_component.ex:219
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr ""
@@ -2221,11 +2215,13 @@ msgstr ""
 msgid "Attachments"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:96
+#: lib/lanttern/personalization/profile_settings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Invalid assessment view"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:71
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:12
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:398
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student"
@@ -2387,7 +2383,7 @@ msgstr ""
 msgid "Goals assessment"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:101
+#: lib/lanttern/personalization/profile_settings.ex:107
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid assessment group by option"
 msgstr ""
@@ -2607,12 +2603,13 @@ msgstr ""
 msgid "No teacher assessment"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:78
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:8
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:88
 #: lib/lanttern_web/live/pages/school/students_component.ex:63
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:29
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:51
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:119
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:203
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:120
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:234
 #, elixir-autogen, elixir-format
 msgid "Classes"
 msgstr ""
@@ -2667,108 +2664,94 @@ msgstr ""
 msgid "All strand evidences"
 msgstr ""
 
-#: lib/lanttern/students_records/student_record.ex:91
+#: lib/lanttern/students_records/student_record.ex:112
 #, elixir-autogen, elixir-format
 msgid "At least 1 student is required"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:49
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:54
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:26
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:27
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit student record"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:110
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:98
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:180
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Filter records by student"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:74
+#: lib/lanttern/personalization/profile_settings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Invalid permissions"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:100
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:88
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:170
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:122
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:125
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Load more records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:74
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:63
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:139
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:89
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "New student record"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:46
+#: lib/lanttern_web/components/students_records_components.ex:43
 #, elixir-autogen, elixir-format
 msgid "No students records found for selected filters."
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:95
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Record"
-msgstr ""
-
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:68
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Record type"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:114
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:84
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:176
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:105
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:38
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:46
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:69
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:29
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:3
-#: lib/lanttern_web/live/shared/menu_component.ex:427
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:17
+#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:30
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:2
+#: lib/lanttern_web/live/shared/menu_component.ex:426
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Students records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:117
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:105
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:187
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Type the name of the student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:55
-#, elixir-autogen, elixir-format
-msgid "all statuses"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:43
-#, elixir-autogen, elixir-format
-msgid "all student record types"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:20
-#, elixir-autogen, elixir-format
-msgid "all students"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:146
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:134
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:202
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:127
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:171
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter students records by status"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:132
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:120
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:216
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:141
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:157
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter students records by type"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:61
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "Time"
 msgstr ""
@@ -2995,8 +2978,8 @@ msgstr ""
 msgid "Edit class"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:36
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:76
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:38
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:78
 #: lib/lanttern_web/live/pages/school/students_component.ex:77
 #: lib/lanttern_web/live/pages/school/students_component.ex:109
 #: lib/lanttern_web/live/pages/school/students_component.ex:318
@@ -3052,7 +3035,6 @@ msgid "Students in this class"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/students_component.ex:35
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:32
 #, elixir-autogen, elixir-format, fuzzy
 msgid "all classes"
 msgstr ""
@@ -3082,7 +3064,7 @@ msgstr ""
 msgid "Add cycle"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:169
+#: lib/lanttern_web/live/shared/menu_component.ex:168
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
@@ -3156,7 +3138,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/guardian/guardian_home_live.ex:127
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:127
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:164
-#: lib/lanttern_web/live/shared/menu_component.ex:540
+#: lib/lanttern_web/live/shared/menu_component.ex:539
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr ""
@@ -3202,7 +3184,7 @@ msgstr ""
 msgid "Edit note"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:233
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:279
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit record"
 msgstr ""
@@ -3274,12 +3256,12 @@ msgstr ""
 msgid "Link students from %{year} to this report card"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:140
+#: lib/lanttern_web/live/shared/menu_component.ex:131
 #, elixir-autogen, elixir-format
 msgid "Loading cycles"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:95
+#: lib/lanttern_web/live/shared/menu_component.ex:86
 #, elixir-autogen, elixir-format
 msgid "Loading profiles"
 msgstr ""
@@ -3331,7 +3313,7 @@ msgstr ""
 msgid "No class selected"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:131
+#: lib/lanttern_web/live/shared/menu_component.ex:122
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No cycle selected"
 msgstr ""
@@ -3346,7 +3328,7 @@ msgstr ""
 msgid "No cycles in this school"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:160
+#: lib/lanttern_web/live/shared/menu_component.ex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No cycles registered"
 msgstr ""
@@ -3540,33 +3522,28 @@ msgstr ""
 msgid "Link strand to report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:125
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:113
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:195
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:150
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter students records by class"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:129
-#, elixir-autogen, elixir-format
-msgid "Details"
-msgstr ""
-
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:27
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:28
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student record detail"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:238
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:284
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student record not found"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:27
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:29
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student records"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:215
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:261
 #, elixir-autogen, elixir-format
 msgid "This record was deleted"
 msgstr ""
@@ -3609,7 +3586,7 @@ msgstr ""
 msgid "Check the student and school relationship"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:59
+#: lib/lanttern_web/live/pages/school/staff_component.ex:64
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Edit cycle profile picture"
@@ -3875,7 +3852,9 @@ msgstr ""
 msgid "Cancel remove"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:161
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:26
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:62
+#: lib/lanttern_web/live/pages/school/staff_component.ex:166
 #, elixir-autogen, elixir-format
 msgid "Edit staff member"
 msgstr ""
@@ -3906,7 +3885,7 @@ msgstr ""
 msgid "Lanttern user email"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:149
+#: lib/lanttern_web/live/pages/school/staff_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "New staff member"
 msgstr ""
@@ -3926,7 +3905,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:434
+#: lib/lanttern_web/live/shared/menu_component.ex:433
 #, elixir-autogen, elixir-format
 msgid "School management"
 msgstr ""
@@ -3936,12 +3915,13 @@ msgstr ""
 msgid "Staff"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:93
+#: lib/lanttern_web/live/pages/school/staff_component.ex:98
 #, elixir-autogen, elixir-format
 msgid "Staff member created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:94
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:93
+#: lib/lanttern_web/live/pages/school/staff_component.ex:99
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staff member updated successfully"
 msgstr ""
@@ -3973,7 +3953,7 @@ msgstr ""
 msgid "No deactivated staff members found"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:95
+#: lib/lanttern_web/live/pages/school/staff_component.ex:100
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staff member deactivated successfully"
 msgstr ""
@@ -3981,4 +3961,96 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/staff_component.ex:18
 #, elixir-autogen, elixir-format
 msgid "View deactivated staff members"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:4
+#, elixir-autogen, elixir-format
+msgid "%{school} staff"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:4
+#, elixir-autogen, elixir-format
+msgid "%{school} students"
+msgstr ""
+
+#: lib/lanttern_web/components/students_records_components.ex:120
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:253
+#, elixir-autogen, elixir-format
+msgid "Assigned to"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:43
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:58
+#, elixir-autogen, elixir-format
+msgid "Assigned to %{staff_member}"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:72
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:80
+#, elixir-autogen, elixir-format
+msgid "Assignee"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:144
+#, elixir-autogen, elixir-format
+msgid "Assignees"
+msgstr ""
+
+#: lib/lanttern_web/components/students_records_components.ex:111
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:249
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Created by"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:160
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:190
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Filter records by assignee"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:137
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:246
+#, elixir-autogen, elixir-format
+msgid "Internal student record tracking"
+msgstr ""
+
+#: lib/lanttern/personalization/profile_settings.ex:113
+#, elixir-autogen, elixir-format
+msgid "Invalid view option"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/menu_component.ex:163
+#, elixir-autogen, elixir-format
+msgid "My area"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:143
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:93
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:102
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Showing 1 result for selected filters"
+msgid_plural "Showing %{count} results for selected filters"
+msgstr[0] ""
+msgstr[1] ""
+
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:102
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Staff member deleted successfully"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:167
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:197
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Type the name of the assignee"
+msgstr ""
+
+#: lib/lanttern_web/components/students_records_components.ex:104
+#, elixir-autogen, elixir-format
+msgid "View more"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:40
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:52
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Created by %{staff_member}"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n>1);\n"
 
 #: lib/lanttern_web/components/core_components.ex:771
-#: lib/lanttern_web/components/core_components.ex:1872
-#: lib/lanttern_web/components/core_components.ex:1934
+#: lib/lanttern_web/components/core_components.ex:1888
+#: lib/lanttern_web/components/core_components.ex:1950
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Ações"
@@ -25,13 +25,13 @@ msgstr "Ações"
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:2
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:441
+#: lib/lanttern_web/live/shared/menu_component.ex:440
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr "Currículo"
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:420
+#: lib/lanttern_web/live/shared/menu_component.ex:419
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr "Dashboard"
@@ -42,11 +42,6 @@ msgstr "Dashboard"
 msgid "Rubrics"
 msgstr "Rubricas"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:3
-#, elixir-autogen, elixir-format
-msgid "School"
-msgstr "Escola"
-
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:20
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:3
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:2
@@ -55,8 +50,8 @@ msgstr "Escola"
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:422
-#: lib/lanttern_web/live/shared/menu_component.ex:466
+#: lib/lanttern_web/live/shared/menu_component.ex:421
+#: lib/lanttern_web/live/shared/menu_component.ex:465
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr "Trilhas"
@@ -68,13 +63,13 @@ msgstr "Trilhas"
 msgid "close"
 msgstr "fechar"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:181
+#: lib/lanttern_web/live/shared/menu_component.ex:180
 #, elixir-autogen, elixir-format
 msgid "Language:"
 msgstr "Idioma:"
 
 #: lib/lanttern_web/controllers/privacy_policy_html/accept_policy.html.heex:25
-#: lib/lanttern_web/live/shared/menu_component.ex:174
+#: lib/lanttern_web/live/shared/menu_component.ex:173
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Sair"
@@ -137,7 +132,7 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:96
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:71
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:40
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:147
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:174
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Cancelar"
@@ -194,7 +189,7 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:105
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:43
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:150
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Salvar"
@@ -225,7 +220,7 @@ msgstr "Suas trilhas favoritas"
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:51
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:62
 #: lib/lanttern_web/live/shared/reporting/strand_report_form_component.ex:55
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:129
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:130
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Descrição"
@@ -248,7 +243,7 @@ msgstr "O arquivo \"%{file}\" é inválido."
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:44
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:45
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:46
 #, elixir-autogen, elixir-format
 msgid "Name"
 msgstr "Nome"
@@ -275,8 +270,8 @@ msgstr "Nenhum ano selecionado"
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:26
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:35
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:40
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:135
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:41
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:162
 #, elixir-autogen, elixir-format
 msgid "Oops, something went wrong! Please check the errors below."
 msgstr "Oops, algo deu errado! Por favor, confira os erros abaixo."
@@ -379,7 +374,8 @@ msgstr "Não conseguimos nos conectar"
 msgid "Something went wrong!"
 msgstr "Algo deu errado!"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:8
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:10
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:10
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:11
 #, elixir-autogen, elixir-format
 msgid "About"
@@ -417,7 +413,7 @@ msgstr "Não foi possível encontrar a trilha"
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:226
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:272
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Deletar"
@@ -484,7 +480,7 @@ msgstr "Adicione suas anotações..."
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:64
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:224
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:270
 #, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr "Você tem certeza?"
@@ -809,7 +805,7 @@ msgstr "Momento atualizado com sucesso"
 msgid "Moments"
 msgstr "Momentos"
 
-#: lib/lanttern_web/components/core_components.ex:1822
+#: lib/lanttern_web/components/core_components.ex:1838
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr "Mover momento para baixo"
@@ -901,8 +897,6 @@ msgstr[0] "1 nota atualizada"
 msgstr[1] "%{count} notas atualizadas"
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:13
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:34
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:6
 #, elixir-autogen, elixir-format
 msgid "Showing 1 result for"
 msgid_plural "Showing %{count} results for"
@@ -1034,7 +1028,7 @@ msgstr "Item curricular removido"
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:25
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:49
 #: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:49
-#: lib/lanttern_web/live/shared/menu_component.ex:130
+#: lib/lanttern_web/live/shared/menu_component.ex:121
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:37
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:39
 #, elixir-autogen, elixir-format
@@ -1222,8 +1216,8 @@ msgstr "Relatório de notas atualizado com sucesso"
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:2
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:20
-#: lib/lanttern_web/live/shared/menu_component.ex:453
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:22
+#: lib/lanttern_web/live/shared/menu_component.ex:452
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr "Relatórios de notas"
@@ -1285,7 +1279,7 @@ msgstr "Card de momento atualizado com sucesso"
 msgid "Move down"
 msgstr "Mover para baixo"
 
-#: lib/lanttern_web/components/core_components.ex:1812
+#: lib/lanttern_web/components/core_components.ex:1828
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1394,7 +1388,7 @@ msgstr "Recalcular nota"
 
 #: lib/lanttern_web/components/attachments_components.ex:135
 #: lib/lanttern_web/components/core_components.ex:207
-#: lib/lanttern_web/components/core_components.ex:1382
+#: lib/lanttern_web/components/core_components.ex:1387
 #: lib/lanttern_web/components/form_components.ex:718
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
@@ -1419,11 +1413,11 @@ msgstr "Id do report card"
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:3
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:22
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:14
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:16
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:115
-#: lib/lanttern_web/live/shared/menu_component.ex:447
-#: lib/lanttern_web/live/shared/menu_component.ex:460
-#: lib/lanttern_web/live/shared/menu_component.ex:473
+#: lib/lanttern_web/live/shared/menu_component.ex:446
+#: lib/lanttern_web/live/shared/menu_component.ex:459
+#: lib/lanttern_web/live/shared/menu_component.ex:472
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr "Report cards"
@@ -1559,11 +1553,10 @@ msgstr "Report card de estudante"
 msgid "Student report card deleted"
 msgstr "Report card de estudante deletado"
 
-#: lib/lanttern_web/components/students_records_components.ex:61
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:11
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:101
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:187
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:102
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:218
 #, elixir-autogen, elixir-format
 msgid "Students"
 msgstr "Estudantes"
@@ -1591,9 +1584,11 @@ msgstr "Formato de cor do texto inválido. Utilize cores hex."
 msgid "The parent cycle grade is calculated based on it's children cycles. E.g. 2024 grade is based on 2024 Q1, Q2, Q3, and Q4 grades."
 msgstr "A nota do ciclo pai é calculada com baseem seus sub ciclos. Ex: a nota de 2024 é baseada nas notas de 2024 1º, 2º, 3º e 4º bi."
 
-#: lib/lanttern_web/components/students_records_components.ex:103
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:122
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:55
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:63
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:42
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:170
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:207
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr "Tipo"
@@ -1633,7 +1628,6 @@ msgid "all years"
 msgstr "todos os anos"
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:23
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:45
 #, elixir-autogen, elixir-format
 msgid "and"
 msgstr "e"
@@ -1808,8 +1802,8 @@ msgstr "Limpar seleção"
 msgid "Hey!"
 msgstr "Olá!"
 
-#: lib/lanttern_web/components/core_components.ex:1440
-#: lib/lanttern_web/components/core_components.ex:1462
+#: lib/lanttern_web/components/core_components.ex:1450
+#: lib/lanttern_web/components/core_components.ex:1472
 #, elixir-autogen, elixir-format
 msgid "Selected"
 msgstr "Selecionado"
@@ -1863,7 +1857,7 @@ msgstr "Confirmar"
 
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:11
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:212
+#: lib/lanttern_web/live/shared/menu_component.ex:211
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
 msgstr "Política de privacidade"
@@ -1905,7 +1899,7 @@ msgstr "Ao utilizar o Lanttern, você confirma ter lido e estar de acordo com no
 msgid "Privacy policy and terms of service"
 msgstr "Política de privacidade e termos de uso"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:220
+#: lib/lanttern_web/live/shared/menu_component.ex:219
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr "Termos de uso"
@@ -2221,11 +2215,13 @@ msgstr "Upload de arquivo"
 msgid "Attachments"
 msgstr "Anexos"
 
-#: lib/lanttern/personalization/profile_settings.ex:96
+#: lib/lanttern/personalization/profile_settings.ex:102
 #, elixir-autogen, elixir-format
 msgid "Invalid assessment view"
 msgstr "Visualização de avaliação inválida"
 
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:71
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:12
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:398
 #, elixir-autogen, elixir-format
 msgid "Student"
@@ -2387,7 +2383,7 @@ msgstr "Avaliação de objetivo"
 msgid "Goals assessment"
 msgstr "Avaliação de objetivos"
 
-#: lib/lanttern/personalization/profile_settings.ex:101
+#: lib/lanttern/personalization/profile_settings.ex:107
 #, elixir-autogen, elixir-format
 msgid "Invalid assessment group by option"
 msgstr "Opção de agrupamento de avaliação inválida"
@@ -2607,12 +2603,13 @@ msgstr "Sem autoavaliação do estudante"
 msgid "No teacher assessment"
 msgstr "Sem avaliação do professor"
 
-#: lib/lanttern_web/components/students_records_components.ex:78
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:8
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:88
 #: lib/lanttern_web/live/pages/school/students_component.ex:63
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:29
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:51
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:119
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:203
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:120
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:234
 #, elixir-autogen, elixir-format
 msgid "Classes"
 msgstr "Turmas"
@@ -2667,108 +2664,94 @@ msgstr "Possui evidências de aprendizagem"
 msgid "All strand evidences"
 msgstr "Todas as evidências da trilha"
 
-#: lib/lanttern/students_records/student_record.ex:91
+#: lib/lanttern/students_records/student_record.ex:112
 #, elixir-autogen, elixir-format
 msgid "At least 1 student is required"
 msgstr "Obrigatório vincular ao menos 1 estudante"
 
-#: lib/lanttern_web/components/students_records_components.ex:49
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:54
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Date"
 msgstr "Data"
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:26
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "Edit student record"
 msgstr "Editar registro de estudante"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:110
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:98
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:180
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Filter records by student"
 msgstr "Filtrar registros por estudante"
 
-#: lib/lanttern/personalization/profile_settings.ex:74
+#: lib/lanttern/personalization/profile_settings.ex:78
 #, elixir-autogen, elixir-format
 msgid "Invalid permissions"
 msgstr "Permissões inválidas"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:100
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:88
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:170
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:122
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Load more records"
 msgstr "Carregar mais registros"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:74
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:63
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:139
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:89
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "New student record"
 msgstr "Novo registro de estudante"
 
-#: lib/lanttern_web/components/students_records_components.ex:46
+#: lib/lanttern_web/components/students_records_components.ex:43
 #, elixir-autogen, elixir-format
 msgid "No students records found for selected filters."
 msgstr "Nenhum registro de estudante encontrado para os filtros selecionados."
 
-#: lib/lanttern_web/components/students_records_components.ex:95
-#, elixir-autogen, elixir-format
-msgid "Record"
-msgstr "Registro"
-
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:68
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Record type"
 msgstr "Tipo de registro"
 
-#: lib/lanttern_web/components/students_records_components.ex:114
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:84
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:176
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:105
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:38
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:46
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:69
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:201
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Status"
 
-#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:29
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:3
-#: lib/lanttern_web/live/shared/menu_component.ex:427
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:17
+#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:30
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:2
+#: lib/lanttern_web/live/shared/menu_component.ex:426
 #, elixir-autogen, elixir-format
 msgid "Students records"
 msgstr "Registros de estudantes"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:117
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:105
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:187
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Type the name of the student"
 msgstr "Digite o nome do estudante"
 
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:55
-#, elixir-autogen, elixir-format
-msgid "all statuses"
-msgstr "todos os status"
-
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:43
-#, elixir-autogen, elixir-format
-msgid "all student record types"
-msgstr "todos os tipos de registro de estudante"
-
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:20
-#, elixir-autogen, elixir-format
-msgid "all students"
-msgstr "todos estudantes"
-
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:146
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:134
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:202
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:127
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:171
 #, elixir-autogen, elixir-format
 msgid "Filter students records by status"
 msgstr "Filtrar registros de estudantes por status"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:132
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:120
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:216
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:141
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Filter students records by type"
 msgstr "Filtrar registros de estudantes por tipo"
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:61
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "Time"
 msgstr "Horário"
@@ -2995,8 +2978,8 @@ msgstr "Criar turma"
 msgid "Edit class"
 msgstr "Editar turma"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:36
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:76
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:38
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:78
 #: lib/lanttern_web/live/pages/school/students_component.ex:77
 #: lib/lanttern_web/live/pages/school/students_component.ex:109
 #: lib/lanttern_web/live/pages/school/students_component.ex:318
@@ -3052,7 +3035,6 @@ msgid "Students in this class"
 msgstr "Estudantes nesta turma"
 
 #: lib/lanttern_web/live/pages/school/students_component.ex:35
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:32
 #, elixir-autogen, elixir-format
 msgid "all classes"
 msgstr "todas as turmas"
@@ -3082,7 +3064,7 @@ msgstr "Já existe um relatório de notas para o mesmo ciclo e ano"
 msgid "Add cycle"
 msgstr "Adicionar ciclo"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:169
+#: lib/lanttern_web/live/shared/menu_component.ex:168
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Admin"
@@ -3156,7 +3138,7 @@ msgstr "Criar trilha"
 #: lib/lanttern_web/live/pages/guardian/guardian_home_live.ex:127
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:127
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:164
-#: lib/lanttern_web/live/shared/menu_component.ex:540
+#: lib/lanttern_web/live/shared/menu_component.ex:539
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr "Ciclo atual alterado"
@@ -3202,7 +3184,7 @@ msgstr "Editar ciclo"
 msgid "Edit note"
 msgstr "Editar nota"
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:233
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:279
 #, elixir-autogen, elixir-format
 msgid "Edit record"
 msgstr "Editar registro"
@@ -3274,12 +3256,12 @@ msgstr "Vincular estudantes de %{year} (%{cycle}) a este report card"
 msgid "Link students from %{year} to this report card"
 msgstr "Vncular estudantes de %{year} a este report card"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:140
+#: lib/lanttern_web/live/shared/menu_component.ex:131
 #, elixir-autogen, elixir-format
 msgid "Loading cycles"
 msgstr "Carregando ciclos"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:95
+#: lib/lanttern_web/live/shared/menu_component.ex:86
 #, elixir-autogen, elixir-format
 msgid "Loading profiles"
 msgstr "Carregando perfis"
@@ -3331,7 +3313,7 @@ msgstr "Nenhum relatório de notas de %{cycle} alinhdo aos filtros atuais foi cr
 msgid "No class selected"
 msgstr "Nenhuma turma selecionada"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:131
+#: lib/lanttern_web/live/shared/menu_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "No cycle selected"
 msgstr "Nenhum ciclo selecionado"
@@ -3346,7 +3328,7 @@ msgstr "Nenhum ciclo encontrado nesta escola."
 msgid "No cycles in this school"
 msgstr "Nenhum ciclo nesta escola"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:160
+#: lib/lanttern_web/live/shared/menu_component.ex:151
 #, elixir-autogen, elixir-format
 msgid "No cycles registered"
 msgstr "Nenhum ciclo registrado"
@@ -3540,33 +3522,28 @@ msgstr "turmas"
 msgid "Link strand to report"
 msgstr "Vincular trilha ao report"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:125
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:113
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:195
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:150
 #, elixir-autogen, elixir-format
 msgid "Filter students records by class"
 msgstr "Filtrar registros de estudantes por turma"
 
-#: lib/lanttern_web/components/students_records_components.ex:129
-#, elixir-autogen, elixir-format
-msgid "Details"
-msgstr "Detalhes"
-
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:27
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:28
 #, elixir-autogen, elixir-format
 msgid "Student record detail"
 msgstr "Detalhe do registro de estudante"
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:238
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:284
 #, elixir-autogen, elixir-format
 msgid "Student record not found"
 msgstr "Registro de estudante não encontrado"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:27
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:29
 #, elixir-autogen, elixir-format
 msgid "Student records"
 msgstr "Registros de estudante"
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:215
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:261
 #, elixir-autogen, elixir-format
 msgid "This record was deleted"
 msgstr "Este registro foi deletado"
@@ -3609,7 +3586,7 @@ msgstr "Confira a relação entre ciclo e escola"
 msgid "Check the student and school relationship"
 msgstr "Confira a relação entre estudante e escola"
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:59
+#: lib/lanttern_web/live/pages/school/staff_component.ex:64
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Edit cycle profile picture"
@@ -3875,7 +3852,9 @@ msgstr "Você tem certeza? Você pode reativar o colaborador mais tarde."
 msgid "Cancel remove"
 msgstr "Cancelar remoção"
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:161
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:26
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:62
+#: lib/lanttern_web/live/pages/school/staff_component.ex:166
 #, elixir-autogen, elixir-format
 msgid "Edit staff member"
 msgstr "Editar colaborador"
@@ -3906,7 +3885,7 @@ msgstr "Colaborador inválido"
 msgid "Lanttern user email"
 msgstr "Email de usuário Lanttern"
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:149
+#: lib/lanttern_web/live/pages/school/staff_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "New staff member"
 msgstr "Novo colaborador"
@@ -3926,7 +3905,7 @@ msgstr "Reativar"
 msgid "Role"
 msgstr "Função"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:434
+#: lib/lanttern_web/live/shared/menu_component.ex:433
 #, elixir-autogen, elixir-format
 msgid "School management"
 msgstr "Gerenciamento da escola"
@@ -3936,12 +3915,13 @@ msgstr "Gerenciamento da escola"
 msgid "Staff"
 msgstr "Equipe"
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:93
+#: lib/lanttern_web/live/pages/school/staff_component.ex:98
 #, elixir-autogen, elixir-format
 msgid "Staff member created successfully"
 msgstr "Colaborador criado com sucesso"
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:94
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:93
+#: lib/lanttern_web/live/pages/school/staff_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Staff member updated successfully"
 msgstr "Colaborador atualizado com sucesso"
@@ -3973,7 +3953,7 @@ msgstr "Colaboradores desativados"
 msgid "No deactivated staff members found"
 msgstr "Nenhum colaborador desativado encontrado"
 
-#: lib/lanttern_web/live/pages/school/staff_component.ex:95
+#: lib/lanttern_web/live/pages/school/staff_component.ex:100
 #, elixir-autogen, elixir-format
 msgid "Staff member deactivated successfully"
 msgstr "Colaborador desativado com sucesso"
@@ -3982,3 +3962,95 @@ msgstr "Colaborador desativado com sucesso"
 #, elixir-autogen, elixir-format
 msgid "View deactivated staff members"
 msgstr "Ver colaboradores desativados"
+
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:4
+#, elixir-autogen, elixir-format
+msgid "%{school} staff"
+msgstr "Colaboradores de %{school}"
+
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:4
+#, elixir-autogen, elixir-format
+msgid "%{school} students"
+msgstr "Estudantes de %{school}"
+
+#: lib/lanttern_web/components/students_records_components.ex:120
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:253
+#, elixir-autogen, elixir-format
+msgid "Assigned to"
+msgstr "Atribuído a"
+
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:43
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:58
+#, elixir-autogen, elixir-format
+msgid "Assigned to %{staff_member}"
+msgstr "Atribuído a %{staff_member}"
+
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:72
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:80
+#, elixir-autogen, elixir-format
+msgid "Assignee"
+msgstr "Responsável"
+
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:144
+#, elixir-autogen, elixir-format
+msgid "Assignees"
+msgstr "Responsáveis"
+
+#: lib/lanttern_web/components/students_records_components.ex:111
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:249
+#, elixir-autogen, elixir-format
+msgid "Created by"
+msgstr "Criado por"
+
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:160
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:190
+#, elixir-autogen, elixir-format
+msgid "Filter records by assignee"
+msgstr "Filtrar registros por responsável"
+
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:137
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:246
+#, elixir-autogen, elixir-format
+msgid "Internal student record tracking"
+msgstr "Acompanhamento interno de registro de estudante"
+
+#: lib/lanttern/personalization/profile_settings.ex:113
+#, elixir-autogen, elixir-format
+msgid "Invalid view option"
+msgstr "Opção de visualização inválida"
+
+#: lib/lanttern_web/live/shared/menu_component.ex:163
+#, elixir-autogen, elixir-format
+msgid "My area"
+msgstr "Minha área"
+
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:143
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:93
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:102
+#, elixir-autogen, elixir-format
+msgid "Showing 1 result for selected filters"
+msgid_plural "Showing %{count} results for selected filters"
+msgstr[0] "Mostrando 1 resultado para os filtros selecionados"
+msgstr[1] "Mostrando %{count} resultados para os filtros selecionados"
+
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:102
+#, elixir-autogen, elixir-format
+msgid "Staff member deleted successfully"
+msgstr "Colaborador deletado com sucesso"
+
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:167
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:197
+#, elixir-autogen, elixir-format
+msgid "Type the name of the assignee"
+msgstr "Digite o nome do responsável"
+
+#: lib/lanttern_web/components/students_records_components.ex:104
+#, elixir-autogen, elixir-format
+msgid "View more"
+msgstr "Ver mais"
+
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:40
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:52
+#, elixir-autogen, elixir-format
+msgid "Created by %{staff_member}"
+msgstr "Criado por %{staff_member}"

--- a/priv/repo/migrations/20250127104225_add_created_by_staff_member_id_to_students_records.exs
+++ b/priv/repo/migrations/20250127104225_add_created_by_staff_member_id_to_students_records.exs
@@ -1,0 +1,48 @@
+defmodule Lanttern.Repo.Migrations.AddCreatedByStaffMemberIdToStudentsRecords do
+  use Ecto.Migration
+
+  @prefix "log"
+
+  def change do
+    # creating unique constraints to allow composite foreign keys.
+    # this guarantees, in the database level, that staff member
+    # and student record belong to the same school
+
+    # removing existing "staff_school_id_index" to prevent unnecessary index
+    drop index(:staff, [:school_id])
+    create unique_index(:staff, [:school_id, :id])
+
+    alter table(:students_records) do
+      add :created_by_staff_member_id,
+          references(:staff, with: [school_id: :school_id], on_delete: :nothing)
+    end
+
+    alter table(:students_records, prefix: @prefix) do
+      add :created_by_staff_member_id, :bigint
+    end
+
+    # update all existing records with a staff member id
+    # based on the students records logs:
+
+    execute """
+            update students_records sr
+            set created_by_staff_member_id = subquery.staff_member_id
+            from (
+              select
+                sr_log.student_record_id,
+                s.id staff_member_id
+              from log.students_records sr_log
+              join profiles p on p.id = sr_log.profile_id
+              join staff s on s.id = p.staff_member_id
+              where sr_log.operation = 'CREATE'
+            ) as subquery
+            where subquery.student_record_id = sr.id
+            """,
+            ""
+
+    # then make the column not null
+
+    execute "ALTER TABLE students_records ALTER COLUMN created_by_staff_member_id SET NOT NULL",
+            ""
+  end
+end

--- a/priv/repo/migrations/20250127122632_create_students_records_assignees.exs
+++ b/priv/repo/migrations/20250127122632_create_students_records_assignees.exs
@@ -1,0 +1,29 @@
+defmodule Lanttern.Repo.Migrations.CreateStudentsRecordsAssignees do
+  use Ecto.Migration
+
+  @prefix "log"
+
+  def change do
+    # use composite foreign keys to guarantee,
+    # in the database level, that record and assignee
+    # belong to the same school
+
+    create table(:students_records_assignees, primary_key: false) do
+      # in the future we will handle how to cascade staff and school deletion to ss records
+      add :staff_member_id,
+          references(:staff, with: [school_id: :school_id], on_delete: :nothing),
+          primary_key: true
+
+      add :student_record_id,
+          references(:students_records, with: [school_id: :school_id], on_delete: :delete_all),
+          primary_key: true
+
+      add :school_id, references(:schools, on_delete: :nothing), null: false
+    end
+
+    # also add assignees field to student records log
+    alter table(:students_records, prefix: @prefix) do
+      add :assignees_ids, {:array, :bigint}
+    end
+  end
+end

--- a/priv/repo/migrations/20250127172238_add_name_gin_index_to_staff.exs
+++ b/priv/repo/migrations/20250127172238_add_name_gin_index_to_staff.exs
@@ -1,0 +1,14 @@
+defmodule Lanttern.Repo.Migrations.AddNameGinIndexToStaff do
+  use Ecto.Migration
+
+  def change do
+    execute "CREATE EXTENSION IF NOT EXISTS pg_trgm", ""
+
+    execute """
+              CREATE INDEX staff_name_gin_trgm_idx
+                ON staff
+                USING gin (name gin_trgm_ops);
+            """,
+            "DROP INDEX staff_name_gin_trgm_idx"
+  end
+end

--- a/test/lanttern/schools_test.exs
+++ b/test/lanttern/schools_test.exs
@@ -985,6 +985,29 @@ defmodule Lanttern.SchoolsTest do
       assert [deactivated_staff_member] == Schools.list_staff_members(only_deactivated: true)
     end
 
+    test "search_staff_members/2 returns all items matched by search" do
+      _staff_member_1 = staff_member_fixture(%{name: "lorem ipsum xolor sit amet"})
+      staff_member_2 = staff_member_fixture(%{name: "lorem ipsum dolor sit amet"})
+      staff_member_3 = staff_member_fixture(%{name: "lorem ipsum dolorxxx sit amet"})
+      _staff_member_4 = staff_member_fixture(%{name: "lorem ipsum xxxxx sit amet"})
+
+      assert [staff_member_2, staff_member_3] == Schools.search_staff_members("dolor")
+    end
+
+    test "search_staff_members/2 with school opt returns only staff_members from given school" do
+      school = school_fixture()
+
+      _staff_member_1 = staff_member_fixture(%{name: "lorem ipsum xolor sit amet"})
+
+      staff_member_2 =
+        staff_member_fixture(%{name: "lorem ipsum dolor sit amet", school_id: school.id})
+
+      _staff_member_3 = staff_member_fixture(%{name: "lorem ipsum dolorxxx sit amet"})
+      _staff_member_4 = staff_member_fixture(%{name: "lorem ipsum xxxxx sit amet"})
+
+      assert [staff_member_2] == Schools.search_staff_members("dolor", school_id: school.id)
+    end
+
     test "get_staff_member!/1 returns the staff member with given id" do
       staff_member = staff_member_fixture()
       assert Schools.get_staff_member!(staff_member.id) == staff_member

--- a/test/lanttern/schools_test.exs
+++ b/test/lanttern/schools_test.exs
@@ -927,15 +927,20 @@ defmodule Lanttern.SchoolsTest do
       assert Schools.list_staff_members() == [staff_member]
     end
 
-    test "list_staff_members/1 with school opts returns staff members filtered by school" do
+    test "list_staff_members/1 with school and staff_members_ids opts returns staff members filtered correctly" do
       school = school_fixture()
       staff_member_1 = staff_member_fixture(%{school_id: school.id, name: "AAA"})
       staff_member_2 = staff_member_fixture(%{school_id: school.id, name: "BBB"})
 
       # extra staff_member for filtering validation
       staff_member_fixture()
+      staff_member_fixture(%{school_id: school.id})
 
-      assert [staff_member_1, staff_member_2] == Schools.list_staff_members(school_id: school.id)
+      assert [staff_member_1, staff_member_2] ==
+               Schools.list_staff_members(
+                 school_id: school.id,
+                 staff_members_ids: [staff_member_1.id, staff_member_2.id]
+               )
     end
 
     test "list_staff_members/1 with opts returns all students as expected" do

--- a/test/lanttern/students_records_test.exs
+++ b/test/lanttern/students_records_test.exs
@@ -112,6 +112,34 @@ defmodule Lanttern.StudentsRecordsTest do
       assert expected_student_record.id == student_record.id
     end
 
+    test "list_students_records/1 with owner and assignees opts students_records filtered by given owner and assignees" do
+      school = SchoolsFixtures.school_fixture()
+      owner = SchoolsFixtures.staff_member_fixture(%{school_id: school.id})
+      assignee = SchoolsFixtures.staff_member_fixture(%{school_id: school.id})
+
+      student_record =
+        student_record_fixture(%{
+          school_id: school.id,
+          created_by_staff_member_id: owner.id,
+          assignees_ids: [assignee.id]
+        })
+
+      # extra fixture to test filtering
+      student_record_fixture()
+      student_record_fixture(%{school_id: school.id, created_by_staff_member_id: assignee.id})
+      student_record_fixture(%{school_id: school.id, assignees_ids: [owner.id]})
+      student_record_fixture(%{school_id: school.id})
+
+      [expected_student_record] =
+        StudentsRecords.list_students_records(
+          school_id: school.id,
+          owner_id: owner.id,
+          assignees_ids: [assignee.id]
+        )
+
+      assert expected_student_record.id == student_record.id
+    end
+
     test "list_students_records_page/1 returns all students_records in a Page struct" do
       student_record_1 = student_record_fixture(%{date: ~D[2024-01-01], time: nil})
       student_record_2_1 = student_record_fixture(%{date: ~D[2024-02-01], time: ~T[09:00:00]})

--- a/test/lanttern/students_records_test.exs
+++ b/test/lanttern/students_records_test.exs
@@ -173,6 +173,7 @@ defmodule Lanttern.StudentsRecordsTest do
       school = SchoolsFixtures.school_fixture()
       type = student_record_type_fixture(%{school_id: school.id})
       status = student_record_status_fixture(%{school_id: school.id})
+      staff_member = SchoolsFixtures.staff_member_fixture(%{school_id: school.id})
       student = SchoolsFixtures.student_fixture(%{school_id: school.id})
       class = SchoolsFixtures.class_fixture(%{school_id: school.id})
 
@@ -187,6 +188,7 @@ defmodule Lanttern.StudentsRecordsTest do
         date: ~D[2024-09-15],
         time: ~T[14:00:00],
         description: "some description",
+        created_by_staff_member_id: staff_member.id,
         students_ids: [student.id],
         classes_ids: [class.id]
       }
@@ -202,7 +204,10 @@ defmodule Lanttern.StudentsRecordsTest do
       assert student_record.time == ~T[14:00:00]
       assert student_record.description == "some description"
 
-      student_record = student_record |> Repo.preload([:students, :classes])
+      student_record =
+        student_record |> Repo.preload([:created_by_staff_member, :students, :classes])
+
+      assert student_record.created_by_staff_member == staff_member
       assert student_record.students == [student]
       assert student_record.classes == [class]
 

--- a/test/lanttern_web/live/admin/student_record_live_test.exs
+++ b/test/lanttern_web/live/admin/student_record_live_test.exs
@@ -33,6 +33,7 @@ defmodule LantternWeb.Admin.StudentRecordLiveTest do
 
     test "saves new student_record", %{conn: conn} do
       school = SchoolsFixtures.school_fixture()
+      staff_member = SchoolsFixtures.staff_member_fixture(%{school_id: school.id})
       student = SchoolsFixtures.student_fixture(%{school_id: school.id})
       status = student_record_status_fixture(%{school_id: school.id})
       type = student_record_type_fixture(%{school_id: school.id})
@@ -50,6 +51,7 @@ defmodule LantternWeb.Admin.StudentRecordLiveTest do
 
       create_attrs = %{
         school_id: school.id,
+        created_by_staff_member_id: staff_member.id,
         students_ids: [student.id],
         status_id: status.id,
         type_id: type.id,

--- a/test/lanttern_web/live/pages/school/staff/id/staff_member_live_test.exs
+++ b/test/lanttern_web/live/pages/school/staff/id/staff_member_live_test.exs
@@ -1,0 +1,65 @@
+defmodule LantternWeb.StaffMemberLiveTest do
+  use LantternWeb.ConnCase
+
+  alias Lanttern.SchoolsFixtures
+
+  @live_view_base_path "/school/staff"
+
+  setup [:register_and_log_in_staff_member]
+
+  describe "Staff member live view basic navigation" do
+    test "disconnected and connected mount", %{conn: conn, user: user} do
+      school_id = user.current_profile.school_id
+
+      staff_member =
+        SchoolsFixtures.staff_member_fixture(%{
+          school_id: school_id,
+          name: "some staff member abc xyz"
+        })
+
+      conn = get(conn, "#{@live_view_base_path}/#{staff_member.id}")
+
+      assert html_response(conn, 200) =~ ~r/<h1 .+>\s*some staff member abc xyz\s*<\/h1>/
+
+      {:ok, _view, _html} = live(conn)
+    end
+  end
+
+  describe "Staff member management permissions" do
+    test "allow user with school management permissions to edit staff member", context do
+      %{conn: conn, user: user} = add_school_management_permissions(context)
+      school_id = user.current_profile.school_id
+
+      staff_member =
+        SchoolsFixtures.staff_member_fixture(%{school_id: school_id, name: "staff member abc"})
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{staff_member.id}?edit=true")
+
+      assert view |> has_element?("#staff-member-form-overlay h2", "Edit staff member")
+    end
+
+    test "allow user without school management permissions to edit their own staff member", %{
+      conn: conn,
+      user: user
+    } do
+      {:ok, view, _html} =
+        live(conn, "#{@live_view_base_path}/#{user.current_profile.staff_member.id}?edit=true")
+
+      assert view |> has_element?("#staff-member-form-overlay h2", "Edit staff member")
+    end
+
+    test "prevent user without school management permissions to edit staff member", %{
+      conn: conn,
+      user: user
+    } do
+      school_id = user.current_profile.school_id
+
+      staff_member =
+        SchoolsFixtures.staff_member_fixture(%{school_id: school_id, name: "staff member abc"})
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{staff_member.id}?edit=true")
+
+      refute view |> has_element?("#staff-member-form-overlay h2", "Edit staff member")
+    end
+  end
+end

--- a/test/lanttern_web/live/pages/school/student/id/student_live_test.exs
+++ b/test/lanttern_web/live/pages/school/student/id/student_live_test.exs
@@ -57,7 +57,7 @@ defmodule LantternWeb.StudentLiveTest do
       assert view |> has_element?("#student-form-overlay h2", "Edit student")
     end
 
-    test "prevent user without school management permissions to edit class", %{
+    test "prevent user without school management permissions to edit staff member", %{
       conn: conn,
       user: user
     } do

--- a/test/lanttern_web/live/pages/students_records/students_records_live_test.exs
+++ b/test/lanttern_web/live/pages/students_records/students_records_live_test.exs
@@ -45,7 +45,7 @@ defmodule LantternWeb.StudentsRecordsLiveTest do
       {:ok, view, _html} = live(conn, @live_view_base_path)
 
       assert view |> has_element?("span", student.name)
-      assert view |> has_element?("p", student_record.name)
+      assert view |> has_element?("a", student_record.name)
       assert view |> has_element?("p", student_record.description)
       assert view |> has_element?("span", type.name)
       assert view |> has_element?("span", status.name)

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -72,11 +72,12 @@ defmodule LantternWeb.ConnCase do
       |> Lanttern.Repo.preload(current_profile: [staff_member: :school])
       |> Map.update!(:current_profile, fn profile ->
         %Lanttern.Identity.Profile{
-          id: profile.id,
-          name: profile.staff_member.name,
-          type: "staff",
-          school_id: profile.staff_member.school.id,
-          school_name: profile.staff_member.school.name
+          profile
+          | name: profile.staff_member.name,
+            school_id: profile.staff_member.school.id,
+            school_name: profile.staff_member.school.name,
+            role: profile.staff_member.role,
+            profile_picture_url: profile.staff_member.profile_picture_url
         }
       end)
       # profile should always have a current school cycle
@@ -112,11 +113,10 @@ defmodule LantternWeb.ConnCase do
       |> Lanttern.Repo.preload(current_profile: [student: :school])
       |> Map.update!(:current_profile, fn profile ->
         %Lanttern.Identity.Profile{
-          id: profile.id,
-          name: profile.student.name,
-          type: "student",
-          school_id: profile.student.school.id,
-          school_name: profile.student.school.name
+          profile
+          | name: profile.student.name,
+            school_id: profile.student.school.id,
+            school_name: profile.student.school.name
         }
       end)
       # profile should always have a current school cycle
@@ -152,11 +152,10 @@ defmodule LantternWeb.ConnCase do
       |> Lanttern.Repo.preload(current_profile: [guardian_of_student: :school])
       |> Map.update!(:current_profile, fn profile ->
         %Lanttern.Identity.Profile{
-          id: profile.id,
-          name: profile.guardian_of_student.name,
-          type: "guardian",
-          school_id: profile.guardian_of_student.school.id,
-          school_name: profile.guardian_of_student.school.name
+          profile
+          | name: profile.guardian_of_student.name,
+            school_id: profile.guardian_of_student.school.id,
+            school_name: profile.guardian_of_student.school.name
         }
       end)
       # profile should always have a current school cycle

--- a/test/support/fixtures/students_records_fixtures.ex
+++ b/test/support/fixtures/students_records_fixtures.ex
@@ -13,6 +13,7 @@ defmodule Lanttern.StudentsRecordsFixtures do
     {:ok, student_record} =
       attrs
       |> maybe_inject_school_id()
+      |> maybe_inject_created_by_staff_member_id()
       |> maybe_inject_students_ids()
       |> maybe_inject_type_id()
       |> maybe_inject_status_id()
@@ -77,6 +78,17 @@ defmodule Lanttern.StudentsRecordsFixtures do
   defp maybe_inject_school_id(attrs) do
     attrs
     |> Map.put(:school_id, SchoolsFixtures.school_fixture().id)
+  end
+
+  defp maybe_inject_created_by_staff_member_id(%{created_by_staff_member_id: _} = attrs),
+    do: attrs
+
+  defp maybe_inject_created_by_staff_member_id(%{school_id: school_id} = attrs) do
+    attrs
+    |> Map.put(
+      :created_by_staff_member_id,
+      SchoolsFixtures.staff_member_fixture(%{school_id: school_id}).id
+    )
   end
 
   defp maybe_inject_students_ids(%{students_ids: _} = attrs), do: attrs


### PR DESCRIPTION
in this PR we added support to link staff members to students records.

on student record creation, the `created_by_staff_member` info will be registered, and uses with authorization to manage students records can add and remove assignees from the record.

we also redesigned the students records list UI, preparing it for future updates:

<img width="1423" alt="image" src="https://github.com/user-attachments/assets/256f56e4-b12b-4393-88a6-aba0af8b0df6" />

and added a new staff member view, where we can view the students records created by or assigned to the user.

resolves #229 

---

# generated by Copilot

This pull request introduces several new features and improvements across multiple modules to enhance the personalization and management of student records and staff members. The changes primarily focus on adding new fields and functionalities to various schemas and modules.

### Enhancements to Student Records and Staff Management:

* `lib/lanttern/personalization/profile_settings.ex`:
  * Added new fields `student_record_assignees_ids` and `student_record_staff_member_view` to the `ProfileSettings` schema and corresponding Ecto fields. [[1]](diffhunk://#diff-8539b27a855c43a2b36032badac0e87e4c0b1393f8f9812bbfd4616cdbde3cfbR37-R38) [[2]](diffhunk://#diff-8539b27a855c43a2b36032badac0e87e4c0b1393f8f9812bbfd4616cdbde3cfbR58-R59) [[3]](diffhunk://#diff-8539b27a855c43a2b36032badac0e87e4c0b1393f8f9812bbfd4616cdbde3cfbR94-R95)
  * Added validation for `student_record_staff_member_view` to ensure it contains valid options.

* `lib/lanttern/schools.ex`:
  * Introduced `staff_members_ids` and `base_query` options for filtering staff members and extended the `list_staff_members` function to support these options. [[1]](diffhunk://#diff-483fc42c5c948251bf7abd422364a6ebc626f74c40ea6ed2eed1855bba6a3322R955-R960) [[2]](diffhunk://#diff-483fc42c5c948251bf7abd422364a6ebc626f74c40ea6ed2eed1855bba6a3322R969-R972) [[3]](diffhunk://#diff-483fc42c5c948251bf7abd422364a6ebc626f74c40ea6ed2eed1855bba6a3322R990-R998)
  * Added `search_staff_members` function to search staff members by name with support for additional options.

* `lib/lanttern/students_records.ex`:
  * Added new fields `owner_id` and `assignees_ids` to filter student records and updated the `apply_list_students_records_opts` function to handle these new filters. (F541d475L11R11, [[1]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R42-R43) [[2]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R107-R125)

* `lib/lanttern/students_records/student_record.ex`:
  * Added new fields `created_by_staff_member` and `assignees_ids` to the `StudentRecord` schema, including associations and validations. [[1]](diffhunk://#diff-766e5076246c3a8bd7e24566c6f210165404293cf996f974522a63fe2b929d5dR11-R18) [[2]](diffhunk://#diff-766e5076246c3a8bd7e24566c6f210165404293cf996f974522a63fe2b929d5dR29-R30) [[3]](diffhunk://#diff-766e5076246c3a8bd7e24566c6f210165404293cf996f974522a63fe2b929d5dR50-R70) [[4]](diffhunk://#diff-766e5076246c3a8bd7e24566c6f210165404293cf996f974522a63fe2b929d5dR84-R100) [[5]](diffhunk://#diff-766e5076246c3a8bd7e24566c6f210165404293cf996f974522a63fe2b929d5dR148-R164)

* `lib/lanttern/students_records/student_record_assignee.ex`:
  * Created a new `Assignee` schema to manage the relationship between student records and staff members.

### UI Improvements:

* `lib/lanttern_web/components/core_components.ex`:
  * Updated the `person_badge` component to support new themes and added a `profile_picture` component with customizable themes and sizes. (Fd64144eL21R21, [[1]](diffhunk://#diff-aa46793bbfa3dea60fb58422045e2f809eea50915535871845a3aeb7b3765e71L1357-R1368) [[2]](diffhunk://#diff-aa46793bbfa3dea60fb58422045e2f809eea50915535871845a3aeb7b3765e71R1399-R1405) [[3]](diffhunk://#diff-aa46793bbfa3dea60fb58422045e2f809eea50915535871845a3aeb7b3765e71R1566-R1574) [[4]](diffhunk://#diff-aa46793bbfa3dea60fb58422045e2f809eea50915535871845a3aeb7b3765e71L1578-R1591) [[5]](diffhunk://#diff-aa46793bbfa3dea60fb58422045e2f809eea50915535871845a3aeb7b3765e71R1628-R1630)