### PR TITLE
Fix old migration

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2025.4.6-alpha.59",
+      version: "2025.4.6-alpha.60",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/repo/migrations/20250407011632_fix_assessment_point_entries_scale_id_fkey.exs
+++ b/priv/repo/migrations/20250407011632_fix_assessment_point_entries_scale_id_fkey.exs
@@ -1,0 +1,70 @@
+defmodule Lanttern.Repo.Migrations.FixAssessmentPointEntriesScaleIdFkey do
+  @moduledoc """
+  In an old migration (`AdjustAssessmentPointEntriesScaleConstraints`),
+  we set the assessment point entries' scale id foreign key constraint as
+
+  ```sql
+  ALTER TABLE assessment_point_entries
+  DROP CONSTRAINT assessment_point_entries_scale_id_fkey;
+
+  ALTER TABLE assessment_point_entries
+  ADD CONSTRAINT assessment_point_entries_scale_id_fkey
+  FOREIGN KEY (assessment_point_id, scale_id)
+  REFERENCES assessment_points(id, scale_id);
+  ```
+
+  Which does not make sense, as we're referencing the `assessment_points` table.
+
+  This migration fixes this inconsistency, by recreating the `assessment_point_entries_scale_id_fkey`
+  refrencing the `grading_scales` table, and recreating the `assessment_point_entries_assessment_point_id_fkey`
+  using a composite foreign key with `scale_id`, which was the original intention.
+  """
+
+  use Ecto.Migration
+
+  def change do
+    execute """
+            ALTER TABLE assessment_point_entries
+              DROP CONSTRAINT assessment_point_entries_scale_id_fkey
+            """,
+            """
+            ALTER TABLE assessment_point_entries
+              ADD CONSTRAINT assessment_point_entries_scale_id_fkey
+                FOREIGN KEY (assessment_point_id, scale_id)
+                  REFERENCES assessment_points(id, scale_id)
+            """
+
+    execute """
+            ALTER TABLE assessment_point_entries
+              ADD CONSTRAINT assessment_point_entries_scale_id_fkey
+                FOREIGN KEY (scale_id)
+                  REFERENCES grading_scales(id)
+            """,
+            """
+            ALTER TABLE assessment_point_entries
+              DROP CONSTRAINT assessment_point_entries_scale_id_fkey
+            """
+
+    execute """
+            ALTER TABLE assessment_point_entries
+              DROP CONSTRAINT assessment_point_entries_assessment_point_id_fkey
+            """,
+            """
+            ALTER TABLE assessment_point_entries
+              ADD CONSTRAINT assessment_point_entries_assessment_point_id_fkey
+                FOREIGN KEY (assessment_point_id)
+                  REFERENCES assessment_points(id)
+            """
+
+    execute """
+            ALTER TABLE assessment_point_entries
+              ADD CONSTRAINT assessment_point_entries_assessment_point_id_fkey
+                FOREIGN KEY (assessment_point_id, scale_id)
+                  REFERENCES assessment_points(id, scale_id)
+            """,
+            """
+            ALTER TABLE assessment_point_entries
+              DROP CONSTRAINT assessment_point_entries_assessment_point_id_fkey
+            """
+  end
+end


### PR DESCRIPTION
# Copilot sumary

This pull request includes a version update and a migration fix for foreign key constraints.

Version update:

* [`mix.exs`](diffhunk://#diff-dfa6f4ed74c90e5d4fda283d547d366586e690387289bcfd473e3fa5f9ace308L7-R7): Updated the project version from "2025.4.6-alpha.59" to "2025.4.6-alpha.60".

Migration fix:

* [`priv/repo/migrations/20250407011632_fix_assessment_point_entries_scale_id_fkey.exs`](diffhunk://#diff-7b6c2ea35207c036c3e9dc9746c9920fd77851df7e582d7e1da968c1ebd1e947R1-R70): Added a new migration to correct the foreign key constraints on the `assessment_point_entries` table. The migration drops and recreates the `assessment_point_entries_scale_id_fkey` to reference the `grading_scales` table and adjusts the `assessment_point_entries_assessment_point_id_fkey` to use a composite foreign key with `scale_id`.