### PR TITLE
add basic support to multiple schools

### DIFF
--- a/lib/lanttern/reporting.ex
+++ b/lib/lanttern/reporting.ex
@@ -128,11 +128,31 @@ defmodule Lanttern.Reporting do
   @doc """
   Gets a single report_card.
 
-  Raises `Ecto.NoResultsError` if the Report card does not exist.
+  Returns `nil` if the Report card does not exist.
 
   ## Options:
 
       - `:preloads` – preloads associated data
+
+  ## Examples
+
+      iex> get_report_card(123)
+      %ReportCard{}
+
+      iex> get_report_card(456)
+      nil
+
+  """
+  def get_report_card(id, opts \\ []) do
+    ReportCard
+    |> Repo.get(id)
+    |> maybe_preload(opts)
+  end
+
+  @doc """
+  Gets a single report_card.
+
+  Same as `get_report_card/2`, but raises `Ecto.NoResultsError` if the Report card does not exist.
 
   ## Examples
 

--- a/lib/lanttern/reporting.ex
+++ b/lib/lanttern/reporting.ex
@@ -32,6 +32,7 @@ defmodule Lanttern.Reporting do
 
   - `:preloads` – preloads associated data
   - `:strands_ids` – filter report cards by strands
+  - `:school_id` – filter report cards by school (based on school cycle)
   - `:cycles_ids` - filter report cards by cycles
   - `:parent_cycle_id` - filter report cards by subcycles of the given parent cycle
   - `:years_ids` - filter report cards by year
@@ -68,6 +69,15 @@ defmodule Lanttern.Reporting do
   defp apply_list_report_cards_opts(queryable, [{:cycles_ids, ids} | opts])
        when is_list(ids) and ids != [] do
     from(rc in queryable, where: rc.school_cycle_id in ^ids)
+    |> apply_list_report_cards_opts(opts)
+  end
+
+  defp apply_list_report_cards_opts(queryable, [{:school_id, id} | opts]) do
+    from(
+      rc in queryable,
+      join: sc in assoc(rc, :school_cycle),
+      where: sc.school_id == ^id
+    )
     |> apply_list_report_cards_opts(opts)
   end
 

--- a/lib/lanttern_web/helpers/grades_reports_helpers.ex
+++ b/lib/lanttern_web/helpers/grades_reports_helpers.ex
@@ -9,13 +9,15 @@ defmodule LantternWeb.GradesReportsHelpers do
   @doc """
   Generate list of grades reports to use as `Phoenix.HTML.Form.options_for_select/2` arg
 
