### PR TITLE
basic student record access control

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -40,7 +40,7 @@ module.exports = {
             lighter: colors.yellow["200"],
             lightest: colors.yellow["50"],
           },
-          teacher: {
+          staff: {
             dark: colors.lime["800"],
             accent: colors.lime["500"],
             lighter: colors.lime["200"],

--- a/lib/lanttern/personalization.ex
+++ b/lib/lanttern/personalization.ex
@@ -4,7 +4,7 @@ defmodule Lanttern.Personalization do
 
   ### Permissions info
 
-  - `wcd` - control access to student records
+  - `students_records_full_access` - full students records management access
   - `school_management` - control access to classes, students, and staff management
   - `content_management` - control content related configurations
   """
@@ -15,7 +15,7 @@ defmodule Lanttern.Personalization do
 
   alias Lanttern.Personalization.ProfileSettings
 
-  @valid_permissions ["wcd", "school_management", "content_management"]
+  @valid_permissions ["students_records_full_access", "school_management", "content_management"]
 
   @doc """
   Get profile settings.

--- a/lib/lanttern/students_records.ex
+++ b/lib/lanttern/students_records.ex
@@ -233,7 +233,7 @@ defmodule Lanttern.StudentsRecords do
   defp apply_check_profile_read_permissions(
          queryable,
          %Profile{staff_member: %StaffMember{id: staff_member_id, school_id: school_id}},
-         _has_full_acceess = false
+         false
        ) do
     from(
       sr in queryable,

--- a/lib/lanttern/students_records/student_record.ex
+++ b/lib/lanttern/students_records/student_record.ex
@@ -24,6 +24,7 @@ defmodule Lanttern.StudentsRecords.StudentRecord do
           description: String.t(),
           date: Date.t(),
           time: Time.t(),
+          shared_with_school: boolean(),
           students: [Student.t()],
           students_ids: [pos_integer()],
           created_by_staff_member: StaffMember.t(),
@@ -45,6 +46,7 @@ defmodule Lanttern.StudentsRecords.StudentRecord do
     field :description, :string
     field :date, :date
     field :time, :time
+    field :shared_with_school, :boolean, default: false
     field :students_ids, {:array, :id}, virtual: true
     field :classes_ids, {:array, :id}, virtual: true
     field :assignees_ids, {:array, :id}, virtual: true
@@ -79,6 +81,7 @@ defmodule Lanttern.StudentsRecords.StudentRecord do
       :description,
       :date,
       :time,
+      :shared_with_school,
       :students_ids,
       :classes_ids,
       :assignees_ids,

--- a/lib/lanttern/students_records/student_record.ex
+++ b/lib/lanttern/students_records/student_record.ex
@@ -8,7 +8,7 @@ defmodule Lanttern.StudentsRecords.StudentRecord do
 
   use Gettext, backend: Lanttern.Gettext
 
-  alias Lanttern.StudentsRecords.Assignee
+  alias Lanttern.StudentsRecords.AssigneeRelationship
   alias Lanttern.StudentsRecords.StudentRecordClassRelationship
   alias Lanttern.StudentsRecords.StudentRecordRelationship
   alias Lanttern.StudentsRecords.StudentRecordStatus
@@ -58,7 +58,7 @@ defmodule Lanttern.StudentsRecords.StudentRecord do
 
     has_many :students_relationships, StudentRecordRelationship, on_replace: :delete
     has_many :classes_relationships, StudentRecordClassRelationship, on_replace: :delete
-    has_many :assignees_relationships, Assignee, on_replace: :delete
+    has_many :assignees_relationships, AssigneeRelationship, on_replace: :delete
 
     many_to_many :students, Student,
       join_through: "students_students_records",

--- a/lib/lanttern/students_records/student_record_assignee.ex
+++ b/lib/lanttern/students_records/student_record_assignee.ex
@@ -1,6 +1,6 @@
-defmodule Lanttern.StudentsRecords.Assignee do
+defmodule Lanttern.StudentsRecords.AssigneeRelationship do
   @moduledoc """
-  The `StudentsRecords.Assignee` schema (join table)
+  The `StudentsRecords.AssigneeRelationship` schema (join table)
   """
 
   use Ecto.Schema

--- a/lib/lanttern_web/components/assessments_components.ex
+++ b/lib/lanttern_web/components/assessments_components.ex
@@ -133,7 +133,7 @@ defmodule LantternWeb.AssessmentsComponents do
     <div class={["grid gap-1 w-full", @grid_cols_class, @class]} id={@id}>
       <.assessment_point_entry_value_display entry={@entry} />
       <.assessment_point_entry_value_display :if={@show_student_assessment} entry={@entry} is_student />
-      <div :if={@show_student_assessment} class="text-xs text-center text-ltrn-teacher-dark">
+      <div :if={@show_student_assessment} class="text-xs text-center text-ltrn-staff-dark">
         <%= gettext("Teacher assessment") %>
       </div>
       <div :if={@show_student_assessment} class="text-xs text-center text-ltrn-student-dark">
@@ -252,7 +252,7 @@ defmodule LantternWeb.AssessmentsComponents do
   def assessment_view_dropdow(assigns) do
     {theme, text} =
       case assigns.current_assessment_view do
-        "teacher" -> {"teacher", gettext("Assessed by teacher")}
+        "teacher" -> {"staff", gettext("Assessed by teacher")}
         "student" -> {"student", gettext("Assessed by students")}
         "compare" -> {"primary", gettext("Compare teacher/students")}
       end

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -1782,7 +1782,8 @@ defmodule LantternWeb.CoreComponents do
   @toggle_themes %{
     "default" => "focus:ring-ltrn-primary",
     "diff" => "focus:ring-ltrn-diff-accent",
-    "student" => "focus:ring-ltrn-student-accent"
+    "student" => "focus:ring-ltrn-student-accent",
+    "staff" => "focus:ring-ltrn-staff-accent"
   }
 
   defp toggle_theme(theme),
@@ -1791,7 +1792,8 @@ defmodule LantternWeb.CoreComponents do
   @toggle_enabled_themes %{
     "default" => "bg-ltrn-primary",
     "diff" => "bg-ltrn-diff-accent",
-    "student" => "bg-ltrn-student-accent"
+    "student" => "bg-ltrn-student-accent",
+    "staff" => "bg-ltrn-staff-accent"
   }
 
   defp toggle_enabled_theme(theme),

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -73,7 +73,7 @@ defmodule LantternWeb.CoreComponents do
     "subtle" => "text-ltrn-subtle hover:text-ltrn-dark",
     "primary" => "text-ltrn-dark hover:text-ltrn-subtle",
     "student" => "text-ltrn-student-dark hover:text-ltrn-student-dark/80",
-    "teacher" => "text-ltrn-teacher-dark hover:text-ltrn-teacher-dark/80",
+    "staff" => "text-ltrn-staff-dark hover:text-ltrn-staff-dark/80",
     "alert" => "text-ltrn-subtle hover:text-ltrn-alert-accent"
   }
 
@@ -82,7 +82,7 @@ defmodule LantternWeb.CoreComponents do
     "subtle" => nil,
     "primary" => "bg-ltrn-mesh-primary",
     "student" => "bg-ltrn-student-lightest",
-    "teacher" => "bg-ltrn-teacher-lightest",
+    "staff" => "bg-ltrn-staff-lightest",
     "alert" => "bg-ltrn-alert-lighter"
   }
 
@@ -224,7 +224,7 @@ defmodule LantternWeb.CoreComponents do
     "dark" => "bg-ltrn-dark text-ltrn-lighter",
     "diff" => "bg-ltrn-diff-lighter text-ltrn-diff-dark",
     "student" => "bg-ltrn-student-lighter text-ltrn-student-dark",
-    "teacher" => "bg-ltrn-teacher-lighter text-ltrn-teacher-dark",
+    "staff" => "bg-ltrn-staff-lighter text-ltrn-staff-dark",
     "empty" => "bg-transparent border border-dashed border-ltrn-light text-ltrn-subtle"
   }
 
@@ -236,7 +236,7 @@ defmodule LantternWeb.CoreComponents do
     "dark" => "hover:bg-ltrn-dark/50",
     "diff" => "hover:bg-ltrn-diff-lightest",
     "student" => "hover:bg-ltrn-student-lightest",
-    "teacher" => "hover:bg-ltrn-teacher-lightest"
+    "staff" => "hover:bg-ltrn-staff-lightest"
   }
 
   defp badge_theme(theme, with_hover \\ false) do
@@ -251,7 +251,7 @@ defmodule LantternWeb.CoreComponents do
     "dark" => "text-ltrn-lighter",
     "diff" => "text-ltrn-diff-dark",
     "student" => "text-ltrn-student-dark",
-    "teacher" => "text-ltrn-teacher-dark"
+    "staff" => "text-ltrn-staff-dark"
   }
 
   defp badge_icon_theme(theme),
@@ -521,8 +521,8 @@ defmodule LantternWeb.CoreComponents do
       "bg-ltrn-diff-lightest hover:bg-ltrn-diff-lighter text-ltrn-diff-dark",
       "disabled:opacity-40"
     ],
