### PR TITLE
fixed assessment point entry details

### DIFF
--- a/lib/lanttern/students_records_log/student_record_log.ex
+++ b/lib/lanttern/students_records_log/student_record_log.ex
@@ -13,6 +13,7 @@ defmodule Lanttern.StudentsRecordsLog.StudentRecordLog do
     field :operation, :string
     field :name, :string
     field :description, :string
+    field :internal_notes, :string
     field :date, :date
     field :time, :time
     field :students_ids, {:array, :id}
@@ -35,6 +36,7 @@ defmodule Lanttern.StudentsRecordsLog.StudentRecordLog do
       :operation,
       :name,
       :description,
+      :internal_notes,
       :date,
       :time,
       :students_ids,

--- a/lib/lanttern_web/live/shared/assessments/entry_details_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_details_component.ex
@@ -216,7 +216,7 @@ defmodule LantternWeb.Assessments.EntryDetailsComponent do
   def comment_area(assigns) do
     new_assigns =
       case assigns.theme do
-        "teacher" ->
+        "staff" ->
           %{
             bg_lightest: "bg-ltrn-staff-lightest",
             text_accent: "text-ltrn-staff-accent",

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2025.1.29-alpha.46",
+      version: "2025.1.30-alpha.47",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20250130101738_add_internal_notes_to_students_records_log.exs
+++ b/priv/repo/migrations/20250130101738_add_internal_notes_to_students_records_log.exs
@@ -1,0 +1,11 @@
+defmodule Lanttern.Repo.Migrations.AddInternalNotesToStudentsRecordsLog do
+  use Ecto.Migration
+
+  @prefix "log"
+
+  def change do
+    alter table(:students_records, prefix: @prefix) do
+      add :internal_notes, :text
+    end
+  end
+end

--- a/test/lanttern/students_records_test.exs
+++ b/test/lanttern/students_records_test.exs
@@ -523,6 +523,7 @@ defmodule Lanttern.StudentsRecordsTest do
         date: ~D[2024-09-15],
         time: ~T[14:00:00],
         description: "some description",
+        internal_notes: "some internal notes",
         created_by_staff_member_id: staff_member.id,
         students_ids: [student.id],
         classes_ids: [class.id],
@@ -543,6 +544,7 @@ defmodule Lanttern.StudentsRecordsTest do
       assert student_record.date == ~D[2024-09-15]
       assert student_record.time == ~T[14:00:00]
       assert student_record.description == "some description"
+      assert student_record.internal_notes == "some internal notes"
       assert student_record.created_by_staff_member == staff_member
       assert student_record.students == [student]
       assert student_record.classes == [class]
@@ -569,6 +571,7 @@ defmodule Lanttern.StudentsRecordsTest do
         assert student_record_log.date == student_record.date
         assert student_record_log.time == student_record.time
         assert student_record_log.description == student_record.description
+        assert student_record_log.internal_notes == student_record.internal_notes
         assert student_record_log.assignees_ids == [assignee.id]
 
         assert student_record_log.created_by_staff_member_id ==


### PR DESCRIPTION
- adjusted clause in `EntryDetailsComponent` causing the bug
- added support to student record `internal_notes` logging