+  View `GradesReports.list_grades_reports/1` for opts details.
+
   ## Examples
 
       iex> generate_grades_report_options()
       ["grades report name": 1, ...]
   """
-  def generate_grades_report_options() do
-    GradesReports.list_grades_reports()
+  def generate_grades_report_options(opts \\ []) do
+    GradesReports.list_grades_reports(opts)
     |> Enum.map(fn gr -> {gr.name, gr.id} end)
   end
 

--- a/lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex
+++ b/lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex
@@ -2,7 +2,7 @@ defmodule LantternWeb.GradesReportLive do
   use LantternWeb, :live_view
 
   alias Lanttern.GradesReports
-  # alias Lanttern.GradesReports.GradesReport
+  alias Lanttern.GradesReports.GradesReport
 
   # # local view components
   # alias LantternWeb.ReportCardLive.GradesReportGridSetupOverlayComponent
@@ -45,16 +45,13 @@ defmodule LantternWeb.GradesReportLive do
                grades_report_subjects: :subject
              ]
            ) do
-        nil ->
-          raise LantternWeb.NotFoundError
-
-        %{school_cycle: %{school_id: school_id}}
-        when school_id != socket.assigns.current_user.current_profile.school_id ->
-          # prevent access to other schools grades reports
-          raise LantternWeb.NotFoundError
-
-        grades_report ->
+        %GradesReport{school_cycle: %{school_id: school_id}} = grades_report
+        when school_id == socket.assigns.current_user.current_profile.school_id ->
           grades_report
+
+        _ ->
+          # nil or other schools grades reports
+          raise LantternWeb.NotFoundError
       end
 
     grades_report_cycles =

--- a/lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex
+++ b/lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex
@@ -45,8 +45,16 @@ defmodule LantternWeb.GradesReportLive do
                grades_report_subjects: :subject
              ]
            ) do
-        nil -> raise LantternWeb.NotFoundError
-        grades_report -> grades_report
+        nil ->
+          raise LantternWeb.NotFoundError
+
+        %{school_cycle: %{school_id: school_id}}
+        when school_id != socket.assigns.current_user.current_profile.school_id ->
+          # prevent access to other schools grades reports
+          raise LantternWeb.NotFoundError
+
+        grades_report ->
+          grades_report
       end
 
     grades_report_cycles =

--- a/lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex
@@ -2,6 +2,7 @@ defmodule LantternWeb.ReportCardLive do
   use LantternWeb, :live_view
 
   alias Lanttern.Reporting
+  alias Lanttern.Reporting.ReportCard
   import Lanttern.SupabaseHelpers, only: [object_url_to_render_url: 2]
 
   # page components
@@ -35,16 +36,13 @@ defmodule LantternWeb.ReportCardLive do
   defp assign_report_card(socket, %{"id" => id}) do
     report_card =
       case Reporting.get_report_card(id, preloads: [:year, school_cycle: :parent_cycle]) do
-        nil ->
-          raise LantternWeb.NotFoundError
-
-        %{school_cycle: %{school_id: school_id}}
-        when school_id != socket.assigns.current_user.current_profile.school_id ->
-          # prevent access to other schools report cards
-          raise LantternWeb.NotFoundError
-
-        report_card ->
+        %ReportCard{school_cycle: %{school_id: school_id}} = report_card
+        when school_id == socket.assigns.current_user.current_profile.school_id ->
           report_card
+
+        _ ->
+          # nil or access to other schools report cards
+          raise LantternWeb.NotFoundError
       end
 
     socket

--- a/lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex
@@ -24,19 +24,43 @@ defmodule LantternWeb.ReportCardLive do
   # lifecycle
 
   @impl true
-  def handle_params(%{"id" => id} = params, _url, socket) do
+  def mount(params, _session, socket) do
+    socket =
+      socket
+      |> assign_report_card(params)
+
+    {:ok, socket}
+  end
+
+  defp assign_report_card(socket, %{"id" => id}) do
+    report_card =
+      case Reporting.get_report_card(id, preloads: [:year, school_cycle: :parent_cycle]) do
+        nil ->
+          raise LantternWeb.NotFoundError
+
+        %{school_cycle: %{school_id: school_id}}
+        when school_id != socket.assigns.current_user.current_profile.school_id ->
+          # prevent access to other schools report cards
+          raise LantternWeb.NotFoundError
+
+        report_card ->
+          report_card
+      end
+
+    socket
+    |> assign(:report_card, report_card)
+    |> assign(
+      :cover_image_url,
+      object_url_to_render_url(report_card.cover_image_url, width: 1280, height: 640)
+    )
+    |> assign(:page_title, report_card.name)
+  end
+
+  @impl true
+  def handle_params(params, _url, socket) do
     socket =
       socket
       |> assign(:params, params)
-      |> assign_new(:report_card, fn ->
-        Reporting.get_report_card!(id, preloads: [:year, school_cycle: :parent_cycle])
-      end)
-      |> assign_new(
-        :cover_image_url,
-        fn %{report_card: report_card} ->
-          object_url_to_render_url(report_card.cover_image_url, width: 1280, height: 640)
-        end
-      )
       |> assign_current_tab(params)
       |> assign_is_editing(params)
 

--- a/lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex
+++ b/lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex
@@ -124,6 +124,7 @@
     id={@report_card.id}
     report_card={@report_card}
     navigate={@current_path}
+    parent_cycle_id={@report_card.school_cycle.parent_cycle_id}
     hide_submit
   />
   <:actions>

--- a/lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex
+++ b/lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex
@@ -92,7 +92,7 @@
     report_card={%ReportCard{}}
     navigate={fn report_card -> ~p"/report_cards/#{report_card}" end}
     hide_submit
-    parent_cycle_id={Map.get(@current_user.current_profile.current_school_cycle || %{}, :id)}
+    parent_cycle_id={@current_user.current_profile.current_school_cycle.id}
   />
   <:actions>
     <.button

--- a/lib/lanttern_web/live/pages/school/moment_cards_templates_component.ex
+++ b/lib/lanttern_web/live/pages/school/moment_cards_templates_component.ex
@@ -167,11 +167,12 @@ defmodule LantternWeb.SchoolLive.MomentCardsTemplatesComponent do
     school_id = socket.assigns.current_user.current_profile.school_id
 
     templates =
-      SchoolConfig.list_moment_cards_templates(schools_ids: [school_id])
+      SchoolConfig.list_moment_cards_templates(school_id: school_id)
 
     socket
     |> stream(:templates, templates)
     |> assign(:templates_count, length(templates))
+    |> assign(:templates_ids, Enum.map(templates, &"#{&1.id}"))
   end
 
   defp assign_template(
@@ -187,7 +188,9 @@ defmodule LantternWeb.SchoolLive.MomentCardsTemplatesComponent do
 
   defp assign_template(%{assigns: %{params: %{"id" => id}}} = socket) do
     template =
-      SchoolConfig.get_moment_card_template(id)
+      if id in socket.assigns.templates_ids do
+        SchoolConfig.get_moment_card_template(id)
+      end
 
     socket
     |> assign(:template, template)

--- a/lib/lanttern_web/live/pages/strands/id/about_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/about_component.ex
@@ -237,7 +237,8 @@ defmodule LantternWeb.StrandLive.AboutComponent do
     report_cards =
       Reporting.list_report_cards(
         preloads: :school_cycle,
-        strands_ids: [socket.assigns.strand.id]
+        strands_ids: [socket.assigns.strand.id],
+        school_id: socket.assigns.current_profile.school_id
       )
 
     socket

--- a/lib/lanttern_web/live/pages/strands/id/strand_live.html.heex
+++ b/lib/lanttern_web/live/pages/strands/id/strand_live.html.heex
@@ -65,6 +65,7 @@
     id="strand-about"
     strand={@strand}
     params={@params}
+    current_profile={@current_user.current_profile}
   />
   <.live_component
     :if={@live_action == :rubrics}

--- a/lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex
@@ -47,6 +47,7 @@ defmodule LantternWeb.Filters.ClassesFilterOverlayComponent do
             module={ClassSearchComponent}
             id={"#{@id}-class-search"}
             notify_component={@myself}
+            school_id={@current_user.current_profile.school_id}
             label={gettext("Search all school classes")}
           />
         </form>

--- a/lib/lanttern_web/live/shared/reporting/report_card_form_component.ex
+++ b/lib/lanttern_web/live/shared/reporting/report_card_form_component.ex
@@ -94,13 +94,12 @@ defmodule LantternWeb.Reporting.ReportCardFormComponent do
   @impl true
   def mount(socket) do
     year_options = TaxonomyHelpers.generate_year_options()
-    grades_report_options = GradesReportsHelpers.generate_grades_report_options()
 
     socket =
       socket
       |> assign(:class, nil)
       |> assign(:year_options, year_options)
-      |> assign(:grades_report_options, grades_report_options)
+      |> assign(:parent_cycle_id, nil)
       |> assign(:hide_submit, false)
       |> assign(:is_removing_cover, false)
       |> allow_upload(:cover,
@@ -128,6 +127,7 @@ defmodule LantternWeb.Reporting.ReportCardFormComponent do
 
     socket
     |> assign_cycle_options()
+    |> assign_grades_report_options()
     |> assign_form(changeset)
     |> assign(:initialized, true)
   end
@@ -135,8 +135,30 @@ defmodule LantternWeb.Reporting.ReportCardFormComponent do
   defp initialize(socket), do: socket
 
   defp assign_cycle_options(socket) do
-    cycle_options = SchoolsHelpers.generate_cycle_options(subcycles_only: true)
+    opts = [subcycles_only: true]
+
+    opts =
+      case socket.assigns.parent_cycle_id do
+        parent_cycle_id when is_integer(parent_cycle_id) ->
+          [{:subcycles_of_parent_id, parent_cycle_id} | opts]
+
+        _ ->
+          opts
+      end
+
+    cycle_options = SchoolsHelpers.generate_cycle_options(opts)
     assign(socket, :cycle_options, cycle_options)
+  end
+
+  defp assign_grades_report_options(socket) do
+    opts =
+      case socket.assigns.parent_cycle_id do
+        parent_cycle_id when is_integer(parent_cycle_id) -> [school_cycle_id: parent_cycle_id]
+        _ -> []
+      end
+
+    grades_report_options = GradesReportsHelpers.generate_grades_report_options(opts)
+    assign(socket, :grades_report_options, grades_report_options)
   end
 
   @impl true

--- a/lib/lanttern_web/live/shared/schools/class_search_component.ex
+++ b/lib/lanttern_web/live/shared/schools/class_search_component.ex
@@ -1,6 +1,14 @@
 defmodule LantternWeb.Schools.ClassSearchComponent do
   @moduledoc """