-    "teacher" => [
-      "bg-ltrn-teacher-lighter text-ltrn-teacher-dark hover:opacity-80",
+    "staff" => [
+      "bg-ltrn-staff-lighter text-ltrn-staff-dark hover:opacity-80",
       "disabled:opacity-40"
     ],
     "student" => [
@@ -1313,7 +1313,7 @@ defmodule LantternWeb.CoreComponents do
   end
 
   @doc """
-  Renders a student or teacher badge.
+  Renders a student or staff member badge.
 
   ## Examples
 
@@ -1396,11 +1396,11 @@ defmodule LantternWeb.CoreComponents do
   end
 
   defp person_badge_theme_style("cyan"), do: "text-ltrn-dark bg-ltrn-mesh-cyan"
-  defp person_badge_theme_style("staff"), do: "text-ltrn-teacher-dark bg-ltrn-teacher-lighter"
+  defp person_badge_theme_style("staff"), do: "text-ltrn-staff-dark bg-ltrn-staff-lighter"
   defp person_badge_theme_style(_subtle), do: "text-ltrn-subtle bg-ltrn-lighter"
 
   defp person_badge_link_theme_style("cyan"), do: "hover:text-ltrn-subtle"
-  defp person_badge_link_theme_style("staff"), do: "hover:text-ltrn-teacher-accent"
+  defp person_badge_link_theme_style("staff"), do: "hover:text-ltrn-staff-accent"
   defp person_badge_link_theme_style(_subtle), do: "hover:text-ltrn-subtle"
 
   @doc """

--- a/lib/lanttern_web/components/grades_reports_components.ex
+++ b/lib/lanttern_web/components/grades_reports_components.ex
@@ -910,7 +910,7 @@ defmodule LantternWeb.GradesReportsComponents do
         <.icon
           :if={@entry.comment}
           name="hero-chat-bubble-oval-left-mini"
-          class="text-ltrn-teacher-accent"
+          class="text-ltrn-staff-accent"
         />
         <.icon_button
           :if={@on_calculate_cell}
@@ -955,7 +955,7 @@ defmodule LantternWeb.GradesReportsComponents do
          _
        )
        when score != composition_score,
-       do: "p-1 border border-ltrn-teacher-accent bg-ltrn-teacher-lightest"
+       do: "p-1 border border-ltrn-staff-accent bg-ltrn-staff-lightest"
 
   defp get_students_grades_grid_cell_wrapper_class(
          %{
@@ -965,7 +965,7 @@ defmodule LantternWeb.GradesReportsComponents do
          _
        )
        when ordinal_value_id != composition_ordinal_value_id,
-       do: "p-1 border border-ltrn-teacher-accent bg-ltrn-teacher-lightest"
+       do: "p-1 border border-ltrn-staff-accent bg-ltrn-staff-lightest"
 
   defp get_students_grades_grid_cell_wrapper_class(%{comment: comment}, _)
        when is_binary(comment),

--- a/lib/lanttern_web/components/navigation_components.ex
+++ b/lib/lanttern_web/components/navigation_components.ex
@@ -141,7 +141,7 @@ defmodule LantternWeb.NavigationComponents do
   end
 
   @doc """
-  Renders a student or teacher tab.
+  Renders a student or staff member tab.
 
   ## Examples
 

--- a/lib/lanttern_web/components/reporting_components.ex
+++ b/lib/lanttern_web/components/reporting_components.ex
@@ -35,7 +35,7 @@ defmodule LantternWeb.ReportingComponents do
     {bg_class, icon_class, text_class, text} =
       case assigns.type do
         "teacher" ->
-          {"bg-ltrn-teacher-lightest", "text-ltrn-teacher-accent", "text-ltrn-teacher-dark",
+          {"bg-ltrn-staff-lightest", "text-ltrn-staff-accent", "text-ltrn-staff-dark",
            gettext("Teacher comment")}
 
         "student" ->

--- a/lib/lanttern_web/components/students_records_components.ex
+++ b/lib/lanttern_web/components/students_records_components.ex
@@ -106,7 +106,7 @@ defmodule LantternWeb.StudentsRecordsComponents do
           </div>
         </div>
         <div class="px-2 pb-2">
-          <div class="flex items-center gap-4 p-2 rounded-sm bg-ltrn-teacher-lightest">
+          <div class="flex items-center gap-4 p-2 rounded-sm bg-ltrn-staff-lightest">
             <div class="flex items-center gap-2">
               <span class="text-xs text-ltrn-subtle"><%= gettext("Created by") %></span>
               <.person_badge

--- a/lib/lanttern_web/components/students_records_components.ex
+++ b/lib/lanttern_web/components/students_records_components.ex
@@ -106,27 +106,33 @@ defmodule LantternWeb.StudentsRecordsComponents do
           </div>
         </div>
         <div class="px-2 pb-2">
-          <div class="flex items-center gap-4 p-2 rounded-sm bg-ltrn-staff-lightest">
-            <div class="flex items-center gap-2">
-              <span class="text-xs text-ltrn-subtle"><%= gettext("Created by") %></span>
-              <.person_badge
-                person={student_record.created_by_staff_member}
-                theme="staff"
-                navigate={@staff_navigate.(student_record.created_by_staff_member.id)}
-                truncate
-              />
-            </div>
-            <div :if={student_record.assignees != []} class="flex items-center gap-2">
-              <span class="text-xs text-ltrn-subtle"><%= gettext("Assigned to") %></span>
+          <div class="flex items-center justify-between gap-4 p-2 rounded-sm bg-ltrn-staff-lightest">
+            <div class="md:flex items-center gap-4">
               <div class="flex items-center gap-2">
+                <span class="text-xs text-ltrn-subtle"><%= gettext("Created by") %></span>
                 <.person_badge
-                  :for={assignee <- student_record.assignees}
-                  person={assignee}
+                  person={student_record.created_by_staff_member}
                   theme="staff"
-                  navigate={@staff_navigate.(assignee.id)}
+                  navigate={@staff_navigate.(student_record.created_by_staff_member.id)}
                   truncate
                 />
               </div>
+              <div :if={student_record.assignees != []} class="flex items-center gap-2 mt-2 md:mt-0">
+                <span class="text-xs text-ltrn-subtle"><%= gettext("Assigned to") %></span>
+                <div class="flex flex-wrap items-center gap-2">
+                  <.person_badge
+                    :for={assignee <- student_record.assignees}
+                    person={assignee}
+                    theme="staff"
+                    navigate={@staff_navigate.(assignee.id)}
+                    truncate
+                  />
+                </div>
+              </div>
+            </div>
+            <div :if={student_record.shared_with_school} class="group relative">
+              <.icon name="hero-globe-americas" class="w-6 h-6 text-ltrn-staff-accent" />
+              <.tooltip h_pos="right"><%= gettext("Visible to all school staff") %></.tooltip>
             </div>
           </div>
         </div>

--- a/lib/lanttern_web/helpers/personalization_helpers.ex
+++ b/lib/lanttern_web/helpers/personalization_helpers.ex
@@ -7,7 +7,7 @@ defmodule LantternWeb.PersonalizationHelpers do
   alias Lanttern.Personalization
 
   @permission_to_option_map %{
-    "wcd" => "WCD",
+    "students_records_full_access" => "Students records full access",
     "school_management" => "School management",
     "content_management" => "Content management"
   }

--- a/lib/lanttern_web/helpers/schools_helpers.ex
+++ b/lib/lanttern_web/helpers/schools_helpers.ex
@@ -66,12 +66,12 @@ defmodule LantternWeb.SchoolsHelpers do
   end
 
   @doc """
-  Generate list of teachers to use as `Phoenix.HTML.Form.options_for_select/2` arg
+  Generate list of staff members to use as `Phoenix.HTML.Form.options_for_select/2` arg
 
   ## Examples
 
       iex> generate_staff_member_options()
-      [{"teacher name", 1}, ...]
+      [{"staff member name", 1}, ...]
   """
   def generate_staff_member_options() do
     Schools.list_staff_members()

--- a/lib/lanttern_web/live/pages/admin/import_staff_members/import_staff_members_live.ex
+++ b/lib/lanttern_web/live/pages/admin/import_staff_members/import_staff_members_live.ex
@@ -77,8 +77,8 @@ defmodule LantternWeb.Admin.ImportStaffMembersLive do
       <table class="w-full my-6">
         <thead class="text-left">
           <tr>
-            <th class="p-2">Teacher name</th>
-            <th class="p-2">Teacher email</th>
+            <th class="p-2">Staff member name</th>
+            <th class="p-2">Staff member email</th>
           </tr>
         </thead>
         <tbody>
@@ -109,8 +109,8 @@ defmodule LantternWeb.Admin.ImportStaffMembersLive do
       <table class="w-full my-6">
         <thead class="text-left">
           <tr>
-            <th class="p-2">Teacher name</th>
-            <th class="p-2">Teacher email</th>
+            <th class="p-2">Staff member name</th>
+            <th class="p-2">Staff member email</th>
             <th class="p-2">Status</th>
           </tr>
         </thead>
@@ -289,7 +289,7 @@ defmodule LantternWeb.Admin.ImportStaffMembersLive do
 
       csv |> hd() |> length() != 2 ->
         {:error,
-         "Expected 2 columns (teacher name and email), but got #{csv |> hd() |> length()}"}
+         "Expected 2 columns (staff member name and email), but got #{csv |> hd() |> length()}"}
 
       true ->
         {:ok, csv}

--- a/lib/lanttern_web/live/pages/admin/profile_settings_live/form_component.ex
+++ b/lib/lanttern_web/live/pages/admin/profile_settings_live/form_component.ex
@@ -21,7 +21,7 @@ defmodule LantternWeb.Admin.ProfileSettingsLive.FormComponent do
         phx-submit="save"
       >
         <.input
-          id="wcd-toggle"
+          id="permissions-toggle"
           field={@form[:permissions]}
           type="select"
           multiple

--- a/lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex
+++ b/lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex
@@ -20,7 +20,6 @@ defmodule LantternWeb.StaffMemberLive do
       socket
       |> assign_staff_member(params)
       |> assign_is_school_manager()
-      |> assign_is_wcd()
       |> assign_is_current_user()
 
     {:ok, socket}
@@ -53,11 +52,6 @@ defmodule LantternWeb.StaffMemberLive do
         socket.assigns.staff_member.id
 
     assign(socket, :is_current_user, is_current_user)
-  end
-
-  defp assign_is_wcd(socket) do
-    is_wcd = "wcd" in socket.assigns.current_user.current_profile.permissions
-    assign(socket, :is_wcd, is_wcd)
   end
 
   defp assign_is_school_manager(socket) do

--- a/lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex
+++ b/lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex
@@ -10,7 +10,6 @@
           <%= gettext("About") %>
         </:tab>
         <:tab
-          :if={@is_wcd}
           patch={~p"/school/staff/#{@staff_member}/students_records"}
           is_current={@live_action == :students_records}
         >
@@ -47,7 +46,7 @@
   </.responsive_container>
 </div>
 <.live_component
-  :if={@live_action == :students_records && @is_wcd}
+  :if={@live_action == :students_records}
   module={StudentsRecordsComponent}
   id="students-records"
   staff_member={@staff_member}

--- a/lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex
+++ b/lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex
@@ -186,6 +186,7 @@ defmodule LantternWeb.StaffMemberLive.StudentsRecordsComponent do
             id="student-search-modal-search"
             notify_component={@myself}
             label={gettext("Type the name of the student")}
+            school_id={@current_user.current_profile.school_id}
           />
         </form>
       </.modal>

--- a/lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex
+++ b/lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex
@@ -329,7 +329,7 @@ defmodule LantternWeb.StaffMemberLive.StudentsRecordsComponent do
 
   defp stream_students_records(socket, reset \\ false) do
     %{
-      current_user: %{current_profile: %{school_id: school_id}},
+      current_user: %{current_profile: profile},
       selected_students_ids: students_ids,
       selected_classes_ids: classes_ids,
       selected_student_record_types_ids: types_ids,
@@ -343,7 +343,7 @@ defmodule LantternWeb.StaffMemberLive.StudentsRecordsComponent do
 
     page =
       StudentsRecords.list_students_records_page(
-        school_id: school_id,
+        check_profile_permissions: profile,
         students_ids: students_ids,
         classes_ids: classes_ids,
         types_ids: types_ids,

--- a/lib/lanttern_web/live/pages/school/students/id/student_live.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_live.ex
@@ -23,7 +23,6 @@ defmodule LantternWeb.StudentLive do
       socket
       |> assign_student(params)
       |> assign_is_school_manager()
-      |> assign_is_wcd()
 
     {:ok, socket, temporary_assigns: [student_grades_maps: %{}]}
   end
@@ -54,11 +53,6 @@ defmodule LantternWeb.StudentLive do
       "school_management" in socket.assigns.current_user.current_profile.permissions
 
     assign(socket, :is_school_manager, is_school_manager)
-  end
-
-  defp assign_is_wcd(socket) do
-    is_wcd = "wcd" in socket.assigns.current_user.current_profile.permissions
-    assign(socket, :is_wcd, is_wcd)
   end
 
   @impl true

--- a/lib/lanttern_web/live/pages/school/students/id/student_live.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_live.ex
@@ -42,7 +42,7 @@ defmodule LantternWeb.StudentLive do
   end
 
   # check if user can view the student profile
-  # teachers can view only students from their school
+  # staff members can view only students from their school
   defp check_if_user_has_access(current_user, student) do
     if student.school_id != current_user.current_profile.school_id,
       do: raise(LantternWeb.NotFoundError)

--- a/lib/lanttern_web/live/pages/school/students/id/student_live.html.heex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_live.html.heex
@@ -22,7 +22,6 @@
           <%= gettext("Grades reports") %>
         </:tab>
         <:tab
-          :if={@is_wcd}
           patch={~p"/school/students/#{@student}/student_records"}
           is_current={@live_action == :student_records}
         >
@@ -62,7 +61,7 @@
   />
 </div>
 <.live_component
-  :if={@live_action == :student_records && @is_wcd}
+  :if={@live_action == :student_records}
   module={StudentRecordsComponent}
   id="student-records"
   student={@student}

--- a/lib/lanttern_web/live/pages/school/students/id/student_records_component.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_records_component.ex
@@ -260,7 +260,7 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
 
   defp stream_students_records(socket, reset \\ false) do
     %{
-      current_user: %{current_profile: %{school_id: school_id}},
+      current_user: %{current_profile: profile},
       selected_student_record_types_ids: types_ids,
       selected_student_record_statuses_ids: statuses_ids,
       selected_student_record_assignees_ids: assignees_ids
@@ -273,7 +273,7 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
 
     page =
       StudentsRecords.list_students_records_page(
-        school_id: school_id,
+        check_profile_permissions: profile,
         students_ids: [socket.assigns.student.id],
         types_ids: types_ids,
         statuses_ids: statuses_ids,

--- a/lib/lanttern_web/live/pages/school/students/id/student_records_component.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_records_component.ex
@@ -75,7 +75,7 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
             <.badge
               :for={assignee <- @selected_student_record_assignees}
               on_remove={JS.push("remove_assignee_filter", target: @myself)}
-              theme="teacher"
+              theme="staff"
             >
               <%= assignee.name %>
             </.badge>

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.ex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.ex
@@ -8,8 +8,6 @@ defmodule LantternWeb.StudentsRecordsLive do
   import LantternWeb.FiltersHelpers,
     only: [assign_user_filters: 2, assign_classes_filter: 2, save_profile_filters: 2]
 
-  import LantternWeb.PersonalizationHelpers, only: [profile_has_permission?: 2]
-
   # shared components
 
   alias LantternWeb.Schools.StaffMemberSearchComponent
@@ -22,9 +20,6 @@ defmodule LantternWeb.StudentsRecordsLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    if !profile_has_permission?(socket.assigns.current_user.current_profile, "wcd"),
-      do: raise(LantternWeb.NotFoundError)
-
     socket =
       socket
       |> assign(:page_title, gettext("Students records"))

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.ex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.ex
@@ -50,7 +50,7 @@ defmodule LantternWeb.StudentsRecordsLive do
 
   defp stream_students_records(socket, reset \\ false) do
     %{
-      current_user: %{current_profile: %{school_id: school_id}},
+      current_user: %{current_profile: profile},
       selected_students_ids: students_ids,
       selected_classes_ids: classes_ids,
       selected_student_record_types_ids: types_ids,
@@ -65,7 +65,7 @@ defmodule LantternWeb.StudentsRecordsLive do
 
     page =
       StudentsRecords.list_students_records_page(
-        school_id: school_id,
+        check_profile_permissions: profile,
         students_ids: students_ids,
         classes_ids: classes_ids,
         types_ids: types_ids,

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.html.heex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.html.heex
@@ -140,6 +140,7 @@
       id="student-search-modal-search"
       notify_parent
       label={gettext("Type the name of the student")}
+      school_id={@current_user.current_profile.school_id}
     />
   </form>
 </.modal>

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.html.heex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.html.heex
@@ -83,7 +83,7 @@
         <.badge
           :for={assignee <- @selected_student_record_assignees}
           on_remove={JS.push("remove_assignee_filter")}
-          theme="teacher"
+          theme="staff"
         >
           <%= assignee.name %>
         </.badge>

--- a/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
@@ -391,7 +391,7 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
   def compare_header(assigns) do
     ~H"""
     <div class="flex gap-1 w-full mt-2">
-      <div class="flex-1 pb-1 border-b-2 border-ltrn-teacher-accent text-xs text-center text-ltrn-teacher-dark">
+      <div class="flex-1 pb-1 border-b-2 border-ltrn-staff-accent text-xs text-center text-ltrn-staff-dark">
         <%= gettext("Teacher") %>
       </div>
       <div class="flex-1 pb-1 border-b-2 border-ltrn-student-accent text-xs text-center text-ltrn-student-dark">

--- a/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
@@ -336,7 +336,7 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
     note_icon_class =
       cond do
         entry_note && view == "student" -> "text-ltrn-student-accent"
-        entry_note -> "text-ltrn-teacher-accent"
+        entry_note -> "text-ltrn-staff-accent"
         true -> ""
       end
 

--- a/lib/lanttern_web/live/shared/assessments/entry_details_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_details_component.ex
@@ -38,7 +38,7 @@ defmodule LantternWeb.Assessments.EntryDetailsComponent do
         class="mt-10"
       >
         <div class="grid grid-cols-2 gap-2">
-          <div class="pb-1 border-b-2 border-ltrn-teacher-accent text-xs text-center text-ltrn-teacher-dark">
+          <div class="pb-1 border-b-2 border-ltrn-staff-accent text-xs text-center text-ltrn-staff-dark">
             <%= gettext("Teacher assessment") %>
           </div>
           <div class="pb-1 border-b-2 border-ltrn-student-accent text-xs text-center text-ltrn-student-dark">
@@ -110,7 +110,7 @@ defmodule LantternWeb.Assessments.EntryDetailsComponent do
         is_editing={@is_editing_note}
         form={@form}
         error={@save_note_error}
-        theme="teacher"
+        theme="staff"
         on_edit={JS.push("edit_note", target: @myself)}
         on_cancel={JS.push("cancel_edit_note", target: @myself)}
         on_save={JS.push("save_note", target: @myself)}
@@ -218,9 +218,9 @@ defmodule LantternWeb.Assessments.EntryDetailsComponent do
       case assigns.theme do
         "teacher" ->
           %{
-            bg_lightest: "bg-ltrn-teacher-lightest",
-            text_accent: "text-ltrn-teacher-accent",
-            text_dark: "text-ltrn-teacher-dark",
+            bg_lightest: "bg-ltrn-staff-lightest",
+            text_accent: "text-ltrn-staff-accent",
+            text_dark: "text-ltrn-staff-dark",
             comment_text: gettext("Teacher comment"),
             no_comment_text: gettext("No teacher comment"),
             field: assigns.form[:report_note]

--- a/lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex
+++ b/lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex
@@ -36,7 +36,7 @@ defmodule LantternWeb.GradesReports.StudentGradesReportEntryFormComponent do
           />
           <p
             :if={@has_manual_edit}
-            class="p-2 rounded-sm border border-ltrn-teacher-accent mt-2 text-sm bg-ltrn-teacher-lightest"
+            class="p-2 rounded-sm border border-ltrn-staff-accent mt-2 text-sm bg-ltrn-staff-lightest"
           >
             <%= gettext(
               "Different from grade composition. Use comments field to justify it if needed."

--- a/lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex
+++ b/lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex
@@ -36,7 +36,7 @@ defmodule LantternWeb.GradesReports.StudentGradesReportFinalEntryFormComponent d
           />
           <p
             :if={@has_manual_edit}
-            class="p-2 rounded-sm border border-ltrn-teacher-accent mt-2 text-sm bg-ltrn-teacher-lightest"
+            class="p-2 rounded-sm border border-ltrn-staff-accent mt-2 text-sm bg-ltrn-staff-lightest"
           >
             <%= gettext(
               "Different from grade composition. Use comments field to justify it if needed."

--- a/lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex
@@ -142,14 +142,14 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
       <.markdown_supported class="mb-6" />
       <div
         :if={@template_instructions}
-        class="p-4 border border-ltrn-teacher-accent rounded-sm mb-6 bg-ltrn-teacher-lightest"
+        class="p-4 border border-ltrn-staff-accent rounded-sm mb-6 bg-ltrn-staff-lightest"
       >
-        <h6 class="font-display font-black font-lg text-ltrn-teacher-dark">
+        <h6 class="font-display font-black font-lg text-ltrn-staff-dark">
           <%= gettext("Template instructions") %>
         </h6>
         <.markdown text={@template_instructions} class="mt-4" />
       </div>
-      <div class="p-4 rounded-sm mb-6 bg-ltrn-teacher-lightest">
+      <div class="p-4 rounded-sm mb-6 bg-ltrn-staff-lightest">
         <.input
           field={@form[:teacher_instructions]}
           type="textarea"
@@ -213,8 +213,8 @@ defmodule LantternWeb.LearningContext.MomentCardOverlayComponent do
     ~H"""
     <.scroll_to_top overlay_id={@id} id="details-scroll-top" />
     <.markdown text={@moment_card.description} class="mt-6" />
-    <div :if={@moment_card.teacher_instructions} class="p-4 rounded-sm mt-6 bg-ltrn-teacher-lightest">
-      <p class="mb-4 font-bold text-ltrn-teacher-dark">
+    <div :if={@moment_card.teacher_instructions} class="p-4 rounded-sm mt-6 bg-ltrn-staff-lightest">
+      <p class="mb-4 font-bold text-ltrn-staff-dark">
         <%= gettext("Teacher instructions") %>
       </p>
       <.markdown text={@moment_card.teacher_instructions} />

--- a/lib/lanttern_web/live/shared/menu_component.ex
+++ b/lib/lanttern_web/live/shared/menu_component.ex
@@ -423,8 +423,7 @@ defmodule LantternWeb.MenuComponent do
         profile: "staff",
         active: :students_records,
         path: ~p"/students_records",
-        text: gettext("Students records"),
-        permission: "wcd"
+        text: gettext("Students records")
       },
       %{
         profile: "staff",

--- a/lib/lanttern_web/live/shared/menu_component.ex
+++ b/lib/lanttern_web/live/shared/menu_component.ex
@@ -346,6 +346,7 @@ defmodule LantternWeb.MenuComponent do
     LantternWeb.SchoolLive => :school_management,
     LantternWeb.ClassLive => :school_management,
     LantternWeb.StudentLive => :school_management,
+    LantternWeb.StaffMemberLive => :school_management,
 
     # assessment points
     LantternWeb.AssessmentPointsLive => :assessment_points,
@@ -468,6 +469,12 @@ defmodule LantternWeb.MenuComponent do
         active: :student_report_card,
         path: ~p"/guardian",
         text: gettext("Report cards")
+      },
+      %{
+        profile: "guardian",
+        active: :student_strands,
+        path: ~p"/student_strands",
+        text: gettext("Strands")
       }
     ]
 

--- a/lib/lanttern_web/live/shared/menu_component.ex
+++ b/lib/lanttern_web/live/shared/menu_component.ex
@@ -70,9 +70,8 @@ defmodule LantternWeb.MenuComponent do
               <%= Gettext.dgettext(
                 Lanttern.Gettext,
                 "schools",
-                String.capitalize(
-                  @current_user.current_profile.role || @current_user.current_profile.type
-                )
+                @current_user.current_profile.role ||
+                  String.capitalize(@current_user.current_profile.type)
               ) %> @ <%= @current_user.current_profile.school_name %>
 
               <.icon name="hero-chevron-down" id="profile-list-down-icon" />
@@ -288,7 +287,7 @@ defmodule LantternWeb.MenuComponent do
             <%= Gettext.dgettext(
               Lanttern.Gettext,
               "schools",
-              String.capitalize(Map.get(@profile.staff_member || %{}, :role, @profile.type))
+              @profile.role || String.capitalize(@profile.type)
             ) %> @ <%= @profile.school_name %>
           </span>
         </div>

--- a/lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex
+++ b/lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex
@@ -252,8 +252,8 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
 
   defp assessment_metadata_icon_attrs(:teacher_comment),
     do:
-      {gettext("Teacher comment"), "hero-chat-bubble-oval-left-mini", "bg-ltrn-teacher-lighter",
-       "text-ltrn-teacher-accent"}
+      {gettext("Teacher comment"), "hero-chat-bubble-oval-left-mini", "bg-ltrn-staff-lighter",
+       "text-ltrn-staff-accent"}
 
   defp assessment_metadata_icon_attrs(:student_comment),
     do:

--- a/lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex
@@ -90,9 +90,9 @@ defmodule LantternWeb.SchoolConfig.MomentCardTemplateOverlayComponent do
           <.markdown text={@moment_card_template.template} class="mt-6" />
           <div
             :if={@moment_card_template.instructions}
-            class="p-4 border border-ltrn-teacher-accent rounded-sm mt-10 bg-ltrn-teacher-lightest"
+            class="p-4 border border-ltrn-staff-accent rounded-sm mt-10 bg-ltrn-staff-lightest"
           >
-            <h6 class="font-display font-black font-lg text-ltrn-teacher-dark">
+            <h6 class="font-display font-black font-lg text-ltrn-staff-dark">
               <%= gettext("Additional teacher instructions") %>
             </h6>
             <.markdown text={@moment_card_template.instructions} class="mt-6" />

--- a/lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex
@@ -72,6 +72,7 @@ defmodule LantternWeb.Schools.ClassFormOverlayComponent do
               notify_component={@myself}
               label={gettext("Students in this class")}
               refocus_on_select="true"
+              school_id={@class.school_id}
             />
             <%= if @students != [] do %>
               <ol class="mt-4 text-sm leading-relaxed list-decimal list-inside">

--- a/lib/lanttern_web/live/shared/schools/staff_member_search_component.ex
+++ b/lib/lanttern_web/live/shared/schools/staff_member_search_component.ex
@@ -100,9 +100,9 @@ defmodule LantternWeb.Schools.StaffMemberSearchComponent do
   def handle_event("search", params, socket) do
     query = Map.get(params, "#{socket.assigns.id}-query", "")
     search_opts = if socket.assigns.school_id, do: [school_id: socket.assigns.school_id], else: []
-    # search when more than 3 characters were typed
+    # search when 3 or more characters were typed
     results =
-      if String.length(query) > 3,
+      if String.length(query) >= 3,
         do: Schools.search_staff_members(query, search_opts),
         else: []
 

--- a/lib/lanttern_web/live/shared/schools/student_search_component.ex
+++ b/lib/lanttern_web/live/shared/schools/student_search_component.ex
@@ -87,6 +87,7 @@ defmodule LantternWeb.Schools.StudentSearchComponent do
       socket
       |> assign(:label, nil)
       |> assign(:class, nil)
+      |> assign(:school_id, nil)
       |> assign(:refocus_on_select, "false")
       |> stream(:results, [])
 
@@ -98,10 +99,11 @@ defmodule LantternWeb.Schools.StudentSearchComponent do
   @impl true
   def handle_event("search", params, socket) do
     query = Map.get(params, "#{socket.assigns.id}-query", "")
-    # search when more than 3 characters were typed
+    search_opts = if socket.assigns.school_id, do: [school_id: socket.assigns.school_id], else: []
+    # search when 3 or more characters were typed
     results =
-      if String.length(query) > 3,
-        do: Schools.search_students(query),
+      if String.length(query) >= 3,
+        do: Schools.search_students(query, search_opts),
         else: []
 
     results_simplified = Enum.map(results, fn s -> %{id: s.id} end)

--- a/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
@@ -137,7 +137,7 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
               <p class="mb-6 font-bold text-ltrn-staff-dark">
                 <%= gettext("Internal student record tracking") %>
               </p>
-              <div>
+              <div class="mb-6">
                 <.live_component
                   module={StaffMemberSearchComponent}
                   id="staff-member-search"
@@ -159,6 +159,14 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
                 <div :if={@form.source.action in [:insert, :update]}>
                   <.error :for={{msg, _} <- @form[:assignees_ids].errors}><%= msg %></.error>
                 </div>
+              </div>
+              <div class="p-2 rounded-sm mt-10 -mx-2 -mb-2 bg-ltrn-staff-lighter">
+                <.input
+                  field={@form[:shared_with_school]}
+                  type="toggle"
+                  theme="staff"
+                  label={gettext("Visible to all school staff")}
+                />
               </div>
             </div>
             <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
@@ -199,14 +207,14 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
                   <%= @student_record.time %>
                 </div>
               </div>
-              <div class="flex items-center gap-4">
+              <div class="md:flex items-center gap-4">
                 <div class="flex items-center gap-2">
                   <span><%= gettext("Status") %>:</span>
                   <.badge color_map={@student_record.status}>
                     <%= @student_record.status.name %>
                   </.badge>
                 </div>
-                <div class="flex items-center gap-2">
+                <div class="flex items-center gap-2 mt-4 md:mt-0">
                   <span><%= gettext("Type") %>:</span>
                   <.badge color_map={@student_record.type}>
                     <%= @student_record.type.name %>
@@ -214,7 +222,7 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
                 </div>
               </div>
             </div>
-            <div class="flex items-start gap-4">
+            <div class="md:flex items-start gap-4">
               <div class="flex-1">
                 <div class="flex items-center gap-2">
                   <.icon name="hero-user-group-mini" class="text-ltrn-subtle" />
@@ -231,7 +239,7 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
                   />
                 </div>
               </div>
-              <div :if={@student_record.classes != []} class="flex-1">
+              <div :if={@student_record.classes != []} class="flex-1 mt-4 md:mt-0">
                 <div class="flex items-center gap-2">
                   <.icon name="hero-rectangle-group-mini" class="text-ltrn-subtle" />
                   <p><%= gettext("Classes") %></p>
@@ -260,7 +268,7 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
               </div>
               <div :if={@student_record.assignees != []} class="flex items-center gap-2 mt-4">
                 <span class="text-ltrn-subtle"><%= gettext("Assigned to") %></span>
-                <div class="flex items-center gap-2">
+                <div class="flex flex-wrap items-center gap-2">
                   <.person_badge
                     :for={assignee <- @student_record.assignees}
                     person={assignee}
@@ -268,6 +276,13 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
                     navigate={~p"/school/staff/#{assignee}/students_records"}
                   />
                 </div>
+              </div>
+              <div
+                :if={@student_record.shared_with_school}
+                class="flex items-center gap-2 p-2 rounded-sm mt-10 -mx-2 -mb-2 text-ltrn-staff-dark bg-ltrn-staff-lighter"
+              >
+                <.icon name="hero-globe-americas-mini" />
+                <%= gettext("This record is visible to all school staff") %>
               </div>
             </div>
             <%= if @is_deleted do %>

--- a/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
@@ -101,6 +101,7 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
                 notify_component={@myself}
                 label={gettext("Students")}
                 refocus_on_select="true"
+                school_id={@current_user.current_profile.school_id}
               />
               <div :if={@selected_students != []} class="flex flex-wrap gap-2 mt-2">
                 <.person_badge
@@ -143,6 +144,7 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
                   notify_component={@myself}
                   label={gettext("Assignees")}
                   refocus_on_select="true"
+                  school_id={@current_user.current_profile.school_id}
                 />
                 <div :if={@selected_assignees != []} class="flex flex-wrap gap-2 mt-2">
                   <.person_badge

--- a/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
@@ -417,6 +417,7 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
   defp assign_student_record(%{assigns: %{student_record_id: id}} = socket) do
     student_record =
       StudentsRecords.get_student_record(id,
+        check_profile_permissions: socket.assigns.current_user.current_profile,
         preloads: [
           :students,
           :type,

--- a/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
@@ -133,8 +133,8 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
               phx-debounce="1500"
             />
             <.markdown_supported class="mb-6" />
-            <div class="p-4 rounded-sm mb-6 bg-ltrn-teacher-lightest">
-              <p class="mb-6 font-bold text-ltrn-teacher-dark">
+            <div class="p-4 rounded-sm mb-6 bg-ltrn-staff-lightest">
+              <p class="mb-6 font-bold text-ltrn-staff-dark">
                 <%= gettext("Internal student record tracking") %>
               </p>
               <div>
@@ -244,8 +244,8 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
               </div>
             </div>
             <.markdown text={@student_record.description} class="mt-6" />
-            <div class="p-4 rounded-sm mt-6 bg-ltrn-teacher-lightest">
-              <p class="mb-6 font-bold text-ltrn-teacher-dark">
+            <div class="p-4 rounded-sm mt-6 bg-ltrn-staff-lightest">
+              <p class="mb-6 font-bold text-ltrn-staff-dark">
                 <%= gettext("Internal student record tracking") %>
               </p>
               <div class="flex items-center gap-2">

--- a/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
@@ -148,6 +148,7 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
                   <.person_badge
                     :for={assignee <- @selected_assignees}
                     person={assignee}
+                    theme="staff"
                     on_remove={
                       JS.push("remove_assignee", value: %{"id" => assignee.id}, target: @myself)
                     }
@@ -247,12 +248,16 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
               </p>
               <div class="flex items-center gap-2">
                 <span class="text-ltrn-subtle"><%= gettext("Created by") %></span>
-                <.person_badge person={@student_record.created_by_staff_member} />
+                <.person_badge person={@student_record.created_by_staff_member} theme="staff" />
               </div>
               <div :if={@student_record.assignees != []} class="flex items-center gap-2 mt-4">
                 <span class="text-ltrn-subtle"><%= gettext("Assigned to") %></span>
                 <div class="flex items-center gap-2">
-                  <.person_badge :for={assignee <- @student_record.assignees} person={assignee} />
+                  <.person_badge
+                    :for={assignee <- @student_record.assignees}
+                    person={assignee}
+                    theme="staff"
+                  />
                 </div>
               </div>
             </div>

--- a/lib/lanttern_web/router.ex
+++ b/lib/lanttern_web/router.ex
@@ -153,9 +153,6 @@ defmodule LantternWeb.Router do
         {LantternWeb.Path, :put_path_in_socket}
       ] do
       live "/student", StudentHomeLive
-
-      # todo: move back to authenticated_student_or_guardian in the future
-      live "/student_strands", StudentStrandsLive
     end
 
     live_session :authenticated_student_or_guardian,
@@ -167,6 +164,8 @@ defmodule LantternWeb.Router do
       live "/strand_report/:strand_report_id",
            StudentStrandReportLive,
            :show
+
+      live "/student_strands", StudentStrandsLive
     end
 
     live_session :authenticated_user,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2025.1.28-alpha.44",
+      version: "2025.1.29-alpha.45",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12,8 +12,8 @@ msgid ""
 msgstr ""
 
 #: lib/lanttern_web/components/core_components.ex:771
-#: lib/lanttern_web/components/core_components.ex:1888
-#: lib/lanttern_web/components/core_components.ex:1950
+#: lib/lanttern_web/components/core_components.ex:1890
+#: lib/lanttern_web/components/core_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -25,13 +25,13 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:2
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:440
+#: lib/lanttern_web/live/shared/menu_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:419
+#: lib/lanttern_web/live/shared/menu_component.ex:418
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -50,8 +50,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:421
-#: lib/lanttern_web/live/shared/menu_component.ex:465
+#: lib/lanttern_web/live/shared/menu_component.ex:420
+#: lib/lanttern_web/live/shared/menu_component.ex:463
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr ""
@@ -63,13 +63,13 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:180
+#: lib/lanttern_web/live/shared/menu_component.ex:179
 #, elixir-autogen, elixir-format
 msgid "Language:"
 msgstr ""
 
 #: lib/lanttern_web/controllers/privacy_policy_html/accept_policy.html.heex:25
-#: lib/lanttern_web/live/shared/menu_component.ex:173
+#: lib/lanttern_web/live/shared/menu_component.ex:172
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -127,12 +127,12 @@ msgstr ""
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:51
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:113
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:114
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:96
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:71
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:40
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:174
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:185
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -184,12 +184,12 @@ msgstr ""
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:116
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:61
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:105
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:43
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:177
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:188
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
@@ -220,7 +220,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:51
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:62
 #: lib/lanttern_web/live/shared/reporting/strand_report_form_component.ex:55
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:130
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:131
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
@@ -271,7 +271,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:35
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:41
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:162
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:173
 #, elixir-autogen, elixir-format
 msgid "Oops, something went wrong! Please check the errors below."
 msgstr ""
@@ -410,10 +410,10 @@ msgstr ""
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:57
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:248
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:109
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:272
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:306
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
@@ -477,10 +477,10 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:246
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:107
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:64
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:270
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:304
 #, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1838
+#: lib/lanttern_web/components/core_components.ex:1840
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -1028,7 +1028,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:25
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:49
 #: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:49
-#: lib/lanttern_web/live/shared/menu_component.ex:121
+#: lib/lanttern_web/live/shared/menu_component.ex:120
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:37
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:39
 #, elixir-autogen, elixir-format
@@ -1217,7 +1217,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:22
-#: lib/lanttern_web/live/shared/menu_component.ex:452
+#: lib/lanttern_web/live/shared/menu_component.ex:450
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr ""
@@ -1279,7 +1279,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1828
+#: lib/lanttern_web/components/core_components.ex:1830
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1415,9 +1415,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:16
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:115
-#: lib/lanttern_web/live/shared/menu_component.ex:446
-#: lib/lanttern_web/live/shared/menu_component.ex:459
-#: lib/lanttern_web/live/shared/menu_component.ex:472
+#: lib/lanttern_web/live/shared/menu_component.ex:444
+#: lib/lanttern_web/live/shared/menu_component.ex:457
+#: lib/lanttern_web/live/shared/menu_component.ex:470
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:11
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:102
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:218
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:229
 #, elixir-autogen, elixir-format
 msgid "Students"
 msgstr ""
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "The parent cycle grade is calculated based on it's children cycles. E.g. 2024 grade is based on 2024 Q1, Q2, Q3, and Q4 grades."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:122
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:123
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:55
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:63
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:42
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:207
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:218
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr ""
@@ -1857,7 +1857,7 @@ msgstr ""
 
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:11
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:211
+#: lib/lanttern_web/live/shared/menu_component.ex:210
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
 msgstr ""
@@ -1899,7 +1899,7 @@ msgstr ""
 msgid "Privacy policy and terms of service"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:219
+#: lib/lanttern_web/live/shared/menu_component.ex:218
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr ""
@@ -2220,7 +2220,7 @@ msgstr ""
 msgid "Invalid assessment view"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:71
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:72
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:12
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:398
 #, elixir-autogen, elixir-format
@@ -2604,12 +2604,12 @@ msgid "No teacher assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:8
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:88
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:89
 #: lib/lanttern_web/live/pages/school/students_component.ex:63
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:29
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:51
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:120
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:234
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:121
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:245
 #, elixir-autogen, elixir-format
 msgid "Classes"
 msgstr ""
@@ -2664,7 +2664,7 @@ msgstr ""
 msgid "All strand evidences"
 msgstr ""
 
-#: lib/lanttern/students_records/student_record.ex:112
+#: lib/lanttern/students_records/student_record.ex:115
 #, elixir-autogen, elixir-format
 msgid "At least 1 student is required"
 msgstr ""
@@ -2679,7 +2679,7 @@ msgstr ""
 msgid "Edit student record"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:180
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:181
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Filter records by student"
@@ -2690,14 +2690,14 @@ msgstr ""
 msgid "Invalid permissions"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:170
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:171
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:122
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Load more records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:139
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:140
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:89
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:97
 #, elixir-autogen, elixir-format
@@ -2714,39 +2714,39 @@ msgstr ""
 msgid "Record type"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:105
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:106
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:38
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:46
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:69
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:201
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:212
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:17
-#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:30
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:16
+#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:25
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:426
+#: lib/lanttern_web/live/shared/menu_component.ex:425
 #, elixir-autogen, elixir-format
 msgid "Students records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:187
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:188
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Type the name of the student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:202
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:204
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:127
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:171
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Filter students records by status"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:216
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:218
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:141
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:157
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Filter students records by type"
 msgstr ""
@@ -2978,8 +2978,8 @@ msgstr ""
 msgid "Edit class"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:38
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:78
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:37
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:77
 #: lib/lanttern_web/live/pages/school/students_component.ex:77
 #: lib/lanttern_web/live/pages/school/students_component.ex:109
 #: lib/lanttern_web/live/pages/school/students_component.ex:318
@@ -3002,7 +3002,7 @@ msgstr ""
 msgid "No classes matching current filters"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:95
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:96
 #, elixir-autogen, elixir-format
 msgid "No students added to this class"
 msgstr ""
@@ -3017,13 +3017,13 @@ msgstr ""
 msgid "Student created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:93
+#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:87
 #: lib/lanttern_web/live/pages/school/students_component.ex:205
 #, elixir-autogen, elixir-format
 msgid "Student deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:84
+#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:78
 #: lib/lanttern_web/live/pages/school/students_component.ex:186
 #, elixir-autogen, elixir-format
 msgid "Student updated successfully"
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Add cycle"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:168
+#: lib/lanttern_web/live/shared/menu_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
@@ -3138,7 +3138,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/guardian/guardian_home_live.ex:127
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:127
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:164
-#: lib/lanttern_web/live/shared/menu_component.ex:539
+#: lib/lanttern_web/live/shared/menu_component.ex:537
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr ""
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "Edit note"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:279
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:315
 #, elixir-autogen, elixir-format
 msgid "Edit record"
 msgstr ""
@@ -3256,12 +3256,12 @@ msgstr ""
 msgid "Link students from %{year} to this report card"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:131
+#: lib/lanttern_web/live/shared/menu_component.ex:130
 #, elixir-autogen, elixir-format
 msgid "Loading cycles"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:86
+#: lib/lanttern_web/live/shared/menu_component.ex:85
 #, elixir-autogen, elixir-format
 msgid "Loading profiles"
 msgstr ""
@@ -3313,7 +3313,7 @@ msgstr ""
 msgid "No class selected"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:122
+#: lib/lanttern_web/live/shared/menu_component.ex:121
 #, elixir-autogen, elixir-format
 msgid "No cycle selected"
 msgstr ""
@@ -3328,7 +3328,7 @@ msgstr ""
 msgid "No cycles in this school"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:151
+#: lib/lanttern_web/live/shared/menu_component.ex:150
 #, elixir-autogen, elixir-format
 msgid "No cycles registered"
 msgstr ""
@@ -3522,8 +3522,8 @@ msgstr ""
 msgid "Link strand to report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:195
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:150
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:197
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Filter students records by class"
 msgstr ""
@@ -3533,17 +3533,17 @@ msgstr ""
 msgid "Student record detail"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:284
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:320
 #, elixir-autogen, elixir-format
 msgid "Student record not found"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:29
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Student records"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:261
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:290
 #, elixir-autogen, elixir-format
 msgid "This record was deleted"
 msgstr ""
@@ -3852,8 +3852,8 @@ msgstr ""
 msgid "Cancel remove"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:26
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:62
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:25
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:61
 #: lib/lanttern_web/live/pages/school/staff_component.ex:166
 #, elixir-autogen, elixir-format
 msgid "Edit staff member"
@@ -3905,7 +3905,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:433
+#: lib/lanttern_web/live/shared/menu_component.ex:431
 #, elixir-autogen, elixir-format
 msgid "School management"
 msgstr ""
@@ -3920,7 +3920,7 @@ msgstr ""
 msgid "Staff member created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:93
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:87
 #: lib/lanttern_web/live/pages/school/staff_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Staff member updated successfully"
@@ -3973,14 +3973,14 @@ msgstr ""
 msgid "%{school} students"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:120
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:253
+#: lib/lanttern_web/components/students_records_components.ex:121
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:270
 #, elixir-autogen, elixir-format
 msgid "Assigned to"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:43
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:58
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:44
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:59
 #, elixir-autogen, elixir-format
 msgid "Assigned to %{staff_member}"
 msgstr ""
@@ -3991,25 +3991,25 @@ msgstr ""
 msgid "Assignee"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:144
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:145
 #, elixir-autogen, elixir-format
 msgid "Assignees"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:111
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:249
+#: lib/lanttern_web/components/students_records_components.ex:112
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Created by"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:160
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:190
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Filter records by assignee"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:137
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:246
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:138
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:257
 #, elixir-autogen, elixir-format
 msgid "Internal student record tracking"
 msgstr ""
@@ -4019,12 +4019,12 @@ msgstr ""
 msgid "Invalid view option"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:163
+#: lib/lanttern_web/live/shared/menu_component.ex:162
 #, elixir-autogen, elixir-format
 msgid "My area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:143
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:144
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:93
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:102
 #, elixir-autogen, elixir-format
@@ -4033,13 +4033,13 @@ msgid_plural "Showing %{count} results for selected filters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:102
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Staff member deleted successfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:167
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:197
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Type the name of the assignee"
 msgstr ""
@@ -4049,8 +4049,19 @@ msgstr ""
 msgid "View more"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:40
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:52
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:41
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:53
 #, elixir-autogen, elixir-format
 msgid "Created by %{staff_member}"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:285
+#, elixir-autogen, elixir-format
+msgid "This record is visible to all school staff"
+msgstr ""
+
+#: lib/lanttern_web/components/students_records_components.ex:135
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:168
+#, elixir-autogen, elixir-format
+msgid "Visible to all school staff"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: lib/lanttern_web/components/core_components.ex:771
-#: lib/lanttern_web/components/core_components.ex:1888
-#: lib/lanttern_web/components/core_components.ex:1950
+#: lib/lanttern_web/components/core_components.ex:1890
+#: lib/lanttern_web/components/core_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
@@ -25,13 +25,13 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:2
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:440
+#: lib/lanttern_web/live/shared/menu_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:419
+#: lib/lanttern_web/live/shared/menu_component.ex:418
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -50,8 +50,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:421
-#: lib/lanttern_web/live/shared/menu_component.ex:465
+#: lib/lanttern_web/live/shared/menu_component.ex:420
+#: lib/lanttern_web/live/shared/menu_component.ex:463
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr ""
@@ -63,13 +63,13 @@ msgstr ""
 msgid "close"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:180
+#: lib/lanttern_web/live/shared/menu_component.ex:179
 #, elixir-autogen, elixir-format
 msgid "Language:"
 msgstr ""
 
 #: lib/lanttern_web/controllers/privacy_policy_html/accept_policy.html.heex:25
-#: lib/lanttern_web/live/shared/menu_component.ex:173
+#: lib/lanttern_web/live/shared/menu_component.ex:172
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr ""
@@ -127,12 +127,12 @@ msgstr ""
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:51
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:113
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:114
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:96
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:71
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:40
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:174
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:185
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr ""
@@ -184,12 +184,12 @@ msgstr ""
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:116
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:61
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:105
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:43
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:177
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:188
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr ""
@@ -220,7 +220,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:51
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:62
 #: lib/lanttern_web/live/shared/reporting/strand_report_form_component.ex:55
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:130
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:131
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr ""
@@ -271,7 +271,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:35
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:41
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:162
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:173
 #, elixir-autogen, elixir-format
 msgid "Oops, something went wrong! Please check the errors below."
 msgstr ""
@@ -410,10 +410,10 @@ msgstr ""
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:57
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:248
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:109
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:272
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:306
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr ""
@@ -477,10 +477,10 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:246
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:107
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:64
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:270
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:304
 #, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr ""
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1838
+#: lib/lanttern_web/components/core_components.ex:1840
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -1028,7 +1028,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:25
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:49
 #: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:49
-#: lib/lanttern_web/live/shared/menu_component.ex:121
+#: lib/lanttern_web/live/shared/menu_component.ex:120
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:37
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:39
 #, elixir-autogen, elixir-format
@@ -1217,7 +1217,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:22
-#: lib/lanttern_web/live/shared/menu_component.ex:452
+#: lib/lanttern_web/live/shared/menu_component.ex:450
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr ""
@@ -1279,7 +1279,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1828
+#: lib/lanttern_web/components/core_components.ex:1830
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1415,9 +1415,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:16
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:115
-#: lib/lanttern_web/live/shared/menu_component.ex:446
-#: lib/lanttern_web/live/shared/menu_component.ex:459
-#: lib/lanttern_web/live/shared/menu_component.ex:472
+#: lib/lanttern_web/live/shared/menu_component.ex:444
+#: lib/lanttern_web/live/shared/menu_component.ex:457
+#: lib/lanttern_web/live/shared/menu_component.ex:470
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr ""
@@ -1556,7 +1556,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:11
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:102
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:218
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:229
 #, elixir-autogen, elixir-format
 msgid "Students"
 msgstr ""
@@ -1584,11 +1584,11 @@ msgstr ""
 msgid "The parent cycle grade is calculated based on it's children cycles. E.g. 2024 grade is based on 2024 Q1, Q2, Q3, and Q4 grades."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:122
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:123
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:55
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:63
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:42
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:207
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:218
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr ""
@@ -1857,7 +1857,7 @@ msgstr ""
 
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:11
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:211
+#: lib/lanttern_web/live/shared/menu_component.ex:210
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
 msgstr ""
@@ -1899,7 +1899,7 @@ msgstr ""
 msgid "Privacy policy and terms of service"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:219
+#: lib/lanttern_web/live/shared/menu_component.ex:218
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr ""
@@ -2220,7 +2220,7 @@ msgstr ""
 msgid "Invalid assessment view"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:71
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:72
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:12
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:398
 #, elixir-autogen, elixir-format, fuzzy
@@ -2604,12 +2604,12 @@ msgid "No teacher assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:8
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:88
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:89
 #: lib/lanttern_web/live/pages/school/students_component.ex:63
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:29
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:51
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:120
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:234
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:121
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:245
 #, elixir-autogen, elixir-format
 msgid "Classes"
 msgstr ""
@@ -2664,7 +2664,7 @@ msgstr ""
 msgid "All strand evidences"
 msgstr ""
 
-#: lib/lanttern/students_records/student_record.ex:112
+#: lib/lanttern/students_records/student_record.ex:115
 #, elixir-autogen, elixir-format
 msgid "At least 1 student is required"
 msgstr ""
@@ -2679,7 +2679,7 @@ msgstr ""
 msgid "Edit student record"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:180
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:181
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Filter records by student"
@@ -2690,14 +2690,14 @@ msgstr ""
 msgid "Invalid permissions"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:170
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:171
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:122
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:125
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Load more records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:139
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:140
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:89
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:97
 #, elixir-autogen, elixir-format
@@ -2714,39 +2714,39 @@ msgstr ""
 msgid "Record type"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:105
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:106
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:38
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:46
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:69
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:201
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:212
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:17
-#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:30
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:16
+#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:25
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:426
+#: lib/lanttern_web/live/shared/menu_component.ex:425
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Students records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:187
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:188
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Type the name of the student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:202
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:204
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:127
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:171
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter students records by status"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:216
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:218
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:141
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:157
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:158
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter students records by type"
 msgstr ""
@@ -2978,8 +2978,8 @@ msgstr ""
 msgid "Edit class"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:38
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:78
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:37
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:77
 #: lib/lanttern_web/live/pages/school/students_component.ex:77
 #: lib/lanttern_web/live/pages/school/students_component.ex:109
 #: lib/lanttern_web/live/pages/school/students_component.ex:318
@@ -3002,7 +3002,7 @@ msgstr ""
 msgid "No classes matching current filters"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:95
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No students added to this class"
 msgstr ""
@@ -3017,13 +3017,13 @@ msgstr ""
 msgid "Student created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:93
+#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:87
 #: lib/lanttern_web/live/pages/school/students_component.ex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:84
+#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:78
 #: lib/lanttern_web/live/pages/school/students_component.ex:186
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student updated successfully"
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "Add cycle"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:168
+#: lib/lanttern_web/live/shared/menu_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr ""
@@ -3138,7 +3138,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/guardian/guardian_home_live.ex:127
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:127
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:164
-#: lib/lanttern_web/live/shared/menu_component.ex:539
+#: lib/lanttern_web/live/shared/menu_component.ex:537
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr ""
@@ -3184,7 +3184,7 @@ msgstr ""
 msgid "Edit note"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:279
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:315
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit record"
 msgstr ""
@@ -3256,12 +3256,12 @@ msgstr ""
 msgid "Link students from %{year} to this report card"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:131
+#: lib/lanttern_web/live/shared/menu_component.ex:130
 #, elixir-autogen, elixir-format
 msgid "Loading cycles"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:86
+#: lib/lanttern_web/live/shared/menu_component.ex:85
 #, elixir-autogen, elixir-format
 msgid "Loading profiles"
 msgstr ""
@@ -3313,7 +3313,7 @@ msgstr ""
 msgid "No class selected"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:122
+#: lib/lanttern_web/live/shared/menu_component.ex:121
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No cycle selected"
 msgstr ""
@@ -3328,7 +3328,7 @@ msgstr ""
 msgid "No cycles in this school"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:151
+#: lib/lanttern_web/live/shared/menu_component.ex:150
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No cycles registered"
 msgstr ""
@@ -3522,8 +3522,8 @@ msgstr ""
 msgid "Link strand to report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:195
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:150
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:197
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:151
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter students records by class"
 msgstr ""
@@ -3533,17 +3533,17 @@ msgstr ""
 msgid "Student record detail"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:284
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:320
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student record not found"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:29
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:28
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student records"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:261
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:290
 #, elixir-autogen, elixir-format
 msgid "This record was deleted"
 msgstr ""
@@ -3852,8 +3852,8 @@ msgstr ""
 msgid "Cancel remove"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:26
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:62
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:25
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:61
 #: lib/lanttern_web/live/pages/school/staff_component.ex:166
 #, elixir-autogen, elixir-format
 msgid "Edit staff member"
@@ -3905,7 +3905,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:433
+#: lib/lanttern_web/live/shared/menu_component.ex:431
 #, elixir-autogen, elixir-format
 msgid "School management"
 msgstr ""
@@ -3920,7 +3920,7 @@ msgstr ""
 msgid "Staff member created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:93
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:87
 #: lib/lanttern_web/live/pages/school/staff_component.ex:99
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staff member updated successfully"
@@ -3973,14 +3973,14 @@ msgstr ""
 msgid "%{school} students"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:120
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:253
+#: lib/lanttern_web/components/students_records_components.ex:121
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:270
 #, elixir-autogen, elixir-format
 msgid "Assigned to"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:43
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:58
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:44
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:59
 #, elixir-autogen, elixir-format
 msgid "Assigned to %{staff_member}"
 msgstr ""
@@ -3991,25 +3991,25 @@ msgstr ""
 msgid "Assignee"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:144
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:145
 #, elixir-autogen, elixir-format
 msgid "Assignees"
 msgstr ""
 
-#: lib/lanttern_web/components/students_records_components.ex:111
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:249
+#: lib/lanttern_web/components/students_records_components.ex:112
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:260
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Created by"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:160
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:190
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:191
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter records by assignee"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:137
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:246
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:138
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:257
 #, elixir-autogen, elixir-format
 msgid "Internal student record tracking"
 msgstr ""
@@ -4019,12 +4019,12 @@ msgstr ""
 msgid "Invalid view option"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:163
+#: lib/lanttern_web/live/shared/menu_component.ex:162
 #, elixir-autogen, elixir-format
 msgid "My area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:143
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:144
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:93
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:102
 #, elixir-autogen, elixir-format, fuzzy
@@ -4033,13 +4033,13 @@ msgid_plural "Showing %{count} results for selected filters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:102
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Staff member deleted successfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:167
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:197
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:198
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Type the name of the assignee"
 msgstr ""
@@ -4049,8 +4049,19 @@ msgstr ""
 msgid "View more"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:40
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:52
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:41
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:53
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Created by %{staff_member}"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:285
+#, elixir-autogen, elixir-format
+msgid "This record is visible to all school staff"
+msgstr ""
+
+#: lib/lanttern_web/components/students_records_components.ex:135
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:168
+#, elixir-autogen, elixir-format
+msgid "Visible to all school staff"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -12,8 +12,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n>1);\n"
 
 #: lib/lanttern_web/components/core_components.ex:771
-#: lib/lanttern_web/components/core_components.ex:1888
-#: lib/lanttern_web/components/core_components.ex:1950
+#: lib/lanttern_web/components/core_components.ex:1890
+#: lib/lanttern_web/components/core_components.ex:1952
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Ações"
@@ -25,13 +25,13 @@ msgstr "Ações"
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:2
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:440
+#: lib/lanttern_web/live/shared/menu_component.ex:438
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr "Currículo"
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:419
+#: lib/lanttern_web/live/shared/menu_component.ex:418
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr "Dashboard"
@@ -50,8 +50,8 @@ msgstr "Rubricas"
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:421
-#: lib/lanttern_web/live/shared/menu_component.ex:465
+#: lib/lanttern_web/live/shared/menu_component.ex:420
+#: lib/lanttern_web/live/shared/menu_component.ex:463
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr "Trilhas"
@@ -63,13 +63,13 @@ msgstr "Trilhas"
 msgid "close"
 msgstr "fechar"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:180
+#: lib/lanttern_web/live/shared/menu_component.ex:179
 #, elixir-autogen, elixir-format
 msgid "Language:"
 msgstr "Idioma:"
 
 #: lib/lanttern_web/controllers/privacy_policy_html/accept_policy.html.heex:25
-#: lib/lanttern_web/live/shared/menu_component.ex:173
+#: lib/lanttern_web/live/shared/menu_component.ex:172
 #, elixir-autogen, elixir-format
 msgid "Log out"
 msgstr "Sair"
@@ -127,12 +127,12 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:51
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:113
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:114
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:96
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:71
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:40
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:174
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:185
 #, elixir-autogen, elixir-format
 msgid "Cancel"
 msgstr "Cancelar"
@@ -184,12 +184,12 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:116
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:61
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:105
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:43
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:177
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:188
 #, elixir-autogen, elixir-format
 msgid "Save"
 msgstr "Salvar"
@@ -220,7 +220,7 @@ msgstr "Suas trilhas favoritas"
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:51
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:62
 #: lib/lanttern_web/live/shared/reporting/strand_report_form_component.ex:55
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:130
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:131
 #, elixir-autogen, elixir-format
 msgid "Description"
 msgstr "Descrição"
@@ -271,7 +271,7 @@ msgstr "Nenhum ano selecionado"
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:35
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:41
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:162
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:173
 #, elixir-autogen, elixir-format
 msgid "Oops, something went wrong! Please check the errors below."
 msgstr "Oops, algo deu errado! Por favor, confira os erros abaixo."
@@ -410,10 +410,10 @@ msgstr "Não foi possível encontrar a trilha"
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:57
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:248
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:108
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:109
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:272
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:306
 #, elixir-autogen, elixir-format
 msgid "Delete"
 msgstr "Deletar"
@@ -477,10 +477,10 @@ msgstr "Adicione suas anotações..."
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:246
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:106
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:107
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:64
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:270
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:304
 #, elixir-autogen, elixir-format
 msgid "Are you sure?"
 msgstr "Você tem certeza?"
@@ -805,7 +805,7 @@ msgstr "Momento atualizado com sucesso"
 msgid "Moments"
 msgstr "Momentos"
 
-#: lib/lanttern_web/components/core_components.ex:1838
+#: lib/lanttern_web/components/core_components.ex:1840
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr "Mover momento para baixo"
@@ -1028,7 +1028,7 @@ msgstr "Item curricular removido"
 #: lib/lanttern_web/live/pages/student_strand_report/id/student_strand_report_live.html.heex:25
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:49
 #: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:49
-#: lib/lanttern_web/live/shared/menu_component.ex:121
+#: lib/lanttern_web/live/shared/menu_component.ex:120
 #: lib/lanttern_web/live/shared/reporting/report_card_form_component.ex:37
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:39
 #, elixir-autogen, elixir-format
@@ -1217,7 +1217,7 @@ msgstr "Relatório de notas atualizado com sucesso"
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:22
-#: lib/lanttern_web/live/shared/menu_component.ex:452
+#: lib/lanttern_web/live/shared/menu_component.ex:450
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr "Relatórios de notas"
@@ -1279,7 +1279,7 @@ msgstr "Card de momento atualizado com sucesso"
 msgid "Move down"
 msgstr "Mover para baixo"
 
-#: lib/lanttern_web/components/core_components.ex:1828
+#: lib/lanttern_web/components/core_components.ex:1830
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:154
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1415,9 +1415,9 @@ msgstr "Id do report card"
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:16
 #: lib/lanttern_web/live/pages/strands/id/about_component.ex:115
-#: lib/lanttern_web/live/shared/menu_component.ex:446
-#: lib/lanttern_web/live/shared/menu_component.ex:459
-#: lib/lanttern_web/live/shared/menu_component.ex:472
+#: lib/lanttern_web/live/shared/menu_component.ex:444
+#: lib/lanttern_web/live/shared/menu_component.ex:457
+#: lib/lanttern_web/live/shared/menu_component.ex:470
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr "Report cards"
@@ -1556,7 +1556,7 @@ msgstr "Report card de estudante deletado"
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:14
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:11
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:102
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:218
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:229
 #, elixir-autogen, elixir-format
 msgid "Students"
 msgstr "Estudantes"
@@ -1584,11 +1584,11 @@ msgstr "Formato de cor do texto inválido. Utilize cores hex."
 msgid "The parent cycle grade is calculated based on it's children cycles. E.g. 2024 grade is based on 2024 Q1, Q2, Q3, and Q4 grades."
 msgstr "A nota do ciclo pai é calculada com baseem seus sub ciclos. Ex: a nota de 2024 é baseada nas notas de 2024 1º, 2º, 3º e 4º bi."
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:122
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:123
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:55
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:63
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:42
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:207
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:218
 #, elixir-autogen, elixir-format
 msgid "Type"
 msgstr "Tipo"
@@ -1857,7 +1857,7 @@ msgstr "Confirmar"
 
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:11
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:48
-#: lib/lanttern_web/live/shared/menu_component.ex:211
+#: lib/lanttern_web/live/shared/menu_component.ex:210
 #, elixir-autogen, elixir-format
 msgid "Privacy policy"
 msgstr "Política de privacidade"
@@ -1899,7 +1899,7 @@ msgstr "Ao utilizar o Lanttern, você confirma ter lido e estar de acordo com no
 msgid "Privacy policy and terms of service"
 msgstr "Política de privacidade e termos de uso"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:219
+#: lib/lanttern_web/live/shared/menu_component.ex:218
 #, elixir-autogen, elixir-format
 msgid "Terms of service"
 msgstr "Termos de uso"
@@ -2220,7 +2220,7 @@ msgstr "Anexos"
 msgid "Invalid assessment view"
 msgstr "Visualização de avaliação inválida"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:71
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:72
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:12
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:398
 #, elixir-autogen, elixir-format
@@ -2604,12 +2604,12 @@ msgid "No teacher assessment"
 msgstr "Sem avaliação do professor"
 
 #: lib/lanttern_web/live/pages/school/school_live.html.heex:8
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:88
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:89
 #: lib/lanttern_web/live/pages/school/students_component.ex:63
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:29
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:51
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:120
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:234
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:121
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:245
 #, elixir-autogen, elixir-format
 msgid "Classes"
 msgstr "Turmas"
@@ -2664,7 +2664,7 @@ msgstr "Possui evidências de aprendizagem"
 msgid "All strand evidences"
 msgstr "Todas as evidências da trilha"
 
-#: lib/lanttern/students_records/student_record.ex:112
+#: lib/lanttern/students_records/student_record.ex:115
 #, elixir-autogen, elixir-format
 msgid "At least 1 student is required"
 msgstr "Obrigatório vincular ao menos 1 estudante"
@@ -2679,7 +2679,7 @@ msgstr "Data"
 msgid "Edit student record"
 msgstr "Editar registro de estudante"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:180
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:181
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Filter records by student"
@@ -2690,14 +2690,14 @@ msgstr "Filtrar registros por estudante"
 msgid "Invalid permissions"
 msgstr "Permissões inválidas"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:170
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:171
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:122
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:125
 #, elixir-autogen, elixir-format
 msgid "Load more records"
 msgstr "Carregar mais registros"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:139
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:140
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:89
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:97
 #, elixir-autogen, elixir-format
@@ -2714,39 +2714,39 @@ msgstr "Nenhum registro de estudante encontrado para os filtros selecionados."
 msgid "Record type"
 msgstr "Tipo de registro"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:105
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:106
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:38
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:46
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:69
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:201
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:212
 #, elixir-autogen, elixir-format
 msgid "Status"
 msgstr "Status"
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:17
-#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:30
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:16
+#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:25
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:426
+#: lib/lanttern_web/live/shared/menu_component.ex:425
 #, elixir-autogen, elixir-format
 msgid "Students records"
 msgstr "Registros de estudantes"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:187
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:188
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:142
 #, elixir-autogen, elixir-format
 msgid "Type the name of the student"
 msgstr "Digite o nome do estudante"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:202
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:204
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:127
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:171
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:172
 #, elixir-autogen, elixir-format
 msgid "Filter students records by status"
 msgstr "Filtrar registros de estudantes por status"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:216
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:218
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:141
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:157
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:158
 #, elixir-autogen, elixir-format
 msgid "Filter students records by type"
 msgstr "Filtrar registros de estudantes por tipo"
@@ -2978,8 +2978,8 @@ msgstr "Criar turma"
 msgid "Edit class"
 msgstr "Editar turma"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:38
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:78
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:37
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:77
 #: lib/lanttern_web/live/pages/school/students_component.ex:77
 #: lib/lanttern_web/live/pages/school/students_component.ex:109
 #: lib/lanttern_web/live/pages/school/students_component.ex:318
@@ -3002,7 +3002,7 @@ msgstr "Novo estudante"
 msgid "No classes matching current filters"
 msgstr "Nenhuma turma correspondente aos filtros selecionados"
 
-#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:95
+#: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:96
 #, elixir-autogen, elixir-format
 msgid "No students added to this class"
 msgstr "Nenhum estudante adicionado à esta turma"
@@ -3017,13 +3017,13 @@ msgstr "Nenhum estudante encontrado para os filtros selecionados."
 msgid "Student created successfully"
 msgstr "Estudante criado com sucesso"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:93
+#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:87
 #: lib/lanttern_web/live/pages/school/students_component.ex:205
 #, elixir-autogen, elixir-format
 msgid "Student deleted successfully"
 msgstr "Estudante deletado com sucesso"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:84
+#: lib/lanttern_web/live/pages/school/students/id/student_live.ex:78
 #: lib/lanttern_web/live/pages/school/students_component.ex:186
 #, elixir-autogen, elixir-format
 msgid "Student updated successfully"
@@ -3064,7 +3064,7 @@ msgstr "Já existe um relatório de notas para o mesmo ciclo e ano"
 msgid "Add cycle"
 msgstr "Adicionar ciclo"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:168
+#: lib/lanttern_web/live/shared/menu_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Admin"
 msgstr "Admin"
@@ -3138,7 +3138,7 @@ msgstr "Criar trilha"
 #: lib/lanttern_web/live/pages/guardian/guardian_home_live.ex:127
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:127
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:164
-#: lib/lanttern_web/live/shared/menu_component.ex:539
+#: lib/lanttern_web/live/shared/menu_component.ex:537
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr "Ciclo atual alterado"
@@ -3184,7 +3184,7 @@ msgstr "Editar ciclo"
 msgid "Edit note"
 msgstr "Editar nota"
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:279
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:315
 #, elixir-autogen, elixir-format
 msgid "Edit record"
 msgstr "Editar registro"
@@ -3256,12 +3256,12 @@ msgstr "Vincular estudantes de %{year} (%{cycle}) a este report card"
 msgid "Link students from %{year} to this report card"
 msgstr "Vncular estudantes de %{year} a este report card"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:131
+#: lib/lanttern_web/live/shared/menu_component.ex:130
 #, elixir-autogen, elixir-format
 msgid "Loading cycles"
 msgstr "Carregando ciclos"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:86
+#: lib/lanttern_web/live/shared/menu_component.ex:85
 #, elixir-autogen, elixir-format
 msgid "Loading profiles"
 msgstr "Carregando perfis"
@@ -3313,7 +3313,7 @@ msgstr "Nenhum relatório de notas de %{cycle} alinhdo aos filtros atuais foi cr
 msgid "No class selected"
 msgstr "Nenhuma turma selecionada"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:122
+#: lib/lanttern_web/live/shared/menu_component.ex:121
 #, elixir-autogen, elixir-format
 msgid "No cycle selected"
 msgstr "Nenhum ciclo selecionado"
@@ -3328,7 +3328,7 @@ msgstr "Nenhum ciclo encontrado nesta escola."
 msgid "No cycles in this school"
 msgstr "Nenhum ciclo nesta escola"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:151
+#: lib/lanttern_web/live/shared/menu_component.ex:150
 #, elixir-autogen, elixir-format
 msgid "No cycles registered"
 msgstr "Nenhum ciclo registrado"
@@ -3522,8 +3522,8 @@ msgstr "turmas"
 msgid "Link strand to report"
 msgstr "Vincular trilha ao report"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:195
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:150
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:197
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:151
 #, elixir-autogen, elixir-format
 msgid "Filter students records by class"
 msgstr "Filtrar registros de estudantes por turma"
@@ -3533,17 +3533,17 @@ msgstr "Filtrar registros de estudantes por turma"
 msgid "Student record detail"
 msgstr "Detalhe do registro de estudante"
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:284
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:320
 #, elixir-autogen, elixir-format
 msgid "Student record not found"
 msgstr "Registro de estudante não encontrado"
 
-#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:29
+#: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:28
 #, elixir-autogen, elixir-format
 msgid "Student records"
 msgstr "Registros de estudante"
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:261
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:290
 #, elixir-autogen, elixir-format
 msgid "This record was deleted"
 msgstr "Este registro foi deletado"
@@ -3852,8 +3852,8 @@ msgstr "Você tem certeza? Você pode reativar o colaborador mais tarde."
 msgid "Cancel remove"
 msgstr "Cancelar remoção"
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:26
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:62
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:25
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:61
 #: lib/lanttern_web/live/pages/school/staff_component.ex:166
 #, elixir-autogen, elixir-format
 msgid "Edit staff member"
@@ -3905,7 +3905,7 @@ msgstr "Reativar"
 msgid "Role"
 msgstr "Função"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:433
+#: lib/lanttern_web/live/shared/menu_component.ex:431
 #, elixir-autogen, elixir-format
 msgid "School management"
 msgstr "Gerenciamento da escola"
@@ -3920,7 +3920,7 @@ msgstr "Equipe"
 msgid "Staff member created successfully"
 msgstr "Colaborador criado com sucesso"
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:93
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:87
 #: lib/lanttern_web/live/pages/school/staff_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Staff member updated successfully"
@@ -3973,14 +3973,14 @@ msgstr "Colaboradores de %{school}"
 msgid "%{school} students"
 msgstr "Estudantes de %{school}"
 
-#: lib/lanttern_web/components/students_records_components.ex:120
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:253
+#: lib/lanttern_web/components/students_records_components.ex:121
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:270
 #, elixir-autogen, elixir-format
 msgid "Assigned to"
 msgstr "Atribuído a"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:43
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:58
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:44
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:59
 #, elixir-autogen, elixir-format
 msgid "Assigned to %{staff_member}"
 msgstr "Atribuído a %{staff_member}"
@@ -3991,25 +3991,25 @@ msgstr "Atribuído a %{staff_member}"
 msgid "Assignee"
 msgstr "Responsável"
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:144
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:145
 #, elixir-autogen, elixir-format
 msgid "Assignees"
 msgstr "Responsáveis"
 
-#: lib/lanttern_web/components/students_records_components.ex:111
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:249
+#: lib/lanttern_web/components/students_records_components.ex:112
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Created by"
 msgstr "Criado por"
 
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:160
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:190
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:191
 #, elixir-autogen, elixir-format
 msgid "Filter records by assignee"
 msgstr "Filtrar registros por responsável"
 
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:137
-#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:246
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:138
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:257
 #, elixir-autogen, elixir-format
 msgid "Internal student record tracking"
 msgstr "Acompanhamento interno de registro de estudante"
@@ -4019,12 +4019,12 @@ msgstr "Acompanhamento interno de registro de estudante"
 msgid "Invalid view option"
 msgstr "Opção de visualização inválida"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:163
+#: lib/lanttern_web/live/shared/menu_component.ex:162
 #, elixir-autogen, elixir-format
 msgid "My area"
 msgstr "Minha área"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:143
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:144
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:93
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:102
 #, elixir-autogen, elixir-format
@@ -4033,13 +4033,13 @@ msgid_plural "Showing %{count} results for selected filters"
 msgstr[0] "Mostrando 1 resultado para os filtros selecionados"
 msgstr[1] "Mostrando %{count} resultados para os filtros selecionados"
 
-#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:102
+#: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Staff member deleted successfully"
 msgstr "Colaborador deletado com sucesso"
 
 #: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:167
-#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:197
+#: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:198
 #, elixir-autogen, elixir-format
 msgid "Type the name of the assignee"
 msgstr "Digite o nome do responsável"
@@ -4049,8 +4049,19 @@ msgstr "Digite o nome do responsável"
 msgid "View more"
 msgstr "Ver mais"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:40
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:52
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:41
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:53
 #, elixir-autogen, elixir-format
 msgid "Created by %{staff_member}"
 msgstr "Criado por %{staff_member}"
+
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:285
+#, elixir-autogen, elixir-format
+msgid "This record is visible to all school staff"
+msgstr "Este registro está visível para toda a equipe da escola"
+
+#: lib/lanttern_web/components/students_records_components.ex:135
+#: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:168
+#, elixir-autogen, elixir-format
+msgid "Visible to all school staff"
+msgstr "Visível para toda a equipe da escola"

--- a/priv/repo/migrations/20250128204210_add_shared_with_school_to_students_records.exs
+++ b/priv/repo/migrations/20250128204210_add_shared_with_school_to_students_records.exs
@@ -1,0 +1,9 @@
+defmodule Lanttern.Repo.Migrations.AddSharedWithSchoolToStudentsRecords do
+  use Ecto.Migration
+
+  def change do
+    alter table(:students_records) do
+      add :shared_with_school, :boolean, default: false, null: false
+    end
+  end
+end

--- a/test/lanttern/personalization_test.exs
+++ b/test/lanttern/personalization_test.exs
@@ -56,7 +56,7 @@ defmodule Lanttern.PersonalizationTest do
       valid_permissions = Personalization.list_valid_permissions()
 
       assert length(valid_permissions) == 3
-      assert "wcd" in valid_permissions
+      assert "students_records_full_access" in valid_permissions
       assert "school_management" in valid_permissions
       assert "content_management" in valid_permissions
     end

--- a/test/lanttern_web/live/admin/profile_setting_live_test.exs
+++ b/test/lanttern_web/live/admin/profile_setting_live_test.exs
@@ -33,14 +33,16 @@ defmodule LantternWeb.Admin.ProfileSettingsLiveTest do
       assert_patch(index_live, ~p"/admin/profile_settings/#{profile.id}/edit")
 
       assert index_live
-             |> form("#profile-settings-form", profile_settings: %{permissions: ["wcd"]})
+             |> form("#profile-settings-form",
+               profile_settings: %{permissions: ["students_records_full_access"]}
+             )
              |> render_submit()
 
       assert_patch(index_live, ~p"/admin/profile_settings")
 
       html = render(index_live)
       assert html =~ "Permissions updated successfully"
-      assert html =~ "wcd"
+      assert html =~ "students_records_full_access"
     end
   end
 end

--- a/test/lanttern_web/live/pages/school/staff/id/staff_member_live_test.exs
+++ b/test/lanttern_web/live/pages/school/staff/id/staff_member_live_test.exs
@@ -62,4 +62,88 @@ defmodule LantternWeb.StaffMemberLiveTest do
       refute view |> has_element?("#staff-member-form-overlay h2", "Edit staff member")
     end
   end
+
+  describe "Students records live view access" do
+    alias Lanttern.StudentsRecordsFixtures
+
+    test "user without full access can access only its own records, records shared with school, or records assigned to them",
+         %{conn: conn, user: user} do
+      %{staff_member_id: staff_member_id, school_id: school_id} = user.current_profile
+      student = SchoolsFixtures.student_fixture(%{school_id: school_id, name: "std abc"})
+      other_staff_member = SchoolsFixtures.staff_member_fixture(%{school_id: school_id})
+
+      assigned_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          created_by_staff_member_id: other_staff_member.id,
+          name: "assigned student record",
+          description: "assigned student record desc",
+          school_id: school_id,
+          students_ids: [student.id],
+          assignees_ids: [staff_member_id]
+        })
+
+      shared_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          created_by_staff_member_id: other_staff_member.id,
+          name: "shared student record",
+          description: "shared student record desc",
+          school_id: school_id,
+          students_ids: [student.id],
+          shared_with_school: true
+        })
+
+      closed_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          created_by_staff_member_id: other_staff_member.id,
+          name: "closed student record",
+          description: "closed student record desc",
+          school_id: school_id,
+          students_ids: [student.id]
+        })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          "#{@live_view_base_path}/#{other_staff_member.id}/students_records"
+        )
+
+      assert view |> has_element?("span", student.name)
+
+      assert view |> has_element?("a", assigned_student_record.name)
+      assert view |> has_element?("p", assigned_student_record.description)
+
+      assert view |> has_element?("a", shared_student_record.name)
+      assert view |> has_element?("p", shared_student_record.description)
+
+      refute view |> has_element?("a", closed_student_record.name)
+      refute view |> has_element?("p", closed_student_record.description)
+    end
+
+    test "user with full access can access any record from the school", context do
+      %{conn: conn, user: user} = add_students_records_full_access_permissions(context)
+
+      %{school_id: school_id} = user.current_profile
+      student = SchoolsFixtures.student_fixture(%{school_id: school_id, name: "std abc"})
+      other_staff_member = SchoolsFixtures.staff_member_fixture(%{school_id: school_id})
+
+      closed_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          created_by_staff_member_id: other_staff_member.id,
+          name: "closed student record",
+          description: "closed student record desc",
+          school_id: school_id,
+          students_ids: [student.id]
+        })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          "#{@live_view_base_path}/#{other_staff_member.id}/students_records"
+        )
+
+      assert view |> has_element?("span", student.name)
+      assert view |> has_element?("a", closed_student_record.name)
+      assert view |> has_element?("p", closed_student_record.description)
+    end
+  end
 end

--- a/test/lanttern_web/live/pages/school/student/id/student_live_test.exs
+++ b/test/lanttern_web/live/pages/school/student/id/student_live_test.exs
@@ -115,4 +115,86 @@ defmodule LantternWeb.StudentLiveTest do
       assert_redirect(view, "https://somevaliduri.com")
     end
   end
+
+  describe "Students records live view access" do
+    alias Lanttern.StudentsRecordsFixtures
+
+    test "user without full access can access only its own records, records shared with school, or records assigned to them",
+         %{conn: conn, user: user} do
+      %{staff_member_id: staff_member_id, school_id: school_id} = user.current_profile
+      student = SchoolsFixtures.student_fixture(%{school_id: school_id, name: "std abc"})
+
+      own_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          created_by_staff_member_id: staff_member_id,
+          name: "my student record",
+          description: "my student record desc",
+          school_id: school_id,
+          students_ids: [student.id]
+        })
+
+      assigned_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          name: "assigned student record",
+          description: "assigned student record desc",
+          school_id: school_id,
+          students_ids: [student.id],
+          assignees_ids: [staff_member_id]
+        })
+
+      shared_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          name: "shared student record",
+          description: "shared student record desc",
+          school_id: school_id,
+          students_ids: [student.id],
+          shared_with_school: true
+        })
+
+      closed_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          name: "closed student record",
+          description: "closed student record desc",
+          school_id: school_id,
+          students_ids: [student.id]
+        })
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{student.id}/student_records")
+
+      assert view |> has_element?("span", student.name)
+
+      assert view |> has_element?("a", own_student_record.name)
+      assert view |> has_element?("p", own_student_record.description)
+
+      assert view |> has_element?("a", assigned_student_record.name)
+      assert view |> has_element?("p", assigned_student_record.description)
+
+      assert view |> has_element?("a", shared_student_record.name)
+      assert view |> has_element?("p", shared_student_record.description)
+
+      refute view |> has_element?("a", closed_student_record.name)
+      refute view |> has_element?("p", closed_student_record.description)
+    end
+
+    test "user with full access can access any record from the school", context do
+      %{conn: conn, user: user} = add_students_records_full_access_permissions(context)
+
+      %{school_id: school_id} = user.current_profile
+      student = SchoolsFixtures.student_fixture(%{school_id: school_id, name: "std abc"})
+
+      closed_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          name: "closed student record",
+          description: "closed student record desc",
+          school_id: school_id,
+          students_ids: [student.id]
+        })
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{student.id}/student_records")
+
+      assert view |> has_element?("span", student.name)
+      assert view |> has_element?("a", closed_student_record.name)
+      assert view |> has_element?("p", closed_student_record.description)
+    end
+  end
 end

--- a/test/lanttern_web/live/pages/students_records/students_records_live_test.exs
+++ b/test/lanttern_web/live/pages/students_records/students_records_live_test.exs
@@ -6,9 +6,9 @@ defmodule LantternWeb.StudentsRecordsLiveTest do
 
   @live_view_base_path "/students_records"
 
-  describe "Students records live view basic navigation" do
-    setup [:register_and_log_in_staff_member]
+  setup [:register_and_log_in_staff_member]
 
+  describe "Students records live view basic navigation" do
     test "disconnected and connected mount", %{conn: conn} do
       conn = get(conn, @live_view_base_path)
       assert html_response(conn, 200) =~ ~r/<h1 .+>\s*Students records\s*<\/h1>/
@@ -34,6 +34,7 @@ defmodule LantternWeb.StudentsRecordsLiveTest do
 
       student_record =
         StudentsRecordsFixtures.student_record_fixture(%{
+          created_by_staff_member_id: user.current_profile.staff_member_id,
           name: "student record abc",
           description: "student record desc",
           school_id: school_id,
@@ -52,18 +53,107 @@ defmodule LantternWeb.StudentsRecordsLiveTest do
     end
   end
 
-  # todo: replace with a test that lists the students records the user has access to
-  # describe "Students records live view access" do
-  #   setup [:register_and_log_in_staff_member]
+  describe "Students records live view access" do
+    test "user (even with full access) can't access records from other schools", context do
+      %{conn: conn} = add_students_records_full_access_permissions(context)
 
-  #   test "user without wcd permission is not allowed to access students records", %{conn: conn} do
-  #     assert_raise(LantternWeb.NotFoundError, fn -> live(conn, @live_view_base_path) end)
-  #   end
-  # end
+      student = SchoolsFixtures.student_fixture(%{name: "std abc"})
+
+      student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          name: "student record abc",
+          description: "student record desc",
+          school_id: student.school_id,
+          students_ids: [student.id]
+        })
+
+      {:ok, view, _html} = live(conn, @live_view_base_path)
+
+      refute view |> has_element?("span", student.name)
+      refute view |> has_element?("a", student_record.name)
+      refute view |> has_element?("p", student_record.description)
+    end
+
+    test "user without full access can access only its own records, records shared with school, or records assigned to them",
+         %{conn: conn, user: user} do
+      %{staff_member_id: staff_member_id, school_id: school_id} = user.current_profile
+      student = SchoolsFixtures.student_fixture(%{school_id: school_id, name: "std abc"})
+
+      own_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          created_by_staff_member_id: staff_member_id,
+          name: "my student record",
+          description: "my student record desc",
+          school_id: school_id,
+          students_ids: [student.id]
+        })
+
+      assigned_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          name: "assigned student record",
+          description: "assigned student record desc",
+          school_id: school_id,
+          students_ids: [student.id],
+          assignees_ids: [staff_member_id]
+        })
+
+      shared_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          name: "shared student record",
+          description: "shared student record desc",
+          school_id: school_id,
+          students_ids: [student.id],
+          shared_with_school: true
+        })
+
+      closed_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          name: "closed student record",
+          description: "closed student record desc",
+          school_id: school_id,
+          students_ids: [student.id]
+        })
+
+      {:ok, view, _html} = live(conn, @live_view_base_path)
+
+      assert view |> has_element?("span", student.name)
+
+      assert view |> has_element?("a", own_student_record.name)
+      assert view |> has_element?("p", own_student_record.description)
+
+      assert view |> has_element?("a", assigned_student_record.name)
+      assert view |> has_element?("p", assigned_student_record.description)
+
+      assert view |> has_element?("a", shared_student_record.name)
+      assert view |> has_element?("p", shared_student_record.description)
+
+      refute view |> has_element?("a", closed_student_record.name)
+      refute view |> has_element?("p", closed_student_record.description)
+    end
+
+    test "user with full access can access any record from the school", context do
+      %{conn: conn, user: user} = add_students_records_full_access_permissions(context)
+
+      %{school_id: school_id} = user.current_profile
+      student = SchoolsFixtures.student_fixture(%{school_id: school_id, name: "std abc"})
+
+      closed_student_record =
+        StudentsRecordsFixtures.student_record_fixture(%{
+          name: "closed student record",
+          description: "closed student record desc",
+          school_id: school_id,
+          students_ids: [student.id]
+        })
+
+      {:ok, view, _html} = live(conn, @live_view_base_path)
+
+      assert view |> has_element?("span", student.name)
+      assert view |> has_element?("a", closed_student_record.name)
+      assert view |> has_element?("p", closed_student_record.description)
+    end
+  end
 
   describe "Student record details" do
-    setup [:register_and_log_in_staff_member]
-
     test "view student record details", %{conn: conn, user: user} do
       school_id = user.current_profile.school_id
       student = SchoolsFixtures.student_fixture(%{school_id: school_id, name: "std abc"})
@@ -102,8 +192,6 @@ defmodule LantternWeb.StudentsRecordsLiveTest do
   end
 
   describe "Student record live school-based access" do
-    setup [:register_and_log_in_staff_member]
-
     test "view records from other schools is not allowed", %{conn: conn} do
       student_record = StudentsRecordsFixtures.student_record_fixture()
 

--- a/test/lanttern_web/live/pages/students_records/students_records_live_test.exs
+++ b/test/lanttern_web/live/pages/students_records/students_records_live_test.exs
@@ -7,7 +7,7 @@ defmodule LantternWeb.StudentsRecordsLiveTest do
   @live_view_base_path "/students_records"
 
   describe "Students records live view basic navigation" do
-    setup [:register_and_log_in_staff_member, :add_wcd_permissions]
+    setup [:register_and_log_in_staff_member]
 
     test "disconnected and connected mount", %{conn: conn} do
       conn = get(conn, @live_view_base_path)
@@ -52,16 +52,17 @@ defmodule LantternWeb.StudentsRecordsLiveTest do
     end
   end
 
-  describe "Students records live view access" do
-    setup [:register_and_log_in_staff_member]
+  # todo: replace with a test that lists the students records the user has access to
+  # describe "Students records live view access" do
+  #   setup [:register_and_log_in_staff_member]
 
-    test "user without wcd permission is not allowed to access students records", %{conn: conn} do
-      assert_raise(LantternWeb.NotFoundError, fn -> live(conn, @live_view_base_path) end)
-    end
-  end
+  #   test "user without wcd permission is not allowed to access students records", %{conn: conn} do
+  #     assert_raise(LantternWeb.NotFoundError, fn -> live(conn, @live_view_base_path) end)
+  #   end
+  # end
 
   describe "Student record details" do
-    setup [:register_and_log_in_staff_member, :add_wcd_permissions]
+    setup [:register_and_log_in_staff_member]
 
     test "view student record details", %{conn: conn, user: user} do
       school_id = user.current_profile.school_id
@@ -101,7 +102,7 @@ defmodule LantternWeb.StudentsRecordsLiveTest do
   end
 
   describe "Student record live school-based access" do
-    setup [:register_and_log_in_staff_member, :add_wcd_permissions]
+    setup [:register_and_log_in_staff_member]
 
     test "view records from other schools is not allowed", %{conn: conn} do
       student_record = StudentsRecordsFixtures.student_record_fixture()

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -191,13 +191,13 @@ defmodule LantternWeb.ConnCase do
   end
 
   @doc """
-  Setup helper that adds wcd permissions to current user profile.
+  Setup helper that adds full students records access permissions to current user profile.
   """
-  def add_wcd_permissions(%{conn: conn, user: user}) do
-    # add wcd permissions to user
+  def add_students_records_full_access_permissions(%{conn: conn, user: user}) do
+    # add students_records_full_access permissions to user
     {:ok, settings} =
       Lanttern.Personalization.set_profile_settings(user.current_profile_id, %{
-        permissions: ["wcd"]
+        permissions: ["students_records_full_access"]
       })
 
     emulate_profile_preload(conn, user, settings)


### PR DESCRIPTION
in this PR, we adjusted the rules for viewing and managing students records.

previously, students records visualization and creation were visible only to users with `wcd` profile permission. now, every staff member can create students records, and we have some specific rules on who can read, update, or delete records. from the `StudentsRecords` context documentation:

# About profile permissions

  Using the `:check_profile_permissions` option, we can validate read,
  update, and delete students records operations based on given `%Profile{}`
  (usually from `socket.assigns.current_user.current_profile`).

  ## Read permissions

  Supported by `list_students_records/1` and `get_student_record/2`.

  A profile has permission to read a student record if it has type `"staff"`
  and the staff member belongs to the same school as the student record, and:

  1. the profile has the `students_records_full_access` permission
  2. or the student record is `shared_with_school`
  3. or the staff member created the student record
  4. or the staff member is an assignee of the student record

  ## Update permissions

  Supported by `update_student_record/3`.

  A profile has permission to update a student record if it has type `"staff"`
  and the staff member belongs to the same school as the student record, and:

  1. the profile has the `students_records_full_access` permission
  2. or the staff member created the student record
  3. or the staff member is an assignee of the student record

  ## Delete permissions

  Supported by `delete_student_record/2`.

  A profile has permission to delete a student record if it has type `"staff"`
  and the staff member belongs to the same school as the student record, and:

  1. the profile has the `students_records_full_access` permission
  2. or the staff member created the student record

resolves #243 

---

# Copilot sumary

This pull request includes significant changes to the `Lanttern` application, focusing on renaming terminology, updating permissions, and adding new functionalities related to student records. The most important changes include renaming "teacher" to "staff", updating permissions for student records, and enhancing the `StudentsRecords` module with new permission checks.

Terminology Updates:
* [`assets/tailwind.config.js`](diffhunk://#diff-52a43e64271620d979d25d597733b7930e6f3771ab30e71ec459bff2398e43dbL43-R43): Renamed the color scheme from `teacher` to `staff`.
* [`lib/lanttern_web/components/assessments_components.ex`](diffhunk://#diff-2fb5dc1a284d03a1844d4153277f1ad0b0887c95999ef900a38952da2d35aea8L136-R136): Updated references from `teacher` to `staff` in assessment components. [[1]](diffhunk://#diff-2fb5dc1a284d03a1844d4153277f1ad0b0887c95999ef900a38952da2d35aea8L136-R136) [[2]](diffhunk://#diff-2fb5dc1a284d03a1844d4153277f1ad0b0887c95999ef900a38952da2d35aea8L255-R255)
* [`lib/lanttern_web/components/core_components.ex`](diffhunk://#diff-aa46793bbfa3dea60fb58422045e2f809eea50915535871845a3aeb7b3765e71L76-R76): Changed theme references from `teacher` to `staff`. [[1]](diffhunk://#diff-aa46793bbfa3dea60fb58422045e2f809eea50915535871845a3aeb7b3765e71L76-R76) [[2]](diffhunk://#diff-aa46793bbfa3dea60fb58422045e2f809eea50915535871845a3aeb7b3765e71L85-R85) [[3]](diffhunk://#diff-aa46793bbfa3dea60fb58422045e2f809eea50915535871845a3aeb7b3765e71L227-R227) [[4]](diffhunk://#diff-aa46793bbfa3dea60fb58422045e2f809eea50915535871845a3aeb7b3765e71L239-R239)

Permissions Updates:
* [`lib/lanttern/personalization.ex`](diffhunk://#diff-a1e92f3e870c81c235d30540d368ecca9c68a49845929a8e162bdad1b1799168L7-R7): Updated the permission name from `wcd` to `students_records_full_access`. [[1]](diffhunk://#diff-a1e92f3e870c81c235d30540d368ecca9c68a49845929a8e162bdad1b1799168L7-R7) [[2]](diffhunk://#diff-a1e92f3e870c81c235d30540d368ecca9c68a49845929a8e162bdad1b1799168L18-R18)

Enhancements to `StudentsRecords` Module:
* [`lib/lanttern/students_records.ex`](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R4-R53): Added detailed documentation and implementation for read, update, and delete permissions based on profile permissions. [[1]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R4-R53) [[2]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R69) [[3]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R88) [[4]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862L120-R190) [[5]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R222-R263) [[6]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R299) [[7]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862L203-R351) [[8]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R384) [[9]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R396-R453) [[10]](diffhunk://#diff-8e929d6d8431820a219a5eb9e78adb8817f2c64a7a2a132a08eade144cce3862R465-R509)
* [`lib/lanttern/students_records/student_record.ex`](diffhunk://#diff-766e5076246c3a8bd7e24566c6f210165404293cf996f974522a63fe2b929d5dR27): Added a new field `shared_with_school` to the `StudentRecord` schema and updated associations. [[1]](diffhunk://#diff-766e5076246c3a8bd7e24566c6f210165404293cf996f974522a63fe2b929d5dR27) [[2]](diffhunk://#diff-766e5076246c3a8bd7e24566c6f210165404293cf996f974522a63fe2b929d5dR49) [[3]](diffhunk://#diff-766e5076246c3a8bd7e24566c6f210165404293cf996f974522a63fe2b929d5dL59-R61) [[4]](diffhunk://#diff-766e5076246c3a8bd7e24566c6f210165404293cf996f974522a63fe2b929d5dR84)
* [`lib/lanttern/students_records/student_record_assignee.ex`](diffhunk://#diff-29d63374a4f3a09629e5a25d43041e233fd556e753e22f051bfbdb95eb9b743eL1-R3): Renamed the `Assignee` schema to `AssigneeRelationship`.