-  Renders a `Class` search component
+  Renders a `Class` search component.
+
+  ### Supported attrs
+
+  - `label` - string
+  - `notify_component`/`notify_parent`
+  - `school_id` - filter search results by school
+  - `class` - any
+  - `refocus_on_select` - string. `"false"` (default) or `"true"`
   """
 
   use LantternWeb, :live_component
@@ -87,6 +95,7 @@ defmodule LantternWeb.Schools.ClassSearchComponent do
       socket
       |> assign(:label, nil)
       |> assign(:class, nil)
+      |> assign(:school_id, nil)
       |> assign(:refocus_on_select, "false")
       |> stream(:classes, [])
 
@@ -97,10 +106,17 @@ defmodule LantternWeb.Schools.ClassSearchComponent do
 
   @impl true
   def handle_event("search", %{"query" => query}, socket) do
+    opts =
+      if socket.assigns.school_id do
+        [schools_ids: [socket.assigns.school_id]]
+      else
+        []
+      end
+
     # search when more than 3 characters were typed
     classes =
       if String.length(query) > 3,
-        do: Schools.search_classes(query),
+        do: Schools.search_classes(query, opts),
         else: []
 
     results_simplified = Enum.map(classes, &%{id: &1.id})

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2025.4.8-alpha.61",
+      version: "2025.4.14-alpha.61",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -80,7 +80,7 @@ msgstr ""
 msgid "You're logged in as"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:67
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:68
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:33
 #: lib/lanttern_web/live/shared/filters/inline_filters_component.ex:33
@@ -88,7 +88,7 @@ msgstr ""
 msgid "Apply filters"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:65
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:66
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:56
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:31
 #, elixir-autogen, elixir-format
@@ -100,7 +100,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:167
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:118
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:125
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:135
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:136
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:142
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:192
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:133
@@ -108,7 +108,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/moment_cards_templates_component.ex:107
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:91
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:136
-#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:123
+#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:124
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:101
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:99
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:113
@@ -116,7 +116,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:261
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:126
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:154
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:59
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:60
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:50
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:64
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:55
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:56
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:46
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:21
 #, elixir-autogen, elixir-format
@@ -163,7 +163,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:170
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:121
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:128
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:138
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:139
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:145
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:195
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:136
@@ -171,7 +171,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/moment_cards_templates_component.ex:110
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:94
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:139
-#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:126
+#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:127
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:104
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:102
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:116
@@ -435,7 +435,7 @@ msgid "Delete"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:48
-#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:109
+#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Edit strand"
 msgstr ""
@@ -821,10 +821,10 @@ msgstr ""
 #: lib/lanttern/learning_context.ex:678
 #: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:243
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:272
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:304
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:220
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:248
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:277
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:309
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:230
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:261
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:297
@@ -867,21 +867,21 @@ msgstr ""
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr ""
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:36
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:38
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:57
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:59
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:41
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:43
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1096,12 +1096,12 @@ msgid "Error deleting curriculum item"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.ex:153
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:190
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Error deleting grade report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:74
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Error deleting report card"
 msgstr ""
@@ -1153,7 +1153,7 @@ msgstr ""
 msgid "Final grade"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:300
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:305
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:326
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
@@ -1344,9 +1344,9 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:243
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:272
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:220
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:248
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:277
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:230
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:261
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:297
@@ -1380,7 +1380,7 @@ msgstr ""
 msgid "Reorder strands reports"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:66
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Report card deleted"
 msgstr ""
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Save self-assessments"
 msgstr ""
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:47
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:49
 #, elixir-autogen, elixir-format
 msgid "1 grade partially updated (only composition, manual grade not changed)"
 msgid_plural "%{count} grades partially updated (only compositions, manual grades not changed)"
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:63
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:65
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no composition entries)"
 msgid_plural "%{count} grades skipped (no composition entries)"
@@ -2659,7 +2659,7 @@ msgstr[1] ""
 msgid "%{grades_report} grid configuration"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:207
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "All final grades calculated succesfully"
 msgstr ""
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "Error deleting student grade report final entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:173
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:178
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_grid_configuration_overlay_component.ex:374
 #, elixir-autogen, elixir-format
 msgid "Error updating final grades visibility"
@@ -2753,7 +2753,7 @@ msgstr ""
 msgid "Final grades visibility"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:295
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "No subcycle entries for this subject"
 msgstr ""
@@ -2769,7 +2769,7 @@ msgstr ""
 msgid "Save student grades report final entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:235
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Student final grades calculated succesfully"
 msgstr ""
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "Student grades report final entry updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:264
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Students final subject grades calculated succesfully"
 msgstr ""
@@ -3096,7 +3096,7 @@ msgid "Filter strands by cycle"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.ex:145
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:182
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Grades report deleted"
 msgstr ""
@@ -3251,7 +3251,7 @@ msgstr ""
 msgid "Rubric deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:50
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Search all school classes"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -80,7 +80,7 @@ msgstr ""
 msgid "You're logged in as"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:67
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:68
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:33
 #: lib/lanttern_web/live/shared/filters/inline_filters_component.ex:33
@@ -88,7 +88,7 @@ msgstr ""
 msgid "Apply filters"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:65
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:66
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:56
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:31
 #, elixir-autogen, elixir-format
@@ -100,7 +100,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:167
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:118
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:125
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:135
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:136
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:142
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:192
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:133
@@ -108,7 +108,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/moment_cards_templates_component.ex:107
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:91
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:136
-#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:123
+#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:124
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:101
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:99
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:113
@@ -116,7 +116,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:261
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:126
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:154
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:59
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:60
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:50
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:64
@@ -140,7 +140,7 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:55
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:56
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:46
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:21
 #, elixir-autogen, elixir-format
@@ -163,7 +163,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:170
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:121
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:128
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:138
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:139
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:145
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:195
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:136
@@ -171,7 +171,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/moment_cards_templates_component.ex:110
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:94
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:139
-#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:126
+#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:127
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:104
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:102
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:116
@@ -435,7 +435,7 @@ msgid "Delete"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:48
-#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:109
+#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Edit strand"
 msgstr ""
@@ -821,10 +821,10 @@ msgstr ""
 #: lib/lanttern/learning_context.ex:678
 #: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:243
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:272
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:304
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:220
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:248
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:277
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:309
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:230
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:261
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:297
@@ -867,21 +867,21 @@ msgstr ""
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr ""
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:36
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:38
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:57
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:59
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:41
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:43
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1096,12 +1096,12 @@ msgid "Error deleting curriculum item"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.ex:153
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:190
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Error deleting grade report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:74
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Error deleting report card"
 msgstr ""
@@ -1153,7 +1153,7 @@ msgstr ""
 msgid "Final grade"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:300
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:305
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:326
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
@@ -1344,9 +1344,9 @@ msgstr ""
 msgid "Overview"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:243
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:272
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:220
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:248
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:277
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:230
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:261
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:297
@@ -1380,7 +1380,7 @@ msgstr ""
 msgid "Reorder strands reports"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:66
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Report card deleted"
 msgstr ""
@@ -2235,7 +2235,7 @@ msgstr ""
 msgid "Save self-assessments"
 msgstr ""
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:47
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:49
 #, elixir-autogen, elixir-format
 msgid "1 grade partially updated (only composition, manual grade not changed)"
 msgid_plural "%{count} grades partially updated (only compositions, manual grades not changed)"
@@ -2647,7 +2647,7 @@ msgstr ""
 msgid "Time"
 msgstr ""
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:63
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:65
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 grade calculation skipped (no composition entries)"
 msgid_plural "%{count} grades skipped (no composition entries)"
@@ -2659,7 +2659,7 @@ msgstr[1] ""
 msgid "%{grades_report} grid configuration"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:207
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All final grades calculated succesfully"
 msgstr ""
@@ -2722,7 +2722,7 @@ msgstr ""
 msgid "Error deleting student grade report final entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:173
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:178
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_grid_configuration_overlay_component.ex:374
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error updating final grades visibility"
@@ -2753,7 +2753,7 @@ msgstr ""
 msgid "Final grades visibility"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:295
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "No subcycle entries for this subject"
 msgstr ""
@@ -2769,7 +2769,7 @@ msgstr ""
 msgid "Save student grades report final entry"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:235
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:240
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student final grades calculated succesfully"
 msgstr ""
@@ -2789,7 +2789,7 @@ msgstr ""
 msgid "Student grades report final entry updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:264
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Students final subject grades calculated succesfully"
 msgstr ""
@@ -3096,7 +3096,7 @@ msgid "Filter strands by cycle"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.ex:145
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:182
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:187
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Grades report deleted"
 msgstr ""
@@ -3251,7 +3251,7 @@ msgstr ""
 msgid "Rubric deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:50
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Search all school classes"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -80,7 +80,7 @@ msgstr "Sair"
 msgid "You're logged in as"
 msgstr "Você está acessando como"
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:67
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:68
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:33
 #: lib/lanttern_web/live/shared/filters/inline_filters_component.ex:33
@@ -88,7 +88,7 @@ msgstr "Você está acessando como"
 msgid "Apply filters"
 msgstr "Aplicar filtros"
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:65
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:66
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:56
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:31
 #, elixir-autogen, elixir-format
@@ -100,7 +100,7 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:167
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:118
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:125
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:135
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:136
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:142
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:192
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:133
@@ -108,7 +108,7 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/school/moment_cards_templates_component.ex:107
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:91
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:136
-#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:123
+#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:124
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:101
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:99
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:113
@@ -116,7 +116,7 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:261
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:126
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:154
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:59
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:60
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:50
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:64
@@ -140,7 +140,7 @@ msgstr "Aplicando filtros..."
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:55
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:56
 #: lib/lanttern_web/live/shared/filters/cycles_filter_overlay_component.ex:46
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:21
 #, elixir-autogen, elixir-format
@@ -163,7 +163,7 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:170
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:121
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:128
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:138
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:139
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:145
 #: lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex:195
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:136
@@ -171,7 +171,7 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/pages/school/moment_cards_templates_component.ex:110
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:94
 #: lib/lanttern_web/live/pages/strands/id/moments_component.ex:139
-#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:126
+#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:127
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:104
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:102
 #: lib/lanttern_web/live/pages/strands/moment/id/moment_live.html.heex:116
@@ -435,7 +435,7 @@ msgid "Delete"
 msgstr "Deletar"
 
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:48
-#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:109
+#: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:110
 #, elixir-autogen, elixir-format
 msgid "Edit strand"
 msgstr "Editar trilha"
@@ -821,10 +821,10 @@ msgstr "Salvar momento"
 #: lib/lanttern/learning_context.ex:678
 #: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:243
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:272
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:304
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:220
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:248
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:277
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:309
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:230
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:261
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:297
@@ -867,21 +867,21 @@ msgstr "Você ainda não poussui anotações para este momento"
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr "Você já deve possuir registros para este ponto de avaliação. Alterar a escala quando registros já existem não é permitido, pois acarretaria perda de dados."
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:36
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:38
 #, elixir-autogen, elixir-format
 msgid "1 grade created"
 msgid_plural "%{count} grades created"
 msgstr[0] "1 nota criada"
 msgstr[1] "%{count} notas criadas"
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:57
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:59
 #, elixir-autogen, elixir-format
 msgid "1 grade removed"
 msgid_plural "%{count} grades removed"
 msgstr[0] "1 nota removida"
 msgstr[1] "%{count} notas removidas"
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:41
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:43
 #, elixir-autogen, elixir-format
 msgid "1 grade updated"
 msgid_plural "%{count} grades updated"
@@ -1096,12 +1096,12 @@ msgid "Error deleting curriculum item"
 msgstr "Erro ao deletar item curricular"
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.ex:153
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:190
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:195
 #, elixir-autogen, elixir-format
 msgid "Error deleting grade report"
 msgstr "Erro ao deletar relatório de nota"
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:74
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:96
 #, elixir-autogen, elixir-format
 msgid "Error deleting report card"
 msgstr "Erro ao deletar report card"
@@ -1153,7 +1153,7 @@ msgstr "Filtrar itens curriculares por ano"
 msgid "Final grade"
 msgstr "Nota final"
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:300
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:305
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:326
 #, elixir-autogen, elixir-format
 msgid "Grade calculated succesfully"
@@ -1344,9 +1344,9 @@ msgstr "Valor normalizado"
 msgid "Overview"
 msgstr "Visão geral"
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:215
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:243
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:272
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:220
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:248
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:277
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:230
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:261
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:297
@@ -1380,7 +1380,7 @@ msgstr "Remover"
 msgid "Reorder strands reports"
 msgstr "Reordenzar relatórios de trilha"
 
-#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:66
+#: lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex:88
 #, elixir-autogen, elixir-format
 msgid "Report card deleted"
 msgstr "Report card deletado"
@@ -2235,7 +2235,7 @@ msgstr "Você está registrando autoavaliações de estudantes"
 msgid "Save self-assessments"
 msgstr "Salvar autoavaliações"
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:47
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:49
 #, elixir-autogen, elixir-format
 msgid "1 grade partially updated (only composition, manual grade not changed)"
 msgid_plural "%{count} grades partially updated (only compositions, manual grades not changed)"
@@ -2647,7 +2647,7 @@ msgstr "Filtrar registros de estudantes por status"
 msgid "Time"
 msgstr "Horário"
 
-#: lib/lanttern_web/helpers/grades_reports_helpers.ex:63
+#: lib/lanttern_web/helpers/grades_reports_helpers.ex:65
 #, elixir-autogen, elixir-format
 msgid "1 grade calculation skipped (no composition entries)"
 msgid_plural "%{count} grades skipped (no composition entries)"
@@ -2659,7 +2659,7 @@ msgstr[1] "%{count} cálculos de nota ignorados (sem registros da composição)"
 msgid "%{grades_report} grid configuration"
 msgstr "configuração da matriz de %{grades_report}"
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:207
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:212
 #, elixir-autogen, elixir-format
 msgid "All final grades calculated succesfully"
 msgstr "Todas notas finais calculadas com sucesso"
@@ -2722,7 +2722,7 @@ msgstr "Editar registro final do relatório de notas de estudante"
 msgid "Error deleting student grade report final entry"
 msgstr "Erro ao deletar registro final do relatório de nota de estudante"
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:173
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:178
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_grid_configuration_overlay_component.ex:374
 #, elixir-autogen, elixir-format
 msgid "Error updating final grades visibility"
@@ -2753,7 +2753,7 @@ msgstr "Notas finais não estão visíveis"
 msgid "Final grades visibility"
 msgstr "Visibilidade das notas finais"
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:295
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:300
 #, elixir-autogen, elixir-format
 msgid "No subcycle entries for this subject"
 msgstr "Nenhum registro de subciclo para esta disciplina"
@@ -2769,7 +2769,7 @@ msgstr "Visibilidade do ciclo maior"
 msgid "Save student grades report final entry"
 msgstr "Salvar registro de relatório de notas de estudante"
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:235
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:240
 #, elixir-autogen, elixir-format
 msgid "Student final grades calculated succesfully"
 msgstr "Notas finais do estudante calculadas com sucesso"
@@ -2789,7 +2789,7 @@ msgstr "Registro final do relatório de notas de estudante criado com sucesso"
 msgid "Student grades report final entry updated successfully"
 msgstr "Registro final do relatório de notas de estudante atualizado com sucesso"
 
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:264
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:269
 #, elixir-autogen, elixir-format
 msgid "Students final subject grades calculated succesfully"
 msgstr "Notas finais dos estudantes na disciplina calculadas com sucesso"
@@ -3096,7 +3096,7 @@ msgid "Filter strands by cycle"
 msgstr "Filtrar trilhas por ciclo"
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.ex:145
-#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:182
+#: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:187
 #, elixir-autogen, elixir-format
 msgid "Grades report deleted"
 msgstr "Relatório de notas deletado"
@@ -3251,7 +3251,7 @@ msgstr "Imagem de capa do report card"
 msgid "Rubric deleted"
 msgstr "Rubrica deletada"
 
-#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:50
+#: lib/lanttern_web/live/shared/filters/classes_filter_overlay_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Search all school classes"
 msgstr "Buscar todas as turmas da escola"

--- a/test/lanttern/reporting_test.exs
+++ b/test/lanttern/reporting_test.exs
@@ -41,6 +41,18 @@ defmodule Lanttern.ReportingTest do
       assert expected.id == report_card.id
     end
 
+    test "list_report_cards/1 with school filter returns all school report_cards" do
+      cycle = SchoolsFixtures.cycle_fixture()
+      report_card = report_card_fixture(%{school_cycle_id: cycle.id})
+
+      # extra report cards for filtering test
+      report_card_fixture()
+
+      [expected] = Reporting.list_report_cards(school_id: cycle.school_id)
+
+      assert expected.id == report_card.id
+    end
+
     test "list_report_cards/1 with year/cycle filters returns all filtered report_cards" do
       year = TaxonomyFixtures.year_fixture()
       cycle = SchoolsFixtures.cycle_fixture()

--- a/test/lanttern_web/live/pages/grades_reports/id/grades_report_live_test.exs
+++ b/test/lanttern_web/live/pages/grades_reports/id/grades_report_live_test.exs
@@ -10,8 +10,12 @@ defmodule LantternWeb.GradesReportLiveTest do
   setup [:register_and_log_in_staff_member]
 
   describe "Grades report live view basic navigation" do
-    test "disconnected and connected mount", %{conn: conn} do
-      grades_report = grades_report_fixture(%{name: "Grades report ABC"})
+    test "disconnected and connected mount", %{conn: conn, user: user} do
+      cycle = SchoolsFixtures.cycle_fixture(%{school_id: user.current_profile.school_id})
+
+      grades_report =
+        grades_report_fixture(%{name: "Grades report ABC", school_cycle_id: cycle.id})
+
       conn = get(conn, "#{@live_view_base_path}/#{grades_report.id}")
 
       assert html_response(conn, 200) =~ ~r"<h1 .+>\s*Grades report ABC\s*<\/h1>"
@@ -19,8 +23,13 @@ defmodule LantternWeb.GradesReportLiveTest do
       {:ok, _view, _html} = live(conn)
     end
 
-    test "show grades report", %{conn: conn} do
-      cycle = SchoolsFixtures.cycle_fixture(%{name: "Some cycle 000"})
+    test "show grades report", %{conn: conn, user: user} do
+      cycle =
+        SchoolsFixtures.cycle_fixture(%{
+          name: "Some cycle 000",
+          school_id: user.current_profile.school_id
+        })
+
       scale = GradingFixtures.scale_fixture(%{name: "Some scale AZ", type: "ordinal"})
 
       _ordinal_value =
@@ -41,6 +50,14 @@ defmodule LantternWeb.GradesReportLiveTest do
       assert view |> has_element?("div", "Some cycle 000")
       assert view |> has_element?("div", "Some scale AZ")
       assert view |> has_element?("span", "Ordinal value A")
+    end
+
+    test "prevent user access to other schools grades reports", %{conn: conn} do
+      grades_report = grades_report_fixture()
+
+      assert_raise(LantternWeb.NotFoundError, fn ->
+        live(conn, "#{@live_view_base_path}/#{grades_report.id}")
+      end)
     end
   end
 end


### PR DESCRIPTION
added some guards to prevent users accessing information from other schools (specially in grades reports and report cards-related contexts).

---

# Copilot summary

This pull request includes several changes to the `Lanttern` project, focusing on enhancing filtering capabilities, improving the handling of report cards, and updating various components to ensure proper data handling and user access. Below are the most important changes grouped by theme:

### Filtering Enhancements:
* Added `:school_id` filter to the `apply_list_report_cards_opts` function to filter report cards by school. (`lib/lanttern/reporting.ex`) [[1]](diffhunk://#diff-943e79615935a12a6af3858e5e4ebf28550695645881518f5fcc3eb802bf65b5R35) [[2]](diffhunk://#diff-943e79615935a12a6af3858e5e4ebf28550695645881518f5fcc3eb802bf65b5R75-R83)
* Updated the `ClassSearchComponent` to support filtering search results by `school_id`. (`lib/lanttern_web/live/shared/schools/class_search_component.ex`) [[1]](diffhunk://#diff-d2b68b62b5589e063a0c0388673c491387e071024812216d451976a9b1bbd50dL3-R11) [[2]](diffhunk://#diff-d2b68b62b5589e063a0c0388673c491387e071024812216d451976a9b1bbd50dR98) [[3]](diffhunk://#diff-d2b68b62b5589e063a0c0388673c491387e071024812216d451976a9b1bbd50dR109-R119)

### Report Card Handling:
* Modified the `get_report_card/2` function to return `nil` instead of raising an error if the report card does not exist. (`lib/lanttern/reporting.ex`)
* Updated `GradesReportLive` and `ReportCardLive` to ensure report cards are only accessible by users from the same school. (`lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex`, `lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex`) [[1]](diffhunk://#diff-6b24554e71dfe4292c9e0b97e9c51b76b31385572ce8c391b270d4fce8f0cbbcL48-R54) [[2]](diffhunk://#diff-f03e6ad3251f38b4b61dd199f21eeb85dc006782af2706d9ac65093f2ea4eb1aL27-R61)

### Component Updates:
* Enhanced the `GradesReportsHelpers` to accept options for generating grades report options. (`lib/lanttern_web/helpers/grades_reports_helpers.ex`)
* Updated `MomentCardsTemplatesComponent` to use `school_id` for listing templates and added template ID assignments. (`lib/lanttern_web/live/pages/school/moment_cards_templates_component.ex`) [[1]](diffhunk://#diff-08c639adec275bbc34e98287594865df89ad2ab4a0562755316aa04b9f51de2eL170-R175) [[2]](diffhunk://#diff-08c639adec275bbc34e98287594865df89ad2ab4a0562755316aa04b9f51de2eR191-R193)

### Miscellaneous Changes:
* Updated the project version in `mix.exs` from `2025.4.8-alpha.61` to `2025.4.14-alpha.61`. (`mix.exs`)
* Adjusted gettext references for localization in various components. (`priv/gettext/default.pot`) [[1]](diffhunk://#diff-466a9f680bc4f0e6d02bff66142a6eb45567dc4ba46e87921f6336d98b8e33e2L83-R91) [[2]](diffhunk://#diff-466a9f680bc4f0e6d02bff66142a6eb45567dc4ba46e87921f6336d98b8e33e2L103-R119) [[3]](diffhunk://#diff-466a9f680bc4f0e6d02bff66142a6eb45567dc4ba46e87921f6336d98b8e33e2L143-R143) [[4]](diffhunk://#diff-466a9f680bc4f0e6d02bff66142a6eb45567dc4ba46e87921f6336d98b8e33e2L166-R174) [[5]](diffhunk://#diff-466a9f680bc4f0e6d02bff66142a6eb45567dc4ba46e87921f6336d98b8e33e2L438-R438)