### PR TITLE
student tags

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -1,0 +1,33 @@
+# This file contains the configuration for Credo and you are probably reading
+# this after creating it with `mix credo.gen.config`.
+#
+# If you find anything wrong or unclear in this file, please report an
+# issue on GitHub: https://github.com/rrrene/credo/issues
+#
+%{
+  #
+  # You can have as many configs as you like in the `configs:` field.
+  configs: [
+    %{
+      #
+      # Run any config using `mix credo -C <name>`. If no config name is given
+      # "default" is used.
+      #
+      name: "default",
+      #
+      # You can customize the parameters of any check by adding a second element
+      # to the tuple.
+      #
+      # To disable a check put `false` as second element:
+      #
+      #     {Credo.Check.Design.DuplicatedCode, false}
+      #
+      checks: %{
+        disabled: [
+          {Credo.Check.Design.AliasUsage, []},
+          {Credo.Check.Readability.MaxLineLength, []}
+        ]
+      }
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ npm-debug.log
 
 # env variables
 .env
+
+# windsurf rules
+.windsurfrules

--- a/lib/lanttern/assessments.ex
+++ b/lib/lanttern/assessments.ex
@@ -241,7 +241,7 @@ defmodule Lanttern.Assessments do
       %Ecto.Changeset{data: %AssessmentPoint{}}
 
   """
-  def new_assessment_point_changeset() do
+  def new_assessment_point_changeset do
     %AssessmentPoint{datetime: DateTime.utc_now()}
     |> change_assessment_point()
   end

--- a/lib/lanttern/assessments/assessment_point.ex
+++ b/lib/lanttern/assessments/assessment_point.ex
@@ -13,10 +13,10 @@ defmodule Lanttern.Assessments.AssessmentPoint do
   alias Lanttern.Assessments.AssessmentPointEntry
   alias Lanttern.Assessments.Feedback
   alias Lanttern.Curricula.CurriculumItem
+  alias Lanttern.Grading.GradeComponent
   alias Lanttern.Grading.Scale
   alias Lanttern.LearningContext.Moment
   alias Lanttern.LearningContext.Strand
-  alias Lanttern.Grading.GradeComponent
   alias Lanttern.Rubrics.Rubric
   alias Lanttern.Schools.Class
 

--- a/lib/lanttern/assessments/assessment_point_entry.ex
+++ b/lib/lanttern/assessments/assessment_point_entry.ex
@@ -27,10 +27,10 @@ defmodule Lanttern.Assessments.AssessmentPointEntry do
   alias Lanttern.Assessments.AssessmentPointEntryEvidence
   alias Lanttern.Assessments.Feedback
   alias Lanttern.Attachments.Attachment
-  alias Lanttern.Schools.Student
-  alias Lanttern.Grading.Scale
   alias Lanttern.Grading.OrdinalValue
+  alias Lanttern.Grading.Scale
   alias Lanttern.Rubrics.Rubric
+  alias Lanttern.Schools.Student
 
   @type t :: %__MODULE__{
           id: pos_integer() | nil,

--- a/lib/lanttern/assessments/feedback.ex
+++ b/lib/lanttern/assessments/feedback.ex
@@ -6,10 +6,10 @@ defmodule Lanttern.Assessments.Feedback do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Lanttern.Identity.Profile
-  alias Lanttern.Schools.Student
   alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.Conversation.Comment
+  alias Lanttern.Identity.Profile
+  alias Lanttern.Schools.Student
 
   @type t :: %__MODULE__{
           id: pos_integer(),

--- a/lib/lanttern/assessments_log.ex
+++ b/lib/lanttern/assessments_log.ex
@@ -6,8 +6,8 @@ defmodule Lanttern.AssessmentsLog do
   import Ecto.Query, warn: false
   alias Lanttern.Repo
 
-  alias Lanttern.AssessmentsLog.AssessmentPointEntryLog
   alias Lanttern.Assessments.AssessmentPointEntry
+  alias Lanttern.AssessmentsLog.AssessmentPointEntryLog
 
   @doc """
   Returns the list of assessment_point_entries logs.

--- a/lib/lanttern/attachments/attachment.ex
+++ b/lib/lanttern/attachments/attachment.ex
@@ -10,12 +10,12 @@ defmodule Lanttern.Attachments.Attachment do
   alias Lanttern.Assessments.AssessmentPointEntry
   alias Lanttern.Assessments.AssessmentPointEntryEvidence
   alias Lanttern.Identity.Profile
+  alias Lanttern.LearningContext.MomentCard
+  alias Lanttern.LearningContext.MomentCardAttachment
   alias Lanttern.Notes.Note
   alias Lanttern.Notes.NoteAttachment
   alias Lanttern.StudentsCycleInfo.StudentCycleInfo
   alias Lanttern.StudentsCycleInfo.StudentCycleInfoAttachment
-  alias Lanttern.LearningContext.MomentCard
-  alias Lanttern.LearningContext.MomentCardAttachment
 
   @type t :: %__MODULE__{
           id: pos_integer(),
@@ -76,7 +76,7 @@ defmodule Lanttern.Attachments.Attachment do
           [link: gettext("Invalid link format")]
 
         {:ok, %URI{scheme: scheme}} when scheme not in ["https", "http"] ->
-          [link: gettext("Links should start with \"https://\" or \"http://\"")]
+          [link: gettext(~s(Links should start with "https://" or "http://"))]
 
         {:ok, _} ->
           []

--- a/lib/lanttern/bncc.ex
+++ b/lib/lanttern/bncc.ex
@@ -21,9 +21,10 @@ defmodule Lanttern.BNCC do
   """
 
   import Ecto.Query, warn: false
+  alias Lanttern.Repo
+
   alias NimbleCSV.RFC4180, as: CSV
 
-  alias Lanttern.Repo
   alias Lanttern.BNCC.HabilidadeBNCCEF
   alias Lanttern.Curricula.Curriculum
   alias Lanttern.Curricula.CurriculumComponent
@@ -64,7 +65,7 @@ defmodule Lanttern.BNCC do
   @doc """
   Check if BNCC curriculum already exists.
   """
-  def bncc_registered?() do
+  def bncc_registered? do
     case Repo.get_by(Curriculum, code: @bncc) do
       nil -> false
       _bncc -> true
@@ -123,7 +124,7 @@ defmodule Lanttern.BNCC do
       iex> seed_bncc()
       {:error, error}
   """
-  def seed_bncc() do
+  def seed_bncc do
     case Repo.get_by(Curriculum, code: @bncc) do
       nil ->
         %{id: bncc_id} = Repo.insert!(%Curriculum{code: @bncc, name: "BNCC"})
@@ -141,7 +142,7 @@ defmodule Lanttern.BNCC do
     end
   end
 
-  defp generate_subjects_and_years_maps() do
+  defp generate_subjects_and_years_maps do
     with subjects_code_id_map <- Taxonomy.generate_subjects_code_id_map(),
          years_code_id_map <- Taxonomy.generate_years_code_id_map() do
       %{
@@ -463,7 +464,7 @@ defmodule Lanttern.BNCC do
       [%Subject{}, ...]
 
   """
-  def list_bncc_ef_subjects() do
+  def list_bncc_ef_subjects do
     from(
       s in Subject,
       where: s.code in @ef_subjects_codes
@@ -480,7 +481,7 @@ defmodule Lanttern.BNCC do
       [%Year{}, ...]
 
   """
-  def list_bncc_ef_years() do
+  def list_bncc_ef_years do
     from(
       y in Year,
       where: y.code in @ef_years_codes

--- a/lib/lanttern/conversation.ex
+++ b/lib/lanttern/conversation.ex
@@ -5,8 +5,9 @@ defmodule Lanttern.Conversation do
 
   import Ecto.Query, warn: false
 
-  import Lanttern.RepoHelpers
   alias Lanttern.Repo
+  import Lanttern.RepoHelpers
+
   alias Lanttern.Conversation.Comment
 
   @doc """

--- a/lib/lanttern/filters.ex
+++ b/lib/lanttern/filters.ex
@@ -6,11 +6,11 @@ defmodule Lanttern.Filters do
   import Ecto.Query, warn: false
   alias Lanttern.Repo
 
+  alias Lanttern.Filters.ProfileReportCardFilter
+  alias Lanttern.Filters.ProfileStrandFilter
+  alias Lanttern.Identity.User
   alias Lanttern.Personalization
   alias Lanttern.Personalization.ProfileSettings
-  alias Lanttern.Filters.ProfileStrandFilter
-  alias Lanttern.Filters.ProfileReportCardFilter
-  alias Lanttern.Identity.User
 
   @doc """
   Set current profile filters.
@@ -66,7 +66,7 @@ defmodule Lanttern.Filters do
       [%ProfileStrandFilter{}, ...]
 
   """
-  def list_profile_strand_filters() do
+  def list_profile_strand_filters do
     Repo.all(ProfileStrandFilter)
   end
 

--- a/lib/lanttern/google_token.ex
+++ b/lib/lanttern/google_token.ex
@@ -21,7 +21,7 @@ defmodule Lanttern.GoogleToken do
     |> add_claim("exp", fn -> generate_exp() end, &(&1 > Timex.now() |> Timex.to_unix()))
   end
 
-  defp generate_exp() do
+  defp generate_exp do
     Timex.now()
     |> Timex.add(Timex.Duration.from_days(30))
   end

--- a/lib/lanttern/identity.ex
+++ b/lib/lanttern/identity.ex
@@ -5,12 +5,13 @@ defmodule Lanttern.Identity do
 
   import Ecto.Query, warn: false
 
-  import Lanttern.RepoHelpers
   alias Lanttern.Repo
-  alias Lanttern.Identity.User
-  alias Lanttern.Identity.UserToken
-  alias Lanttern.Identity.UserNotifier
+  import Lanttern.RepoHelpers
+
   alias Lanttern.Identity.Profile
+  alias Lanttern.Identity.User
+  alias Lanttern.Identity.UserNotifier
+  alias Lanttern.Identity.UserToken
   alias Lanttern.Personalization
   alias Lanttern.Schools
   alias Lanttern.Schools.Cycle

--- a/lib/lanttern/identity/profile.ex
+++ b/lib/lanttern/identity/profile.ex
@@ -8,10 +8,10 @@ defmodule Lanttern.Identity.Profile do
 
   alias Lanttern.Identity.User
   alias Lanttern.Notes.Note
+  alias Lanttern.Personalization.ProfileSettings
   alias Lanttern.Schools.Cycle
   alias Lanttern.Schools.StaffMember
   alias Lanttern.Schools.Student
-  alias Lanttern.Personalization.ProfileSettings
 
   @type t :: %__MODULE__{
           id: pos_integer(),

--- a/lib/lanttern/ilp.ex
+++ b/lib/lanttern/ilp.ex
@@ -593,6 +593,7 @@ defmodule Lanttern.ILP do
   ## Options
 
   - `:classes_ids` - filter results by classes
+  - `:preload_student_tags`
 
   ## Examples
 
@@ -638,6 +639,14 @@ defmodule Lanttern.ILP do
       join: c in assoc(s, :classes),
       where: c.id in ^classes_ids,
       group_by: s.id
+    )
+    |> apply_list_students_and_ilps_opts(opts)
+  end
+
+  defp apply_list_students_and_ilps_opts(queryable, [{:preload_student_tags, true} | opts]) do
+    from(
+      s in queryable,
+      preload: [:tags]
     )
     |> apply_list_students_and_ilps_opts(opts)
   end

--- a/lib/lanttern/ilp/ilp_component.ex
+++ b/lib/lanttern/ilp/ilp_component.ex
@@ -7,8 +7,8 @@ defmodule Lanttern.ILP.ILPComponent do
   import Ecto.Changeset
 
   alias Lanttern.ILP.ILPEntry
-  alias Lanttern.ILP.ILPTemplate
   alias Lanttern.ILP.ILPSection
+  alias Lanttern.ILP.ILPTemplate
 
   @type t :: %__MODULE__{
           id: pos_integer(),

--- a/lib/lanttern/ilp/ilp_section.ex
+++ b/lib/lanttern/ilp/ilp_section.ex
@@ -6,8 +6,8 @@ defmodule Lanttern.ILP.ILPSection do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Lanttern.ILP.ILPTemplate
   alias Lanttern.ILP.ILPComponent
+  alias Lanttern.ILP.ILPTemplate
 
   @type t :: %__MODULE__{
           id: pos_integer(),

--- a/lib/lanttern/learning_context.ex
+++ b/lib/lanttern/learning_context.ex
@@ -4,19 +4,20 @@ defmodule Lanttern.LearningContext do
   """
 
   import Ecto.Query, warn: false
-  import Lanttern.RepoHelpers
-  alias Lanttern.RepoHelpers.Page
-  alias Lanttern.Repo
   use Gettext, backend: Lanttern.Gettext
 
+  alias Lanttern.Repo
+  alias Lanttern.RepoHelpers.Page
+  import Lanttern.RepoHelpers
+
+  alias Lanttern.Assessments.AssessmentPointEntry
   alias Lanttern.Attachments
   alias Lanttern.Attachments.Attachment
-  alias Lanttern.Assessments.AssessmentPointEntry
-  alias Lanttern.LearningContext.Strand
-  alias Lanttern.LearningContext.StarredStrand
   alias Lanttern.LearningContext.Moment
   alias Lanttern.LearningContext.MomentCard
   alias Lanttern.LearningContext.MomentCardAttachment
+  alias Lanttern.LearningContext.StarredStrand
+  alias Lanttern.LearningContext.Strand
   alias Lanttern.LearningContextLog
 
   @doc """

--- a/lib/lanttern/learning_context/moment.ex
+++ b/lib/lanttern/learning_context/moment.ex
@@ -9,9 +9,9 @@ defmodule Lanttern.LearningContext.Moment do
   use Gettext, backend: Lanttern.Gettext
   import Lanttern.SchemaHelpers
 
+  alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.Curricula.CurriculumItem
   alias Lanttern.LearningContext.Strand
-  alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.Taxonomy.Subject
 
   @type t :: %__MODULE__{

--- a/lib/lanttern/learning_context/moment_card_attachment.ex
+++ b/lib/lanttern/learning_context/moment_card_attachment.ex
@@ -6,8 +6,8 @@ defmodule Lanttern.LearningContext.MomentCardAttachment do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Lanttern.LearningContext.MomentCard
   alias Lanttern.Attachments.Attachment
+  alias Lanttern.LearningContext.MomentCard
 
   @type t :: %__MODULE__{
           id: pos_integer(),

--- a/lib/lanttern/learning_context/strand.ex
+++ b/lib/lanttern/learning_context/strand.ex
@@ -9,8 +9,8 @@ defmodule Lanttern.LearningContext.Strand do
   use Gettext, backend: Lanttern.Gettext
   import Lanttern.SchemaHelpers
 
-  alias Lanttern.LearningContext.Moment
   alias Lanttern.Assessments.AssessmentPoint
+  alias Lanttern.LearningContext.Moment
   alias Lanttern.Notes.Note
   alias Lanttern.Notes.StrandNoteRelationship
   alias Lanttern.Reporting.StrandReport

--- a/lib/lanttern/message_board.ex
+++ b/lib/lanttern/message_board.ex
@@ -4,12 +4,13 @@ defmodule Lanttern.MessageBoard do
   """
 
   import Ecto.Query, warn: false
-  import Lanttern.RepoHelpers
-  alias Lanttern.Schools.Student
+
   alias Lanttern.Repo
+  import Lanttern.RepoHelpers
 
   alias Lanttern.MessageBoard.Message
   alias Lanttern.Schools.Class
+  alias Lanttern.Schools.Student
 
   @doc """
   Returns the list of messages.

--- a/lib/lanttern/notes.ex
+++ b/lib/lanttern/notes.ex
@@ -4,20 +4,21 @@ defmodule Lanttern.Notes do
   """
 
   import Ecto.Query, warn: false
-  alias Lanttern.Schools.Student
+
   alias Lanttern.Repo
   import Lanttern.RepoHelpers
 
   alias Lanttern.Attachments
   alias Lanttern.Attachments.Attachment
+  alias Lanttern.Identity.User
+  alias Lanttern.LearningContext.Moment
+  alias Lanttern.LearningContext.Strand
   alias Lanttern.Notes.MomentNoteRelationship
   alias Lanttern.Notes.Note
   alias Lanttern.Notes.NoteAttachment
   alias Lanttern.Notes.StrandNoteRelationship
   alias Lanttern.NotesLog
-  alias Lanttern.Identity.User
-  alias Lanttern.LearningContext.Moment
-  alias Lanttern.LearningContext.Strand
+  alias Lanttern.Schools.Student
 
   @doc """
   Returns the list of notes.

--- a/lib/lanttern/notes/note.ex
+++ b/lib/lanttern/notes/note.ex
@@ -7,8 +7,8 @@ defmodule Lanttern.Notes.Note do
   import Ecto.Changeset
 
   alias Lanttern.Identity.Profile
-  alias Lanttern.LearningContext.Strand
   alias Lanttern.LearningContext.Moment
+  alias Lanttern.LearningContext.Strand
   alias Lanttern.Notes.MomentNoteRelationship
   alias Lanttern.Notes.StrandNoteRelationship
 

--- a/lib/lanttern/notes/strand_note_relationship.ex
+++ b/lib/lanttern/notes/strand_note_relationship.ex
@@ -6,9 +6,9 @@ defmodule Lanttern.Notes.StrandNoteRelationship do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Lanttern.Notes.Note
   alias Lanttern.Identity.Profile
   alias Lanttern.LearningContext.Strand
+  alias Lanttern.Notes.Note
 
   @type t :: %__MODULE__{
           note: Note.t(),

--- a/lib/lanttern/notes_log.ex
+++ b/lib/lanttern/notes_log.ex
@@ -6,8 +6,8 @@ defmodule Lanttern.NotesLog do
   import Ecto.Query, warn: false
   alias Lanttern.Repo
 
-  alias Lanttern.NotesLog.NoteLog
   alias Lanttern.Notes.Note
+  alias Lanttern.NotesLog.NoteLog
 
   @doc """
   Returns the list of notes.

--- a/lib/lanttern/personalization.ex
+++ b/lib/lanttern/personalization.ex
@@ -110,5 +110,5 @@ defmodule Lanttern.Personalization do
 
   """
   @spec list_valid_permissions() :: [binary()]
-  def list_valid_permissions(), do: @valid_permissions
+  def list_valid_permissions, do: @valid_permissions
 end

--- a/lib/lanttern/personalization/profile_settings.ex
+++ b/lib/lanttern/personalization/profile_settings.ex
@@ -33,6 +33,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
           assessment_group_by: String.t(),
           student_id: pos_integer(),
           students_ids: [pos_integer()],
+          student_tags_ids: [pos_integer()],
           student_record_tags_ids: [pos_integer()],
           student_record_statuses_ids: [pos_integer()],
           student_record_assignees_ids: [pos_integer()],
@@ -56,6 +57,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
       field :assessment_group_by, :string
       field :student_id, :id
       field :students_ids, {:array, :id}
+      field :student_tags_ids, {:array, :id}
       field :student_record_tags_ids, {:array, :id}
       field :student_record_statuses_ids, {:array, :id}
       field :student_record_assignees_ids, {:array, :id}
@@ -94,6 +96,7 @@ defmodule Lanttern.Personalization.ProfileSettings do
       :assessment_group_by,
       :student_id,
       :students_ids,
+      :student_tags_ids,
       :student_record_tags_ids,
       :student_record_statuses_ids,
       :student_record_assignees_ids,

--- a/lib/lanttern/repo_helpers.ex
+++ b/lib/lanttern/repo_helpers.ex
@@ -107,7 +107,7 @@ defmodule Lanttern.RepoHelpers do
   Create naive timestamps.
   To be used in `inserted_at` and `updated_at`.
   """
-  def naive_timestamp() do
+  def naive_timestamp do
     NaiveDateTime.utc_now()
     |> NaiveDateTime.truncate(:second)
   end

--- a/lib/lanttern/reporting/strand_report.ex
+++ b/lib/lanttern/reporting/strand_report.ex
@@ -8,8 +8,8 @@ defmodule Lanttern.Reporting.StrandReport do
 
   use Gettext, backend: Lanttern.Gettext
 
-  alias Lanttern.Reporting.ReportCard
   alias Lanttern.LearningContext.Strand
+  alias Lanttern.Reporting.ReportCard
 
   @type t :: %__MODULE__{
           id: pos_integer(),

--- a/lib/lanttern/rubrics.ex
+++ b/lib/lanttern/rubrics.ex
@@ -442,7 +442,7 @@ defmodule Lanttern.Rubrics do
   - when scale type is "ordinal", we use ordinal value's normalized value
   - when scale type is "numeric", we use descriptor's score
   """
-  def full_rubric_query() do
+  def full_rubric_query do
     descriptors_query =
       from(
         d in RubricDescriptor,

--- a/lib/lanttern/rubrics/rubric_descriptor.ex
+++ b/lib/lanttern/rubrics/rubric_descriptor.ex
@@ -6,9 +6,9 @@ defmodule Lanttern.Rubrics.RubricDescriptor do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Lanttern.Rubrics.Rubric
-  alias Lanttern.Grading.Scale
   alias Lanttern.Grading.OrdinalValue
+  alias Lanttern.Grading.Scale
+  alias Lanttern.Rubrics.Rubric
 
   @type t :: %__MODULE__{
           id: pos_integer(),

--- a/lib/lanttern/schools.ex
+++ b/lib/lanttern/schools.ex
@@ -6,16 +6,17 @@ defmodule Lanttern.Schools do
   import Ecto.Query, warn: false
   import Lanttern.RepoHelpers
   use Gettext, backend: Lanttern.Gettext
+
   alias Lanttern.Repo
-  alias Lanttern.Schools.School
-  alias Lanttern.Schools.Cycle
+
+  alias Lanttern.Identity
+  alias Lanttern.Identity.Profile
+  alias Lanttern.Identity.User
   alias Lanttern.Schools.Class
+  alias Lanttern.Schools.Cycle
+  alias Lanttern.Schools.School
   alias Lanttern.Schools.StaffMember
   alias Lanttern.Schools.Student
-  alias Lanttern.Identity
-  alias Lanttern.Identity.User
-  alias Lanttern.Identity.Profile
-
   alias Lanttern.SupabaseHelpers
 
   @doc """
@@ -1400,7 +1401,6 @@ defmodule Lanttern.Schools do
         %Student{} -> [student_id: school_person.id]
       end
 
-    # todo: handle failed deletion of profile
     Repo.get_by(Profile, get_by_opt)
     |> Repo.delete()
   end

--- a/lib/lanttern/schools.ex
+++ b/lib/lanttern/schools.ex
@@ -721,6 +721,7 @@ defmodule Lanttern.Schools do
   - `:preloads` – preloads associated data
   - `:school_id` - filter students by school
   - `:students_ids` - filter students by given ids
+  - `:student_tags_ids` - filter students by their associated tags
   - `:class_id` – filter students by given class
   - `:classes_ids` – filter students by provided list of ids. preloads the classes for each student, and order by class name
   - `:only_in_some_class` - boolean. When `true`, will remove students not linked to a class (and will do the opposite when `false`)
@@ -763,6 +764,19 @@ defmodule Lanttern.Schools do
     from(
       s in queryable,
       where: s.id in ^students_ids
+    )
+    |> apply_list_students_opts(opts)
+  end
+
+  defp apply_list_students_opts(queryable, [{:student_tags_ids, student_tags_ids} | opts])
+       when is_list(student_tags_ids) and student_tags_ids != [] do
+    from(
+      s in queryable,
+      join: str in Lanttern.StudentTags.StudentTagRelationship,
+      on: str.student_id == s.id,
+      where: str.tag_id in ^student_tags_ids,
+      # use preload to prevent duplicated students
+      preload: [student_tag_relationships: str]
     )
     |> apply_list_students_opts(opts)
   end

--- a/lib/lanttern/schools/student.ex
+++ b/lib/lanttern/schools/student.ex
@@ -14,8 +14,8 @@ defmodule Lanttern.Schools.Student do
   alias Lanttern.Identity.Profile
   alias Lanttern.ILP.StudentILP
   alias Lanttern.Reporting.StudentReportCard
-  alias Lanttern.Schools.School
   alias Lanttern.Schools.Class
+  alias Lanttern.Schools.School
   alias Lanttern.StudentsCycleInfo.StudentCycleInfo
 
   @type t :: %__MODULE__{

--- a/lib/lanttern/student_tags.ex
+++ b/lib/lanttern/student_tags.ex
@@ -1,0 +1,152 @@
+defmodule Lanttern.StudentTags do
+  @moduledoc """
+  The StudentTags context.
+  """
+
+  import Ecto.Query, warn: false
+  import Lanttern.RepoHelpers
+  alias Lanttern.Repo
+  alias Lanttern.StudentTags.Tag
+
+  @doc """
+  Returns the list of student_tags.
+
+  ## Options
+
+  - `:school_id` - filter results by school
+
+  ## Examples
+
+      iex> list_student_tags()
+      [%Tag{}, ...]
+
+  """
+  def list_student_tags(opts \\ []) do
+    from(
+      t in Tag,
+      order_by: t.position
+    )
+    |> apply_list_student_tags_opts(opts)
+    |> Repo.all()
+  end
+
+  defp apply_list_student_tags_opts(queryable, []), do: queryable
+
+  defp apply_list_student_tags_opts(queryable, [{:school_id, school_id} | opts]) do
+    from(
+      t in queryable,
+      where: t.school_id == ^school_id
+    )
+    |> apply_list_student_tags_opts(opts)
+  end
+
+  defp apply_list_student_tags_opts(queryable, [_ | opts]),
+    do: apply_list_student_tags_opts(queryable, opts)
+
+  @doc """
+  Gets a single student_tag.
+
+  Raises `Ecto.NoResultsError` if the Student tag does not exist.
+
+  ## Examples
+
+      iex> get_student_tag!(123)
+      %Tag{}
+
+      iex> get_student_tag!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_student_tag!(id), do: Repo.get!(Tag, id)
+
+  @doc """
+  Creates a student_tag.
+
+  ## Examples
+
+      iex> create_student_tag(%{field: value})
+      {:ok, %Tag{}}
+
+      iex> create_student_tag(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_student_tag(attrs \\ %{}) do
+    queryable =
+      case attrs do
+        %{school_id: school_id} when not is_nil(school_id) ->
+          from(t in Tag, where: t.school_id == ^school_id)
+
+        %{"school_id" => school_id} when not is_nil(school_id) ->
+          from(t in Tag, where: t.school_id == ^school_id)
+
+        _ ->
+          Tag
+      end
+
+    attrs = set_position_in_attrs(queryable, attrs)
+
+    %Tag{}
+    |> Tag.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a student_tag.
+
+  ## Examples
+
+      iex> update_student_tag(student_tag, %{field: new_value})
+      {:ok, %Tag{}}
+
+      iex> update_student_tag(student_tag, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_student_tag(%Tag{} = student_tag, attrs) do
+    student_tag
+    |> Tag.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a student_tag.
+
+  ## Examples
+
+      iex> delete_student_tag(student_tag)
+      {:ok, %Tag{}}
+
+      iex> delete_student_tag(student_tag)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_student_tag(%Tag{} = student_tag) do
+    Repo.delete(student_tag)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking student_tag changes.
+
+  ## Examples
+
+      iex> change_student_tag(student_tag)
+      %Ecto.Changeset{data: %Tag{}}
+
+  """
+  def change_student_tag(%Tag{} = student_tag, attrs \\ %{}) do
+    Tag.changeset(student_tag, attrs)
+  end
+
+  @doc """
+  Update student tags positions based on ids list order.
+
+  ## Examples
+
+      iex> update_student_tags_positions([3, 2, 1])
+      :ok
+
+  """
+  @spec update_student_tags_positions([integer()]) :: :ok | {:error, String.t()}
+  def update_student_tags_positions(tags_ids), do: update_positions(Tag, tags_ids)
+end

--- a/lib/lanttern/student_tags/student_tag_relationship.ex
+++ b/lib/lanttern/student_tags/student_tag_relationship.ex
@@ -1,0 +1,22 @@
+defmodule Lanttern.StudentTags.StudentTagRelationship do
+  @moduledoc """
+  The `StudentTags.StudentTagRelationship` schema (join table)
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+  schema "students_tags" do
+    belongs_to :student, Lanttern.Schools.Student, primary_key: true
+    belongs_to :tag, Lanttern.StudentTags.Tag, primary_key: true
+    belongs_to :school, Lanttern.Schools.School
+  end
+
+  @doc false
+  def changeset(assignee, attrs) do
+    assignee
+    |> cast(attrs, [:student_id, :tag_id, :school_id])
+    |> validate_required([:student_id, :tag_id, :school_id])
+  end
+end

--- a/lib/lanttern/student_tags/tag.ex
+++ b/lib/lanttern/student_tags/tag.ex
@@ -1,0 +1,50 @@
+defmodule Lanttern.StudentTags.Tag do
+  @moduledoc """
+  The `StudentTags.Tag` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  use Gettext, backend: Lanttern.Gettext
+
+  alias Lanttern.Schools.School
+
+  @type t :: %__MODULE__{
+          id: pos_integer(),
+          name: String.t(),
+          position: non_neg_integer(),
+          bg_color: String.t(),
+          text_color: String.t(),
+          school: School.t() | Ecto.Association.NotLoaded.t(),
+          school_id: pos_integer(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "schools_student_tags" do
+    field :name, :string
+    field :position, :integer, default: 0
+    field :bg_color, :string
+    field :text_color, :string
+
+    belongs_to :school, School
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(student_tag, attrs) do
+    student_tag
+    |> cast(attrs, [:name, :position, :bg_color, :text_color, :school_id])
+    |> validate_required([:name, :bg_color, :text_color, :school_id])
+    |> check_constraint(:bg_color,
+      name: :schools_student_tags_bg_color_should_be_hex,
+      message: gettext("Background color format not accepted. Use hex color.")
+    )
+    |> check_constraint(:text_color,
+      name: :schools_student_tags_text_color_should_be_hex,
+      message: gettext("Text color format not accepted. Use hex color.")
+    )
+  end
+end

--- a/lib/lanttern/students_cycle_info.ex
+++ b/lib/lanttern/students_cycle_info.ex
@@ -4,17 +4,17 @@ defmodule Lanttern.StudentsCycleInfo do
   """
 
   import Ecto.Query, warn: false
-  alias Lanttern.Schools.Student
-  alias Lanttern.Repo
 
+  alias Lanttern.Repo
   import Lanttern.RepoHelpers
 
   alias Lanttern.Attachments.Attachment
-  alias Lanttern.StudentsCycleInfoLog
-  alias Lanttern.StudentsCycleInfo.StudentCycleInfo
-  alias Lanttern.StudentsCycleInfo.StudentCycleInfoAttachment
   alias Lanttern.Schools.Class
   alias Lanttern.Schools.Cycle
+  alias Lanttern.Schools.Student
+  alias Lanttern.StudentsCycleInfo.StudentCycleInfo
+  alias Lanttern.StudentsCycleInfo.StudentCycleInfoAttachment
+  alias Lanttern.StudentsCycleInfoLog
 
   @doc """
   Returns the list of students_cycle_info.

--- a/lib/lanttern/students_cycle_info/student_cycle_info.ex
+++ b/lib/lanttern/students_cycle_info/student_cycle_info.ex
@@ -8,10 +8,10 @@ defmodule Lanttern.StudentsCycleInfo.StudentCycleInfo do
 
   use Gettext, backend: Lanttern.Gettext
 
-  alias Lanttern.StudentsCycleInfo.StudentCycleInfoAttachment
   alias Lanttern.Schools.Cycle
   alias Lanttern.Schools.School
   alias Lanttern.Schools.Student
+  alias Lanttern.StudentsCycleInfo.StudentCycleInfoAttachment
 
   @type t :: %__MODULE__{
           id: pos_integer(),

--- a/lib/lanttern/students_cycle_info/student_cycle_info_attachment.ex
+++ b/lib/lanttern/students_cycle_info/student_cycle_info_attachment.ex
@@ -6,8 +6,8 @@ defmodule Lanttern.StudentsCycleInfo.StudentCycleInfoAttachment do
   use Ecto.Schema
   import Ecto.Changeset
 
-  alias Lanttern.StudentsCycleInfo.StudentCycleInfo
   alias Lanttern.Attachments.Attachment
+  alias Lanttern.StudentsCycleInfo.StudentCycleInfo
 
   @type t :: %__MODULE__{
           id: pos_integer(),

--- a/lib/lanttern/students_records.ex
+++ b/lib/lanttern/students_records.ex
@@ -45,8 +45,8 @@ defmodule Lanttern.StudentsRecords do
 
   import Ecto.Query, warn: false
   import Lanttern.RepoHelpers
-  alias Lanttern.RepoHelpers.Page
   alias Lanttern.Repo
+  alias Lanttern.RepoHelpers.Page
 
   alias Lanttern.Identity.Profile
   alias Lanttern.StudentsRecords.AssigneeRelationship

--- a/lib/lanttern/students_records/student_record.ex
+++ b/lib/lanttern/students_records/student_record.ex
@@ -10,16 +10,16 @@ defmodule Lanttern.StudentsRecords.StudentRecord do
 
   alias Lanttern.Repo
 
+  alias Lanttern.Schools.Class
+  alias Lanttern.Schools.School
+  alias Lanttern.Schools.StaffMember
+  alias Lanttern.Schools.Student
   alias Lanttern.StudentsRecords.AssigneeRelationship
   alias Lanttern.StudentsRecords.StudentRecordClassRelationship
   alias Lanttern.StudentsRecords.StudentRecordRelationship
   alias Lanttern.StudentsRecords.StudentRecordStatus
   alias Lanttern.StudentsRecords.Tag
   alias Lanttern.StudentsRecords.TagRelationship
-  alias Lanttern.Schools.Class
-  alias Lanttern.Schools.School
-  alias Lanttern.Schools.StaffMember
-  alias Lanttern.Schools.Student
 
   @type t :: %__MODULE__{
           id: pos_integer(),

--- a/lib/lanttern/supabase_helpers.ex
+++ b/lib/lanttern/supabase_helpers.ex
@@ -70,7 +70,7 @@ defmodule Lanttern.SupabaseHelpers do
     )
   end
 
-  defp client() do
+  defp client do
     Supabase.init_client(%{
       name: @client_name,
       conn: %{
@@ -92,7 +92,7 @@ defmodule Lanttern.SupabaseHelpers do
 
       > "\#{config().base_url}/storage/v1/object/public/bucket/object_path"
   """
-  def config() do
+  def config do
     %{
       base_url: System.fetch_env!("SUPABASE_PROJECT_URL"),
       api_key: System.fetch_env!("SUPABASE_PROJECT_API_KEY")

--- a/lib/lanttern/taxonomy.ex
+++ b/lib/lanttern/taxonomy.ex
@@ -56,7 +56,7 @@ defmodule Lanttern.Taxonomy do
   @doc """
   Check if base years and subjects taxonomy already exists.
   """
-  def has_base_taxonomy?() do
+  def has_base_taxonomy? do
     db_year_codes =
       from(y in Year, select: [:code])
       |> Repo.all()
@@ -81,7 +81,7 @@ defmodule Lanttern.Taxonomy do
   @doc """
   Creates base years and subjects taxonomy.
   """
-  def seed_base_taxonomy() do
+  def seed_base_taxonomy do
     @years
     |> Enum.each(fn {code, name} ->
       case Repo.get_by(Year, code: code) do

--- a/lib/lanttern_web/components/assessments_components.ex
+++ b/lib/lanttern_web/components/assessments_components.ex
@@ -205,7 +205,7 @@ defmodule LantternWeb.AssessmentsComponents do
     """
   end
 
-  defp assessment_point_entry_display_base_classes(),
+  defp assessment_point_entry_display_base_classes,
     do: "flex items-center justify-center p-4 rounded font-mono text-sm text-center"
 
   @doc """

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -1885,6 +1885,7 @@ defmodule LantternWeb.CoreComponents do
   attr :picture_size, :string, default: "md"
   attr :theme, :string, default: "default", doc: "default | clean"
   attr :is_deactivated, :boolean, default: false
+  attr :tags, :list, default: nil, doc: "display badges based on tags below the profile name"
   attr :extra_info, :string, default: nil
   attr :on_click, JS, default: nil
   attr :navigate, :string, default: nil
@@ -1924,7 +1925,16 @@ defmodule LantternWeb.CoreComponents do
             <%= if @is_deactivated, do: gettext("(Deactivated)") %>
           </div>
         <% end %>
-        <div :if={@extra_info} class="line-clamp-1 text-xs text-ltrn-subtle"><%= @extra_info %></div>
+        <%= if is_list(@tags) && @tags != [] do %>
+          <div class="flex flew-wrap gap-2 mt-1">
+            <.badge :for={tag <- @tags} color_map={tag}>
+              <%= tag.name %>
+            </.badge>
+          </div>
+        <% end %>
+        <div :if={@extra_info} class="line-clamp-1 text-xs text-ltrn-subtle mt-1">
+          <%= @extra_info %>
+        </div>
       </div>
     </div>
     """

--- a/lib/lanttern_web/components/grades_reports_components.ex
+++ b/lib/lanttern_web/components/grades_reports_components.ex
@@ -206,7 +206,7 @@ defmodule LantternWeb.GradesReportsComponents do
        )
        when not is_nil(ov_id) do
     ~H"""
-    <div class="flex items-stretch justify-stretch gap-1">
+    <div class="relative flex items-stretch justify-stretch gap-1">
       <.live_component
         :if={@student_grades_report_entry.pre_retake_ordinal_value_id}
         module={StudentGradesReportEntryButtonComponent}
@@ -227,6 +227,12 @@ defmodule LantternWeb.GradesReportsComponents do
           if(@on_student_grade_click, do: @on_student_grade_click.(@student_grades_report_entry.id))
         }
       />
+      <div
+        :if={@student_grades_report_entry.comment}
+        class="absolute right-1 top-1 p-1 flex items-center rounded-full bg-ltrn-staff-lightest shadow"
+      >
+        <.icon name="hero-chat-bubble-oval-left-micro" class="w-4 h-4 text-ltrn-staff-accent" />
+      </div>
     </div>
     """
   end
@@ -235,7 +241,7 @@ defmodule LantternWeb.GradesReportsComponents do
          %{student_grades_report_entry: %StudentGradesReportEntry{}} = assigns
        ) do
     ~H"""
-    <div class="flex items-stretch justify-stretch gap-1 font-mono font-bold">
+    <div class="relative flex items-stretch justify-stretch gap-1 font-mono font-bold">
       <button
         :if={@student_grades_report_entry.pre_retake_score}
         type="button"
@@ -257,6 +263,12 @@ defmodule LantternWeb.GradesReportsComponents do
       >
         <%= @student_grades_report_entry.score %>
       </button>
+      <div
+        :if={@student_grades_report_entry.comment}
+        class="absolute right-1 top-1 p-1 flex items-center rounded-full bg-ltrn-staff-lightest shadow"
+      >
+        <.icon name="hero-chat-bubble-oval-left-micro" class="w-4 h-4 text-ltrn-staff-accent" />
+      </div>
     </div>
     """
   end

--- a/lib/lanttern_web/components/learning_context_components.ex
+++ b/lib/lanttern_web/components/learning_context_components.ex
@@ -9,8 +9,8 @@ defmodule LantternWeb.LearningContextComponents do
   import LantternWeb.CoreComponents
   import Lanttern.SupabaseHelpers, only: [object_url_to_render_url: 2]
 
-  alias Phoenix.LiveView.JS
   alias Lanttern.LearningContext.Strand
+  alias Phoenix.LiveView.JS
 
   @doc """
   Renders strand cards.

--- a/lib/lanttern_web/components/schools_components.ex
+++ b/lib/lanttern_web/components/schools_components.ex
@@ -88,6 +88,12 @@ defmodule LantternWeb.SchoolsComponents do
   attr :id, :string, default: nil
 
   def student_card(assigns) do
+    has_badge =
+      (is_list(assigns.student.classes) && assigns.student.classes != []) ||
+        (is_list(assigns.student.tags) && assigns.student.tags != [])
+
+    assigns = assign(assigns, :has_badge, has_badge)
+
     ~H"""
     <.card_base id={@id} class={["flex items-center gap-4 p-4", @class]}>
       <.profile_picture
@@ -105,11 +111,17 @@ defmodule LantternWeb.SchoolsComponents do
             <%= @student.name %>
           </div>
         <% end %>
-        <div
-          :if={is_list(@student.classes) && @student.classes != []}
-          class="flex flex-wrap gap-1 mt-2"
-        >
-          <.badge :for={class <- @student.classes}><%= class.name %></.badge>
+        <div :if={@has_badge} class="flex flex-wrap gap-1 mt-2">
+          <%= if is_list(@student.tags) do %>
+            <.badge :for={tag <- @student.tags} color_map={tag}>
+              <%= tag.name %>
+            </.badge>
+          <% end %>
+          <%= if is_list(@student.classes) do %>
+            <.badge :for={class <- @student.classes}>
+              <%= class.name %>
+            </.badge>
+          <% end %>
         </div>
         <div
           :if={@student.email}

--- a/lib/lanttern_web/controllers/admin_controller.ex
+++ b/lib/lanttern_web/controllers/admin_controller.ex
@@ -1,8 +1,8 @@
 defmodule LantternWeb.AdminController do
   use LantternWeb, :controller
 
-  alias Lanttern.Taxonomy
   alias Lanttern.BNCC
+  alias Lanttern.Taxonomy
 
   def home(conn, _params) do
     render(conn, :home, generate_assigns())
@@ -36,7 +36,7 @@ defmodule LantternWeb.AdminController do
     end
   end
 
-  defp generate_assigns() do
+  defp generate_assigns do
     [
       has_base_taxonomy: Taxonomy.has_base_taxonomy?(),
       is_bncc_registered: BNCC.bncc_registered?()

--- a/lib/lanttern_web/helpers/assessments_helpers.ex
+++ b/lib/lanttern_web/helpers/assessments_helpers.ex
@@ -15,7 +15,7 @@ defmodule LantternWeb.AssessmentsHelpers do
       iex> generate_assessment_point_options()
       ["assessment point name": 1, ...]
   """
-  def generate_assessment_point_options() do
+  def generate_assessment_point_options do
     Assessments.list_assessment_points()
     |> Enum.map(fn ap -> {ap.name, ap.id} end)
   end

--- a/lib/lanttern_web/helpers/curricula_helpers.ex
+++ b/lib/lanttern_web/helpers/curricula_helpers.ex
@@ -13,7 +13,7 @@ defmodule LantternWeb.CurriculaHelpers do
       iex> generate_curriculum_options()
       ["item name": 1, ...]
   """
-  def generate_curriculum_options() do
+  def generate_curriculum_options do
     Curricula.list_curricula()
     |> Enum.map(fn c -> {c.name, c.id} end)
   end
@@ -26,7 +26,7 @@ defmodule LantternWeb.CurriculaHelpers do
       iex> generate_curriculum_component_options()
       ["curriculum component name": 1, ...]
   """
-  def generate_curriculum_component_options() do
+  def generate_curriculum_component_options do
     Curricula.list_curriculum_components()
     |> Enum.map(fn c -> {c.name, c.id} end)
   end
@@ -39,7 +39,7 @@ defmodule LantternWeb.CurriculaHelpers do
       iex> generate_curriculum_item_options()
       ["item name": 1, ...]
   """
-  def generate_curriculum_item_options() do
+  def generate_curriculum_item_options do
     Curricula.list_curriculum_items()
     |> Enum.map(fn i -> {i.name, i.id} end)
   end

--- a/lib/lanttern_web/helpers/filters_helpers.ex
+++ b/lib/lanttern_web/helpers/filters_helpers.ex
@@ -14,6 +14,7 @@ defmodule LantternWeb.FiltersHelpers do
   alias Lanttern.Schools
   alias Lanttern.Schools.Cycle
   alias Lanttern.StudentsRecords
+  alias Lanttern.StudentTags
   alias Lanttern.Taxonomy
 
   import LantternWeb.LocalizationHelpers
@@ -52,6 +53,12 @@ defmodule LantternWeb.FiltersHelpers do
 
   - `:selected_students`
   - `:selected_students_ids`
+
+  ### `:student_tags` assigns
+
+  - `:student_tags` (filtered by user school)
+  - `:selected_student_tags`
+  - `:selected_student_tags_ids`
 
   ### `:student_record_tags` assigns
 
@@ -203,6 +210,29 @@ defmodule LantternWeb.FiltersHelpers do
          socket,
          current_user,
          current_filters,
+         [:student_tags | filter_types]
+       ) do
+    school_id = current_user.current_profile.school_id
+
+    student_tags =
+      StudentTags.list_student_tags(school_id: school_id)
+
+    selected_student_tags_ids = Map.get(current_filters, :student_tags_ids) || []
+
+    selected_student_tags =
+      Enum.filter(student_tags, &(&1.id in selected_student_tags_ids))
+
+    socket
+    |> assign(:student_tags, student_tags)
+    |> assign(:selected_student_tags_ids, selected_student_tags_ids)
+    |> assign(:selected_student_tags, selected_student_tags)
+    |> assign_filter_type(current_user, current_filters, filter_types)
+  end
+
+  defp assign_filter_type(
+         socket,
+         current_user,
+         current_filters,
          [:student_record_tags | filter_types]
        ) do
     school_id = current_user.current_profile.school_id
@@ -336,6 +366,7 @@ defmodule LantternWeb.FiltersHelpers do
     linked_students_classes: :linked_students_classes_ids,
     student: :student_id,
     students: :students_ids,
+    student_tags: :student_tags_ids,
     student_record_tags: :student_record_tags_ids,
     student_record_statuses: :student_record_statuses_ids,
     student_record_assignees: :student_record_assignees_ids,
@@ -351,6 +382,7 @@ defmodule LantternWeb.FiltersHelpers do
     linked_students_classes: :selected_linked_students_classes_ids,
     student: :selected_student_id,
     students: :selected_students_ids,
+    student_tags: :selected_student_tags_ids,
     student_record_tags: :selected_student_record_tags_ids,
     student_record_statuses: :selected_student_record_statuses_ids,
     student_record_assignees: :selected_student_record_assignees_ids,
@@ -708,6 +740,7 @@ defmodule LantternWeb.FiltersHelpers do
   - `:years`
   - `:cycles`
   - `:students`
+  - `:student_tags`
   - `:student_record_tags`
   - `:student_record_status`
   - `:student_record_assignees`

--- a/lib/lanttern_web/helpers/grading_helpers.ex
+++ b/lib/lanttern_web/helpers/grading_helpers.ex
@@ -28,7 +28,7 @@ defmodule LantternWeb.GradingHelpers do
       iex> generate_ordinal_value_options()
       ["ordinal value name": 1, ...]
   """
-  def generate_ordinal_value_options() do
+  def generate_ordinal_value_options do
     Grading.list_ordinal_values()
     |> Enum.map(fn ov -> {ov.name, ov.id} end)
   end

--- a/lib/lanttern_web/helpers/identity_helpers.ex
+++ b/lib/lanttern_web/helpers/identity_helpers.ex
@@ -13,7 +13,7 @@ defmodule LantternWeb.IdentityHelpers do
       iex> generate_user_options()
       [{"user email", 1}, ...]
   """
-  def generate_user_options() do
+  def generate_user_options do
     Identity.list_users()
     |> Enum.map(fn u -> {u.email, u.id} end)
   end
@@ -26,7 +26,7 @@ defmodule LantternWeb.IdentityHelpers do
       iex> generate_profile_options()
       [{"Teacher: name", 1}, ...]
   """
-  def generate_profile_options() do
+  def generate_profile_options do
     Identity.list_profiles(preloads: [:staff_member, :student])
     |> Enum.map(fn p -> {profile_name(p), p.id} end)
   end
@@ -45,7 +45,7 @@ defmodule LantternWeb.IdentityHelpers do
       iex> generate_staff_member_profile_options()
       [{"name", 1}, ...]
   """
-  def generate_staff_member_profile_options() do
+  def generate_staff_member_profile_options do
     Identity.list_profiles(type: "staff", preloads: :staff_member)
     |> Enum.map(fn p -> {p.staff_member.name, p.id} end)
   end

--- a/lib/lanttern_web/helpers/learning_context_helpers.ex
+++ b/lib/lanttern_web/helpers/learning_context_helpers.ex
@@ -13,7 +13,7 @@ defmodule LantternWeb.LearningContextHelpers do
       iex> generate_strand_options()
       [{"strand name", 1}, ...]
   """
-  def generate_strand_options() do
+  def generate_strand_options do
     LearningContext.list_strands()
     |> Enum.map(fn s -> {s.name, s.id} end)
   end

--- a/lib/lanttern_web/helpers/localization_helpers.ex
+++ b/lib/lanttern_web/helpers/localization_helpers.ex
@@ -98,7 +98,7 @@ defmodule LantternWeb.LocalizationHelpers do
       iex> get_html_lang()
       "pt-br"
   """
-  def get_html_lang() do
+  def get_html_lang do
     Gettext.get_locale(Lanttern.Gettext)
     |> String.downcase()
     |> String.replace("_", "-")

--- a/lib/lanttern_web/helpers/personalization_helpers.ex
+++ b/lib/lanttern_web/helpers/personalization_helpers.ex
@@ -22,7 +22,7 @@ defmodule LantternWeb.PersonalizationHelpers do
       iex> generate_permission_options()
       [{"permission", "value"}, ...]
   """
-  def generate_permission_options() do
+  def generate_permission_options do
     Personalization.list_valid_permissions()
     |> Enum.map(fn p -> {@permission_to_option_map[p], p} end)
   end

--- a/lib/lanttern_web/helpers/schools_helpers.ex
+++ b/lib/lanttern_web/helpers/schools_helpers.ex
@@ -3,11 +3,11 @@ defmodule LantternWeb.SchoolsHelpers do
   Helper functions related to `Schools` context
   """
 
-  alias Lanttern.Schools
-  alias Lanttern.Schools.Cycle
-  alias Lanttern.Schools.Class
   alias Lanttern.Identity.Profile
   alias Lanttern.Identity.User
+  alias Lanttern.Schools
+  alias Lanttern.Schools.Class
+  alias Lanttern.Schools.Cycle
 
   @doc """
   Generate list of schools to use as `Phoenix.HTML.Form.options_for_select/2` arg
@@ -17,7 +17,7 @@ defmodule LantternWeb.SchoolsHelpers do
       iex> generate_school_options()
       [{"school name", 1}, ...]
   """
-  def generate_school_options() do
+  def generate_school_options do
     Schools.list_schools()
     |> Enum.map(fn s -> {s.name, s.id} end)
   end
@@ -60,7 +60,7 @@ defmodule LantternWeb.SchoolsHelpers do
       iex> generate_student_options()
       [{"student name", 1}, ...]
   """
-  def generate_student_options() do
+  def generate_student_options do
     Schools.list_students()
     |> Enum.map(fn s -> {s.name, s.id} end)
   end
@@ -73,7 +73,7 @@ defmodule LantternWeb.SchoolsHelpers do
       iex> generate_staff_member_options()
       [{"staff member name", 1}, ...]
   """
-  def generate_staff_member_options() do
+  def generate_staff_member_options do
     Schools.list_staff_members()
     |> Enum.map(fn t -> {t.name, t.id} end)
   end

--- a/lib/lanttern_web/helpers/taxonomy_helpers.ex
+++ b/lib/lanttern_web/helpers/taxonomy_helpers.ex
@@ -13,7 +13,7 @@ defmodule LantternWeb.TaxonomyHelpers do
       iex> generate_subject_options()
       ["subject name": 1, ...]
   """
-  def generate_subject_options() do
+  def generate_subject_options do
     Taxonomy.list_subjects()
     |> Enum.map(fn s -> {s.name, s.id} end)
   end
@@ -26,7 +26,7 @@ defmodule LantternWeb.TaxonomyHelpers do
       iex> generate_year_options()
       ["year name": 1, ...]
   """
-  def generate_year_options() do
+  def generate_year_options do
     Taxonomy.list_years()
     |> Enum.map(fn y -> {y.name, y.id} end)
   end

--- a/lib/lanttern_web/live/pages/admin/import_staff_members/import_staff_members_live.ex
+++ b/lib/lanttern_web/live/pages/admin/import_staff_members/import_staff_members_live.ex
@@ -3,8 +3,8 @@ defmodule LantternWeb.Admin.ImportStaffMembersLive do
 
   alias NimbleCSV.RFC4180, as: CSV
 
-  alias LantternWeb.SchoolsHelpers
   alias Lanttern.Schools
+  alias LantternWeb.SchoolsHelpers
 
   defp render_state(%{state: "uploading"} = assigns) do
     ~H"""

--- a/lib/lanttern_web/live/pages/admin/import_students/import_students_live.ex
+++ b/lib/lanttern_web/live/pages/admin/import_students/import_students_live.ex
@@ -3,8 +3,8 @@ defmodule LantternWeb.Admin.ImportStudentsLive do
 
   alias NimbleCSV.RFC4180, as: CSV
 
-  alias LantternWeb.SchoolsHelpers
   alias Lanttern.Schools
+  alias LantternWeb.SchoolsHelpers
 
   # function components
 

--- a/lib/lanttern_web/live/pages/admin/rubric_live/form_component.ex
+++ b/lib/lanttern_web/live/pages/admin/rubric_live/form_component.ex
@@ -1,8 +1,8 @@
 defmodule LantternWeb.Admin.RubricLive.FormComponent do
   use LantternWeb, :live_component
 
-  alias Lanttern.Rubrics
   alias Lanttern.Grading
+  alias Lanttern.Rubrics
   import LantternWeb.GradingHelpers
 
   @impl true

--- a/lib/lanttern_web/live/pages/admin/student_record_live/form_component.ex
+++ b/lib/lanttern_web/live/pages/admin/student_record_live/form_component.ex
@@ -2,8 +2,8 @@ defmodule LantternWeb.Admin.StudentRecordLive.FormComponent do
   use LantternWeb, :live_component
 
   alias Lanttern.StudentsRecords
-  alias LantternWeb.StudentsRecordsHelpers
   alias LantternWeb.SchoolsHelpers
+  alias LantternWeb.StudentsRecordsHelpers
 
   @impl true
   def render(assigns) do

--- a/lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/report_card_live.ex
@@ -6,9 +6,9 @@ defmodule LantternWeb.ReportCardLive do
   import Lanttern.SupabaseHelpers, only: [object_url_to_render_url: 2]
 
   # page components
-  alias __MODULE__.StudentsComponent
-  alias __MODULE__.StrandsReportsComponent
   alias __MODULE__.GradesComponent
+  alias __MODULE__.StrandsReportsComponent
+  alias __MODULE__.StudentsComponent
   alias __MODULE__.StudentsGradesComponent
   alias __MODULE__.StudentsTrackingComponent
 

--- a/lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/strands_reports_component.ex
@@ -8,9 +8,9 @@ defmodule LantternWeb.ReportCardLive.StrandsReportsComponent do
   import Lanttern.Utils, only: [swap: 3]
 
   # shared components
+  alias LantternWeb.GradesReports.StrandGradesReportSubjectsComponent
   alias LantternWeb.LearningContext.StrandSearchComponent
   alias LantternWeb.Reporting.StrandReportFormComponent
-  alias LantternWeb.GradesReports.StrandGradesReportSubjectsComponent
   import LantternWeb.LearningContextComponents
 
   @impl true

--- a/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
+++ b/lib/lanttern_web/live/pages/report_cards/id/students_component.ex
@@ -13,8 +13,8 @@ defmodule LantternWeb.ReportCardLive.StudentsComponent do
     only: [save_profile_filters: 3, assign_report_card_linked_student_classes_filter: 2]
 
   # shared components
-  alias LantternWeb.Reporting.StudentReportCardFormComponent
   alias LantternWeb.Filters.InlineFiltersComponent
+  alias LantternWeb.Reporting.StudentReportCardFormComponent
 
   @impl true
   def render(assigns) do

--- a/lib/lanttern_web/live/pages/school/classes/id/class_live.ex
+++ b/lib/lanttern_web/live/pages/school/classes/id/class_live.ex
@@ -6,8 +6,8 @@ defmodule LantternWeb.ClassLive do
 
   # page components
 
-  alias __MODULE__.StudentsComponent
   alias __MODULE__.ILPComponent
+  alias __MODULE__.StudentsComponent
   # alias __MODULE__.StudentRecordsComponent
 
   # shared components

--- a/lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex
+++ b/lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex
@@ -81,6 +81,7 @@ defmodule LantternWeb.ClassLive.ILPComponent do
                 cycle_id={@current_user.current_profile.current_school_cycle.id}
                 params={@params}
                 class="flex-1"
+                show_tags
               />
               <%= if ilp do %>
                 <.action
@@ -243,7 +244,8 @@ defmodule LantternWeb.ClassLive.ILPComponent do
         school_id,
         cycle_id,
         ilp_template_id,
-        classes_ids: [socket.assigns.class.id]
+        classes_ids: [socket.assigns.class.id],
+        preload_student_tags: true
       )
 
     students_count = length(students_and_ilps)

--- a/lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex
+++ b/lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex
@@ -13,9 +13,8 @@ defmodule LantternWeb.ClassLive.StudentRecordsComponent do
   use LantternWeb, :live_component
 
   alias Lanttern.Filters
-  alias Lanttern.StudentsRecords
   alias Lanttern.Schools
-
+  alias Lanttern.StudentsRecords
   import LantternWeb.FiltersHelpers, only: [assign_user_filters: 2, save_profile_filters: 2]
 
   # shared components

--- a/lib/lanttern_web/live/pages/school/classes/id/students_component.ex
+++ b/lib/lanttern_web/live/pages/school/classes/id/students_component.ex
@@ -119,7 +119,8 @@ defmodule LantternWeb.ClassLive.StudentsComponent do
         school_id: socket.assigns.current_user.current_profile.school_id,
         load_email: true,
         classes_ids: [socket.assigns.class.id],
-        load_profile_picture_from_cycle_id: cycle_id
+        load_profile_picture_from_cycle_id: cycle_id,
+        preloads: :tags
       )
 
     students =

--- a/lib/lanttern_web/live/pages/school/classes_component.ex
+++ b/lib/lanttern_web/live/pages/school/classes_component.ex
@@ -80,6 +80,11 @@ defmodule LantternWeb.SchoolLive.ClassesComponent do
                   >
                     <%= std.name %>
                   </.link>
+                  <%= if is_list(std.tags) do %>
+                    <.badge :for={tag <- std.tags} :if={is_list(std.tags)} color_map={tag}>
+                      <%= tag.name %>
+                    </.badge>
+                  <% end %>
                   <.badge :if={std.deactivated_at} theme="subtle" class="shrink-0">
                     <%= gettext("Deactivated") %>
                   </.badge>
@@ -197,7 +202,7 @@ defmodule LantternWeb.SchoolLive.ClassesComponent do
         years_ids: socket.assigns.selected_years_ids,
         cycles_ids: cycles_ids,
         count_active_students: true,
-        preloads: :students
+        preloads: [students: :tags]
       )
 
     socket

--- a/lib/lanttern_web/live/pages/school/school_live.ex
+++ b/lib/lanttern_web/live/pages/school/school_live.ex
@@ -2,12 +2,12 @@ defmodule LantternWeb.SchoolLive do
   use LantternWeb, :live_view
 
   # view components
-  alias __MODULE__.StudentsComponent
   alias __MODULE__.ClassesComponent
-  alias __MODULE__.StaffComponent
   alias __MODULE__.CyclesComponent
   alias __MODULE__.MessageBoardComponent
   alias __MODULE__.MomentCardsTemplatesComponent
+  alias __MODULE__.StaffComponent
+  alias __MODULE__.StudentsComponent
 
   # lifecycle
 

--- a/lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex
+++ b/lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex
@@ -13,11 +13,9 @@ defmodule LantternWeb.StaffMemberLive.StudentsRecordsComponent do
   use LantternWeb, :live_component
 
   alias Lanttern.Filters
-  alias Lanttern.StudentsRecords
   alias Lanttern.Schools
   alias Lanttern.Schools.Cycle
-
-  # shared components
+  alias Lanttern.StudentsRecords
   alias LantternWeb.Schools.StudentSearchComponent
   alias LantternWeb.StudentsRecords.StudentRecordOverlayComponent
 

--- a/lib/lanttern_web/live/pages/school/students/id/about_component.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/about_component.ex
@@ -20,6 +20,7 @@ defmodule LantternWeb.StudentLive.AboutComponent do
         student_id={@student.id}
         on_edit_profile_picture={JS.patch(~p"/school/students/#{@student}?edit_profile_picture=true")}
         show_deactivated
+        show_tags
       />
       <div class="flex items-start gap-20 mt-12">
         <div class="flex-1">

--- a/lib/lanttern_web/live/pages/school/students/id/grades_reports_component.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/grades_reports_component.ex
@@ -4,8 +4,8 @@ defmodule LantternWeb.StudentLive.GradesReportsComponent do
   alias Lanttern.GradesReports
 
   # shared components
-  alias LantternWeb.GradesReports.GradeDetailsOverlayComponent
   alias LantternWeb.GradesReports.FinalGradeDetailsOverlayComponent
+  alias LantternWeb.GradesReports.GradeDetailsOverlayComponent
   import LantternWeb.GradesReportsComponents
 
   @impl true

--- a/lib/lanttern_web/live/pages/school/students/id/student_live.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_live.ex
@@ -30,7 +30,7 @@ defmodule LantternWeb.StudentLive do
 
   defp assign_student(socket, params) do
     case Schools.get_student(params["id"],
-           preloads: [:school, classes: [:cycle, :years]],
+           preloads: [:school, :student_tag_relationships, :tags, classes: [:cycle, :years]],
            load_email: true
          ) do
       %Student{} = student ->

--- a/lib/lanttern_web/live/pages/school/students/id/student_live.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_live.ex
@@ -7,10 +7,10 @@ defmodule LantternWeb.StudentLive do
   # page components
 
   alias __MODULE__.AboutComponent
+  alias __MODULE__.GradesReportsComponent
   alias __MODULE__.ILPComponent
   alias __MODULE__.StudentRecordsComponent
   alias __MODULE__.StudentReportCardsComponent
-  alias __MODULE__.GradesReportsComponent
 
   # shared components
 

--- a/lib/lanttern_web/live/pages/school/students/id/student_records_component.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/student_records_component.ex
@@ -13,9 +13,8 @@ defmodule LantternWeb.StudentLive.StudentRecordsComponent do
   use LantternWeb, :live_component
 
   alias Lanttern.Filters
-  alias Lanttern.StudentsRecords
   alias Lanttern.Schools
-
+  alias Lanttern.StudentsRecords
   import LantternWeb.FiltersHelpers, only: [assign_user_filters: 2, save_profile_filters: 2]
 
   # shared components

--- a/lib/lanttern_web/live/pages/school/students_component.ex
+++ b/lib/lanttern_web/live/pages/school/students_component.ex
@@ -149,7 +149,8 @@ defmodule LantternWeb.SchoolLive.StudentsComponent do
         classes_ids: socket.assigns.selected_classes_ids,
         preload_classes_from_cycle_id: cycle_id,
         load_profile_picture_from_cycle_id: cycle_id,
-        only_active: true
+        only_active: true,
+        preloads: :tags
       )
 
     socket
@@ -163,7 +164,8 @@ defmodule LantternWeb.SchoolLive.StudentsComponent do
   defp assign_student(%{assigns: %{params: %{"new" => "true"}}} = socket) do
     student = %Student{
       school_id: socket.assigns.current_user.current_profile.school_id,
-      classes: []
+      classes: [],
+      tags: []
     }
 
     socket
@@ -172,7 +174,11 @@ defmodule LantternWeb.SchoolLive.StudentsComponent do
   end
 
   defp assign_student(%{assigns: %{params: %{"edit" => student_id}}} = socket) do
-    student = Schools.get_student(student_id, preloads: :classes, load_email: true)
+    student =
+      Schools.get_student(student_id,
+        preloads: [:classes, :tags, :student_tag_relationships],
+        load_email: true
+      )
 
     socket
     |> assign(:student, student)

--- a/lib/lanttern_web/live/pages/school/students_component.ex
+++ b/lib/lanttern_web/live/pages/school/students_component.ex
@@ -28,14 +28,17 @@ defmodule LantternWeb.SchoolLive.StudentsComponent do
             <%= gettext("View deactivated students") %>
           </.action>
         </div>
-        <.action
-          :if={@is_school_manager}
-          type="link"
-          patch={~p"/school/students?new=true"}
-          icon_name="hero-plus-circle-mini"
-        >
-          <%= gettext("Add student") %>
-        </.action>
+        <div :if={@is_school_manager} class="flex items-center gap-4">
+          <.action type="link" patch={~p"/school/students?new=true"} icon_name="hero-plus-circle-mini">
+            <%= gettext("Add student") %>
+          </.action>
+          <.link class="hover:text-ltrn-subtle" navigate={~p"/school/students/settings"}>
+            <span class="sr-only">
+              <%= gettext("Students settings") %>
+            </span>
+            <.icon name="hero-cog-6-tooth-mini" />
+          </.link>
+        </div>
       </div>
       <.fluid_grid id="students" phx-update="stream" is_full_width class="p-4">
         <.student_card

--- a/lib/lanttern_web/live/pages/strand_report/id/student_strand_report_live.ex
+++ b/lib/lanttern_web/live/pages/strand_report/id/student_strand_report_live.ex
@@ -9,16 +9,15 @@ defmodule LantternWeb.StudentStrandReportLive do
 
   # shared components
   alias LantternWeb.Notes.NoteComponent
-  alias LantternWeb.Reporting.StrandReportOverviewComponent
   alias LantternWeb.Reporting.StrandReportAssessmentComponent
   alias LantternWeb.Reporting.StrandReportMomentsComponent
-
+  alias LantternWeb.Reporting.StrandReportOverviewComponent
   import LantternWeb.LearningContextComponents, only: [mini_strand_card: 1]
 
   @tabs %{
-    "overview" => :overview,
     "assessment" => :assessment,
     "moments" => :moments,
+    "overview" => :overview,
     "student_notes" => :student_notes
   }
 

--- a/lib/lanttern_web/live/pages/strands/id/about_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/about_component.ex
@@ -53,9 +53,7 @@ defmodule LantternWeb.StrandLive.AboutComponent do
           </.action>
         </div>
         <p class="mt-4">
-          <%= gettext(
-            "Under the hood, goals in Lanttern are defined by assessment points linked directly to the strand — when adding goals, we are adding assessment points which, in turn, hold the curriculum items we'll want to assess along the strand course."
-          ) %>
+          <%= gettext("Use this area to manage the relationship between curriculum and strand.") %>
         </p>
         <div :for={{curriculum_item, i} <- @indexed_curriculum_items} class="mt-6">
           <div class="flex items-stretch gap-6 p-6 rounded bg-white shadow-lg">

--- a/lib/lanttern_web/live/pages/strands/id/about_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/about_component.ex
@@ -53,7 +53,7 @@ defmodule LantternWeb.StrandLive.AboutComponent do
           </.action>
         </div>
         <p class="mt-4">
-          <%= gettext("Use this area to manage the relationship between curriculum and strand.") %>
+          <%= gettext("Use this area to manage the strand curriculum.") %>
         </p>
         <div :for={{curriculum_item, i} <- @indexed_curriculum_items} class="mt-6">
           <div class="flex items-stretch gap-6 p-6 rounded bg-white shadow-lg">

--- a/lib/lanttern_web/live/pages/strands/id/moments_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/moments_component.ex
@@ -7,8 +7,8 @@ defmodule LantternWeb.StrandLive.MomentsComponent do
   import Lanttern.Utils, only: [swap: 3]
 
   # shared components
-  alias LantternWeb.LearningContext.MomentFormComponent
   alias LantternWeb.Dataviz.LantternVizComponent
+  alias LantternWeb.LearningContext.MomentFormComponent
 
   @impl true
   def render(assigns) do

--- a/lib/lanttern_web/live/pages/strands/id/strand_live.ex
+++ b/lib/lanttern_web/live/pages/strands/id/strand_live.ex
@@ -5,10 +5,10 @@ defmodule LantternWeb.StrandLive do
 
   # page components
   alias __MODULE__.AboutComponent
-  alias __MODULE__.StrandRubricsComponent
   alias __MODULE__.AssessmentComponent
   alias __MODULE__.MomentsComponent
   alias __MODULE__.NotesComponent
+  alias __MODULE__.StrandRubricsComponent
 
   # shared components
   alias LantternWeb.LearningContext.StrandFormComponent

--- a/lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex
@@ -11,8 +11,8 @@ defmodule LantternWeb.MomentLive.AssessmentComponent do
   import Lanttern.Utils, only: [swap: 3]
 
   # shared components
-  alias LantternWeb.Assessments.AssessmentsGridComponent
   alias LantternWeb.Assessments.AssessmentPointFormOverlayComponent
+  alias LantternWeb.Assessments.AssessmentsGridComponent
   import LantternWeb.AssessmentsComponents
 
   @impl true

--- a/lib/lanttern_web/live/pages/strands/moment/id/moment_live.ex
+++ b/lib/lanttern_web/live/pages/strands/moment/id/moment_live.ex
@@ -4,10 +4,10 @@ defmodule LantternWeb.MomentLive do
   alias Lanttern.LearningContext
 
   # page components
-  alias LantternWeb.MomentLive.OverviewComponent
   alias LantternWeb.MomentLive.AssessmentComponent
   alias LantternWeb.MomentLive.CardsComponent
   alias LantternWeb.MomentLive.NotesComponent
+  alias LantternWeb.MomentLive.OverviewComponent
 
   # shared components
   alias LantternWeb.LearningContext.MomentFormComponent

--- a/lib/lanttern_web/live/pages/student/student_home_live.ex
+++ b/lib/lanttern_web/live/pages/student/student_home_live.ex
@@ -11,8 +11,8 @@ defmodule LantternWeb.StudentHomeLive do
   alias Lanttern.StudentsCycleInfo
 
   # shared components
-  alias LantternWeb.MessageBoard.MessageBoardViewerComponent
   alias LantternWeb.Attachments.AttachmentAreaComponent
+  alias LantternWeb.MessageBoard.MessageBoardViewerComponent
   alias LantternWeb.Schools.StudentHeaderComponent
   import LantternWeb.SchoolsComponents
 

--- a/lib/lanttern_web/live/pages/student_report_cards/id/strand_report/strand_report_id/student_report_card_strand_report_live.ex
+++ b/lib/lanttern_web/live/pages/student_report_cards/id/strand_report/strand_report_id/student_report_card_strand_report_live.ex
@@ -5,21 +5,20 @@ defmodule LantternWeb.StudentReportCardStrandReportLive do
   alias Lanttern.Notes
   alias Lanttern.Notes.Note
   alias Lanttern.Reporting
-  import Lanttern.SupabaseHelpers, only: [object_url_to_render_url: 2]
 
-  # shared components
   alias LantternWeb.Notes.NoteComponent
-  alias LantternWeb.Reporting.StrandReportOverviewComponent
   alias LantternWeb.Reporting.StrandReportAssessmentComponent
   alias LantternWeb.Reporting.StrandReportMomentsComponent
+  alias LantternWeb.Reporting.StrandReportOverviewComponent
 
+  import Lanttern.SupabaseHelpers, only: [object_url_to_render_url: 2]
   import LantternWeb.LearningContextComponents, only: [mini_strand_card: 1]
   import LantternWeb.ReportingComponents
 
   @tabs %{
-    "overview" => :overview,
     "assessment" => :assessment,
     "moments" => :moments,
+    "overview" => :overview,
     "student_notes" => :student_notes
   }
 

--- a/lib/lanttern_web/live/pages/students/settings/students_settings_live.ex
+++ b/lib/lanttern_web/live/pages/students/settings/students_settings_live.ex
@@ -1,0 +1,34 @@
+defmodule LantternWeb.StudentsSettingsLive do
+  use LantternWeb, :live_view
+
+  # page imports
+  alias __MODULE__.TagsComponent
+
+  # lifecycle
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket =
+      socket
+      |> check_if_user_has_access()
+      |> assign(:page_title, gettext("Student settings"))
+
+    {:ok, socket}
+  end
+
+  defp check_if_user_has_access(socket) do
+    has_access =
+      "school_management" in socket.assigns.current_user.current_profile.permissions
+
+    if has_access do
+      socket
+    else
+      socket
+      |> push_navigate(to: ~p"/school/students", replace: true)
+      |> put_flash(:error, gettext("You don't have access to students settings page"))
+    end
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket), do: {:noreply, assign(socket, :params, params)}
+end

--- a/lib/lanttern_web/live/pages/students/settings/students_settings_live.html.heex
+++ b/lib/lanttern_web/live/pages/students/settings/students_settings_live.html.heex
@@ -1,0 +1,12 @@
+<.header_nav current_user={@current_user}>
+  <:breadcrumb navigate={~p"/school/students"}>
+    <%= @current_user.current_profile.school_name %>
+  </:breadcrumb>
+  <:title><%= gettext("Students settings") %></:title>
+</.header_nav>
+<.live_component
+  module={TagsComponent}
+  id="student-tag-manager"
+  current_user={@current_user}
+  params={@params}
+/>

--- a/lib/lanttern_web/live/pages/students/settings/tags_component.ex
+++ b/lib/lanttern_web/live/pages/students/settings/tags_component.ex
@@ -1,0 +1,168 @@
+defmodule LantternWeb.StudentsSettingsLive.TagsComponent do
+  use LantternWeb, :live_component
+
+  alias Lanttern.StudentTags
+  alias Lanttern.StudentTags.Tag
+
+  # shared components
+  alias LantternWeb.Students.StudentTagFormOverlayComponent
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.action_bar class="flex items-center justify-between gap-4 p-4">
+        <p class="flex items-center gap-2">
+          <.icon name="hero-information-circle-mini" class="text-ltrn-subtle" />
+          <%= gettext("Manage student tags below") %>
+        </p>
+        <.action
+          type="link"
+          patch={~p"/school/students/settings?new=true"}
+          icon_name="hero-plus-circle-mini"
+        >
+          <%= gettext("New tag") %>
+        </.action>
+      </.action_bar>
+      <%= if @has_student_tags do %>
+        <.responsive_container
+          phx-hook="Sortable"
+          id="student-tags"
+          class="p-4"
+          data-sortable-handle=".sortable-handle"
+          phx-update="ignore"
+        >
+          <.dragable_card
+            :for={{dom_id, tag} <- @streams.student_tags}
+            id={"sortable-#{dom_id}"}
+            class="mt-4 first:mt-0"
+          >
+            <div class="flex items-center gap-4 p-6">
+              <.badge color_map={tag}>
+                <%= tag.name %>
+              </.badge>
+              <.action type="link" patch={~p"/school/students/settings?edit=#{tag.id}"} theme="subtle">
+                <%= gettext("Edit") %>
+              </.action>
+            </div>
+          </.dragable_card>
+        </.responsive_container>
+      <% else %>
+        <div class="p-10">
+          <.empty_state><%= gettext("No student tags created yet") %></.empty_state>
+        </div>
+      <% end %>
+      <.live_component
+        :if={@student_tag}
+        module={StudentTagFormOverlayComponent}
+        id="student-tag-form-overlay"
+        tag={@student_tag}
+        title={@student_tag_overlay_title}
+        on_cancel={JS.patch(~p"/school/students/settings")}
+        notify_component={@myself}
+      />
+    </div>
+    """
+  end
+
+  # lifecycle
+
+  @impl true
+  def mount(socket) do
+    {:ok, assign(socket, :initialized, false)}
+  end
+
+  @impl true
+  def update(%{action: {StudentTagFormOverlayComponent, {action, _tag}}}, socket)
+      when action in [:created, :updated, :deleted] do
+    message =
+      case action do
+        :created -> gettext("Tag created successfully")
+        :updated -> gettext("Tag updated successfully")
+        :deleted -> gettext("Tag deleted successfully")
+      end
+
+    nav_opts = [
+      put_flash: {:info, message},
+      push_navigate: [to: ~p"/school/students/settings"]
+    ]
+
+    {:ok, delegate_navigation(socket, nav_opts)}
+  end
+
+  def update(assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> initialize()
+      |> assign_student_tag()
+
+    {:ok, socket}
+  end
+
+  defp initialize(%{assigns: %{initialized: false}} = socket) do
+    socket
+    |> stream_student_tags()
+    |> assign(:initialized, true)
+  end
+
+  defp initialize(socket), do: socket
+
+  defp stream_student_tags(socket) do
+    school_id = socket.assigns.current_user.current_profile.school_id
+    student_tags = StudentTags.list_student_tags(school_id: school_id)
+
+    socket
+    |> stream(:student_tags, student_tags)
+    |> assign(:has_student_tags, length(student_tags) > 0)
+    |> assign(:student_tags_ids, Enum.map(student_tags, &"#{&1.id}"))
+  end
+
+  defp assign_student_tag(%{assigns: %{params: %{"new" => "true"}}} = socket) do
+    student_tag = %Tag{
+      school_id: socket.assigns.current_user.current_profile.school_id
+    }
+
+    socket
+    |> assign(:student_tag, student_tag)
+    |> assign(:student_tag_overlay_title, gettext("New student tag"))
+  end
+
+  defp assign_student_tag(%{assigns: %{params: %{"edit" => tag_id}}} = socket) do
+    if tag_id in socket.assigns.student_tags_ids do
+      student_tag = StudentTags.get_student_tag!(tag_id)
+
+      socket
+      |> assign(:student_tag, student_tag)
+      |> assign(:student_tag_overlay_title, gettext("Edit student tag"))
+    else
+      assign(socket, :student_tag, nil)
+    end
+  end
+
+  defp assign_student_tag(socket), do: assign(socket, :student_tag, nil)
+
+  # event handlers
+
+  @impl true
+  # view Sortable hook for payload info
+  def handle_event("sortable_update", payload, socket) do
+    %{
+      "oldIndex" => old_index,
+      "newIndex" => new_index
+    } = payload
+
+    {changed_id, rest} = List.pop_at(socket.assigns.student_tags_ids, old_index)
+    student_tags_ids = List.insert_at(rest, new_index, changed_id)
+
+    # the inteface was already updated (optimistic update)
+    # just persist the new order
+    StudentTags.update_student_tags_positions(student_tags_ids)
+
+    socket =
+      socket
+      |> assign(:student_tags_ids, student_tags_ids)
+
+    {:noreply, socket}
+  end
+end

--- a/lib/lanttern_web/live/pages/students_records/students_records_live.ex
+++ b/lib/lanttern_web/live/pages/students_records/students_records_live.ex
@@ -2,20 +2,21 @@ defmodule LantternWeb.StudentsRecordsLive do
   use LantternWeb, :live_view
 
   alias Lanttern.Filters
-  alias Lanttern.StudentsRecords
   alias Lanttern.Schools
   alias Lanttern.Schools.Cycle
+  alias Lanttern.StudentsRecords
 
   import LantternWeb.FiltersHelpers,
     only: [assign_user_filters: 2, assign_classes_filter: 2, save_profile_filters: 2]
+
+  import LantternWeb.SchoolsHelpers, only: [class_with_cycle: 2]
+  import LantternWeb.StudentsRecordsComponents
 
   # shared components
 
   alias LantternWeb.Schools.StaffMemberSearchComponent
   alias LantternWeb.Schools.StudentSearchComponent
   alias LantternWeb.StudentsRecords.StudentRecordOverlayComponent
-  import LantternWeb.SchoolsHelpers, only: [class_with_cycle: 2]
-  import LantternWeb.StudentsRecordsComponents
 
   # lifecycle
 

--- a/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
@@ -208,7 +208,6 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
   def assessment_point_header(%{ap_header: %AssessmentPoint{}} = assigns) do
     # when in a moment grid, the header is the assessment point
 
-    # TODO: make the patch dynamic (allow parent control via attrs)
     ~H"""
     <div class="flex flex-col p-2" id={@id}>
       <.link

--- a/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
@@ -109,8 +109,6 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
   end
 
   def marking_input(%{scale_type: "numeric"} = assigns) do
-    # TODO: add min max based on scale
-
     ~H"""
     <.base_input
       name={@field.name}

--- a/lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex
@@ -75,10 +75,16 @@ defmodule LantternWeb.GradesReports.GradeDetailsOverlayComponent do
           </div>
           <p class="text-sm text-ltrn-subtle"><%= gettext("Grade before retake process") %></p>
         </div>
-        <%= if @student_grades_report_entry.comment do %>
-          <h6 class="mb-4 font-display font-bold"><%= gettext("Comment") %></h6>
-          <.markdown text={@student_grades_report_entry.comment} class="mb-10" />
-        <% end %>
+        <div
+          :if={@student_grades_report_entry.comment}
+          class="p-4 rounded-sm mb-10 bg-ltrn-staff-lightest"
+        >
+          <h6 class="flex items-center gap-2 mb-4 font-display font-bold text-ltrn-staff-dark">
+            <.icon name="hero-chat-bubble-oval-left-mini" class="text-ltrn-staff-accent" />
+            <%= gettext("Comment") %>
+          </h6>
+          <.markdown text={@student_grades_report_entry.comment} />
+        </div>
         <h6 class="mb-4 font-display font-bold"><%= gettext("Grade composition") %></h6>
         <.grade_composition_table student_grades_report_entry={@student_grades_report_entry} />
         <.live_component

--- a/lib/lanttern_web/live/shared/grades_reports/grades_report_grid_configuration_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/grades_reports/grades_report_grid_configuration_overlay_component.ex
@@ -6,9 +6,9 @@ defmodule LantternWeb.GradesReports.GradesReportGridConfigurationOverlayComponen
   use LantternWeb, :live_component
 
   alias Lanttern.GradesReports
+  alias Lanttern.GradesReports.GradesReportCycle
   alias Lanttern.Schools
   alias Lanttern.Taxonomy
-  alias Lanttern.GradesReports.GradesReportCycle
 
   import Lanttern.Utils, only: [swap: 3]
 

--- a/lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex
@@ -14,8 +14,8 @@ defmodule LantternWeb.Grading.GradeCompositionOverlayComponent do
 
   alias Lanttern.GradesReports
   alias Lanttern.Grading
-  alias Lanttern.Reporting
   alias Lanttern.Grading.GradeComponent
+  alias Lanttern.Reporting
 
   import Lanttern.Utils, only: [swap: 3]
 

--- a/lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex
+++ b/lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex
@@ -54,6 +54,7 @@ defmodule LantternWeb.ILP.StudentILPManagerComponent do
         student_id={@student.id}
         class="mb-10"
         navigate={@student_navigate}
+        show_tags
       />
       <.card_base :if={!@template} class="p-10">
         <.empty_state><%= gettext("No ILP template selected") %></.empty_state>

--- a/lib/lanttern_web/live/shared/menu_component.ex
+++ b/lib/lanttern_web/live/shared/menu_component.ex
@@ -352,6 +352,7 @@ defmodule LantternWeb.MenuComponent do
     LantternWeb.ClassLive => :school_management,
     LantternWeb.StudentLive => :school_management,
     LantternWeb.StaffMemberLive => :school_management,
+    LantternWeb.StudentsSettingsLive => :school_management,
 
     # assessment points
     LantternWeb.AssessmentPointsLive => :assessment_points,

--- a/lib/lanttern_web/live/shared/reporting/report_card_form_component.ex
+++ b/lib/lanttern_web/live/shared/reporting/report_card_form_component.ex
@@ -6,9 +6,9 @@ defmodule LantternWeb.Reporting.ReportCardFormComponent do
   use LantternWeb, :live_component
 
   alias Lanttern.Reporting
+  alias Lanttern.SupabaseHelpers
   alias LantternWeb.GradesReportsHelpers
   alias LantternWeb.SchoolsHelpers
-  alias Lanttern.SupabaseHelpers
   alias LantternWeb.TaxonomyHelpers
 
   @impl true

--- a/lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex
+++ b/lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex
@@ -106,13 +106,20 @@ defmodule LantternWeb.Reporting.StrandReportAssessmentComponent do
                   sgre.grades_report_subject.subject.name
                 ) %>
               </p>
-              <.live_component
-                module={StudentGradesReportEntryButtonComponent}
-                id={"#{dom_id}-entry-button"}
-                student_grades_report_entry={sgre}
-                on_click={JS.patch("#{@base_path}&sgre=#{sgre.id}")}
-                class="w-full p-2 mt-4 sm:mt-0"
-              />
+              <div class="flex items-center gap-2 mt-4 sm:mt-0">
+                <.live_component
+                  module={StudentGradesReportEntryButtonComponent}
+                  id={"#{dom_id}-entry-button"}
+                  student_grades_report_entry={sgre}
+                  on_click={JS.patch("#{@base_path}&sgre=#{sgre.id}")}
+                  class="flex-1 p-2"
+                />
+                <.icon
+                  :if={sgre.comment}
+                  name="hero-chat-bubble-oval-left-mini"
+                  class="text-ltrn-staff-accent"
+                />
+              </div>
             </.card_base>
           </div>
         </div>

--- a/lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex
@@ -19,8 +19,6 @@ defmodule LantternWeb.Rubrics.RubricFormOverlayComponent do
   """
   use LantternWeb, :live_component
 
-  alias Lanttern.Rubrics
-  alias Lanttern.Rubrics.Rubric
   alias Lanttern.Assessments
   alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.Curricula
@@ -28,8 +26,8 @@ defmodule LantternWeb.Rubrics.RubricFormOverlayComponent do
   alias Lanttern.Grading
   alias Lanttern.Grading.Scale
   alias Lanttern.LearningContext.Moment
-
-  # shared
+  alias Lanttern.Rubrics
+  alias Lanttern.Rubrics.Rubric
   alias LantternWeb.Grading.OrdinalValueBadgeComponent
 
   @impl true

--- a/lib/lanttern_web/live/shared/schools/student_header_component.ex
+++ b/lib/lanttern_web/live/shared/schools/student_header_component.ex
@@ -12,6 +12,7 @@ defmodule LantternWeb.Schools.StudentHeaderComponent do
   - `:class` - any, additional classes for the component
   - `:on_edit_profile_picture` - any, passed to edit profile picture button's `phx-click`
   - `:show_deactivated` - boolean, show deactivated info
+  - `:show_tags` - boolean, show tags info
   - `:navigate` - function, student id as argument. Expect a valid `<.link>` `navigate` attr.
   - `:cycle_tooltip` - string, tooltip for cycle badge. Useful to indicate to users that they can change the current cycle in the main menu.
 
@@ -65,6 +66,11 @@ defmodule LantternWeb.Schools.StudentHeaderComponent do
           </.badge>
         </div>
         <div class="flex items-center gap-4 mt-2">
+          <%= if @show_tags do %>
+            <.badge :for={tag <- @student.tags} color_map={tag}>
+              <%= tag.name %>
+            </.badge>
+          <% end %>
           <div class="group relative" {if(@cycle_tooltip, do: %{"tabindex" => "0"}, else: %{})}>
             <.badge theme="dark">
               <%= @cycle.name %>
@@ -97,6 +103,7 @@ defmodule LantternWeb.Schools.StudentHeaderComponent do
       |> assign(:class, nil)
       |> assign(:on_edit_profile_picture, nil)
       |> assign(:show_deactivated, false)
+      |> assign(:show_tags, false)
       |> assign(:navigate, nil)
       |> assign(:cycle_tooltip, nil)
       |> assign(:initialized, false)
@@ -129,11 +136,23 @@ defmodule LantternWeb.Schools.StudentHeaderComponent do
   end
 
   defp assign_student(socket) do
+    opts = [
+      load_profile_picture_from_cycle_id: socket.assigns.cycle_id,
+      preload_classes_from_cycle_id: socket.assigns.cycle_id,
+      preloads: :tags
+    ]
+
+    opts =
+      if socket.assigns.show_tags do
+        [{:preloads, :tags} | opts]
+      else
+        opts
+      end
+
     student =
       Schools.get_student(
         socket.assigns.student_id,
-        load_profile_picture_from_cycle_id: socket.assigns.cycle_id,
-        preload_classes_from_cycle_id: socket.assigns.cycle_id
+        opts
       )
 
     assign(socket, :student, student)

--- a/lib/lanttern_web/live/shared/schools/student_profile_picture_with_name_component.ex
+++ b/lib/lanttern_web/live/shared/schools/student_profile_picture_with_name_component.ex
@@ -15,6 +15,7 @@ defmodule LantternWeb.Schools.StudentProfilePictureWithNameComponent do
   - `class`
   - `navigate`
   - `picture_size` (default: "md")
+  - `show_tags` (default: `false`) will pass `@student.tags` as `tags` attr to `<.profile_picture_with_name>`
 
   """
   use LantternWeb, :live_component
@@ -30,6 +31,7 @@ defmodule LantternWeb.Schools.StudentProfilePictureWithNameComponent do
         picture_url={@student.profile_picture_url}
         navigate={@navigate}
         picture_size={@picture_size}
+        {if @show_tags, do: %{tags: @student.tags}, else: %{}}
       />
     </div>
     """
@@ -44,6 +46,7 @@ defmodule LantternWeb.Schools.StudentProfilePictureWithNameComponent do
       |> assign(:class, nil)
       |> assign(:picture_size, "md")
       |> assign(:navigate, nil)
+      |> assign(:show_tags, false)
       |> assign(:initialized, false)
 
     {:ok, socket}

--- a/lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex
@@ -1,0 +1,202 @@
+defmodule LantternWeb.Students.StudentTagFormOverlayComponent do
+  @moduledoc """
+  Renders an overlay with a `StudentTags.Tag` form
+
+  ### Attrs
+
+      attr :tag, Tag, required: true
+      attr :title, :string, required: true
+      attr :on_cancel, :any, required: true, doc: "`<.slide_over>` `on_cancel` attr"
+      attr :notify_parent, :boolean
+      attr :notify_component, Phoenix.LiveComponent.CID
+
+  """
+
+  use LantternWeb, :live_component
+
+  alias Lanttern.StudentTags
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div phx-remove={JS.exec("phx-remove", to: "##{@id}")}>
+      <.slide_over id={@id} show on_cancel={@on_cancel}>
+        <:title><%= @title %></:title>
+        <.form
+          id="student-tag-form"
+          for={@form}
+          phx-change="validate"
+          phx-submit="save"
+          phx-target={@myself}
+        >
+          <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
+            <%= gettext("Oops, something went wrong! Please check the errors below.") %>
+          </.error_block>
+          <.input
+            field={@form[:name]}
+            type="text"
+            label={gettext("Name")}
+            class="mb-6"
+            phx-debounce="1500"
+          />
+          <.input
+            field={@form[:bg_color]}
+            type="text"
+            label={gettext("Background color (hex)")}
+            class="mb-6"
+            phx-debounce="1500"
+          />
+          <.input
+            field={@form[:text_color]}
+            type="text"
+            label={gettext("Text color (hex)")}
+            class="mb-6"
+            phx-debounce="1500"
+          />
+        </.form>
+        <.card_base class="p-6">
+          <p class="mb-4 text-ltrn-subtle"><%= gettext("Preview") %></p>
+          <.badge color_map={
+            %{bg_color: @form[:bg_color].value, text_color: @form[:text_color].value}
+          }>
+            <%= @form[:name].value %>
+          </.badge>
+        </.card_base>
+        <:actions_left :if={@tag.id}>
+          <.action
+            type="button"
+            theme="subtle"
+            size="md"
+            phx-click="delete"
+            phx-target={@myself}
+            data-confirm={gettext("Are you sure?")}
+          >
+            <%= gettext("Delete") %>
+          </.action>
+        </:actions_left>
+        <:actions>
+          <.action
+            type="button"
+            theme="subtle"
+            size="md"
+            phx-click={JS.exec("data-cancel", to: "##{@id}")}
+          >
+            <%= gettext("Cancel") %>
+          </.action>
+          <.action
+            type="submit"
+            theme="primary"
+            size="md"
+            icon_name="hero-check"
+            form="student-tag-form"
+          >
+            <%= gettext("Save") %>
+          </.action>
+        </:actions>
+      </.slide_over>
+    </div>
+    """
+  end
+
+  @impl true
+  def mount(socket) do
+    socket =
+      socket
+      |> assign(:initialized, false)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def update(assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> initialize()
+
+    {:ok, socket}
+  end
+
+  defp initialize(%{assigns: %{initialized: false}} = socket) do
+    socket
+    |> assign_form()
+    |> assign(:initialized, true)
+  end
+
+  defp initialize(socket), do: socket
+
+  defp assign_form(socket) do
+    tag = socket.assigns.tag
+    changeset = StudentTags.change_student_tag(tag)
+
+    socket
+    |> assign(:form, to_form(changeset))
+  end
+
+  # event handlers
+
+  @impl true
+  def handle_event("validate", %{"tag" => tag_params}, socket),
+    do: {:noreply, assign_validated_form(socket, tag_params)}
+
+  def handle_event("save", %{"tag" => tag_params}, socket) do
+    tag_params = inject_extra_params(socket, tag_params)
+    save_tag(socket, socket.assigns.tag.id, tag_params)
+  end
+
+  def handle_event("delete", _, socket) do
+    StudentTags.delete_student_tag(socket.assigns.tag)
+    |> case do
+      {:ok, tag} ->
+        notify(__MODULE__, {:deleted, tag}, socket.assigns)
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp assign_validated_form(socket, params) do
+    params = inject_extra_params(socket, params)
+
+    changeset =
+      socket.assigns.tag
+      |> StudentTags.change_student_tag(params)
+      |> Map.put(:action, :validate)
+
+    assign(socket, :form, to_form(changeset))
+  end
+
+  # inject params handled in backend
+  defp inject_extra_params(socket, params) do
+    params
+    |> Map.put("school_id", socket.assigns.tag.school_id)
+  end
+
+  defp save_tag(socket, nil, tag_params) do
+    StudentTags.create_student_tag(tag_params)
+    |> case do
+      {:ok, tag} ->
+        notify(__MODULE__, {:created, tag}, socket.assigns)
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp save_tag(socket, _id, tag_params) do
+    StudentTags.update_student_tag(
+      socket.assigns.tag,
+      tag_params
+    )
+    |> case do
+      {:ok, tag} ->
+        notify(__MODULE__, {:updated, tag}, socket.assigns)
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+end

--- a/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex
@@ -3,19 +3,19 @@ defmodule LantternWeb.StudentsRecords.StudentRecordOverlayComponent do
   Renders an overlay with `StudentRecord` details and editing support
   """
 
-  alias Lanttern.Repo
   use LantternWeb, :live_component
 
-  alias Lanttern.StudentsRecords
-  alias Lanttern.StudentsRecords.StudentRecord
+  alias Lanttern.Repo
   alias Lanttern.Schools
   alias Lanttern.Schools.StaffMember
+  alias Lanttern.StudentsRecords
+  alias Lanttern.StudentsRecords.StudentRecord
 
   # shared
 
+  alias LantternWeb.Schools.ClassesFieldComponent
   alias LantternWeb.Schools.StaffMemberSearchComponent
   alias LantternWeb.Schools.StudentSearchComponent
-  alias LantternWeb.Schools.ClassesFieldComponent
   import LantternWeb.DateTimeHelpers
   import LantternWeb.SchoolsHelpers, only: [class_with_cycle: 2]
   import LantternWeb.StudentsRecordsComponents

--- a/lib/lanttern_web/router.ex
+++ b/lib/lanttern_web/router.ex
@@ -72,6 +72,7 @@ defmodule LantternWeb.Router do
       live "/school/moment_cards_templates", SchoolLive, :manage_moment_cards_templates
 
       live "/school/students/deactivated", DeactivatedStudentsLive, :index
+      live "/school/students/settings", StudentsSettingsLive, :manage_tags
       live "/school/students/:id", StudentLive, :show
       live "/school/students/:id/ilp", StudentLive, :ilp
       live "/school/students/:id/student_records", StudentLive, :student_records
@@ -128,7 +129,6 @@ defmodule LantternWeb.Router do
       live "/students_records", StudentsRecordsLive, :index
       live "/students_records/settings/status", StudentsRecordsSettingsLive, :manage_status
       live "/students_records/settings/tags", StudentsRecordsSettingsLive, :manage_tags
-
       # ILP
 
       live "/ilp", ILPLive, :index

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2025.4.15-alpha.61",
+      version: "2025.4.27-alpha.62",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -88,6 +88,12 @@ defmodule Lanttern.MixProject do
         "tailwind default --minify",
         "esbuild default --minify",
         "phx.digest"
+      ],
+      check: [
+        "format --check-formatted",
+        "deps.unlock --check-unused",
+        "compile --warnings-as-errors",
+        "credo --strict"
       ]
     ]
   end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -12,13 +12,13 @@ msgid ""
 msgstr ""
 
 #: lib/lanttern_web/components/core_components.ex:938
-#: lib/lanttern_web/components/core_components.ex:2187
-#: lib/lanttern_web/components/core_components.ex:2249
+#: lib/lanttern_web/components/core_components.ex:2197
+#: lib/lanttern_web/components/core_components.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1033
+#: lib/lanttern_web/components/grades_reports_components.ex:1045
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:3
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.ex:11
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.html.heex:2
@@ -26,13 +26,13 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:52
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:72
-#: lib/lanttern_web/live/shared/menu_component.ex:452
+#: lib/lanttern_web/live/shared/menu_component.ex:453
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:427
+#: lib/lanttern_web/live/shared/menu_component.ex:428
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -50,9 +50,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.ex:18
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:429
-#: lib/lanttern_web/live/shared/menu_component.ex:483
-#: lib/lanttern_web/live/shared/menu_component.ex:508
+#: lib/lanttern_web/live/shared/menu_component.ex:430
+#: lib/lanttern_web/live/shared/menu_component.ex:484
+#: lib/lanttern_web/live/shared/menu_component.ex:509
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr ""
@@ -126,12 +126,13 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:202
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:161
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:138
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:136
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:114
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:96
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:112
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:132
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:40
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:196
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:102
@@ -187,12 +188,13 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:205
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:164
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:147
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:145
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:61
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:105
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:115
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:141
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:93
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:43
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:205
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:111
@@ -247,7 +249,8 @@ msgstr ""
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:45
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:53
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:44
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:47
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:38
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:49
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:38
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:38
@@ -274,12 +277,13 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:126
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:21
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:39
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:67
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:65
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:40
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:29
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:26
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:35
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:42
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:33
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:44
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:184
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:33
@@ -392,8 +396,8 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1034
-#: lib/lanttern_web/components/grades_reports_components.ex:1107
+#: lib/lanttern_web/components/grades_reports_components.ex:1046
+#: lib/lanttern_web/components/grades_reports_components.ex:1119
 #: lib/lanttern_web/live/pages/strand_report/id/student_strand_report_live.html.heex:21
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:17
 #: lib/lanttern_web/live/pages/student_report_cards/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:25
@@ -407,7 +411,7 @@ msgid "Couldn't find strand"
 msgstr ""
 
 #: lib/lanttern_web/components/message_board_components.ex:52
-#: lib/lanttern_web/components/schools_components.ex:187
+#: lib/lanttern_web/components/schools_components.ex:199
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:158
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:109
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:116
@@ -422,11 +426,12 @@ msgstr ""
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:103
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:248
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:130
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:128
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:126
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:109
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:92
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:112
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:338
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:92
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:74
@@ -469,7 +474,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/form_components.ex:742
 #: lib/lanttern_web/components/message_board_components.ex:40
-#: lib/lanttern_web/components/schools_components.ex:185
+#: lib/lanttern_web/components/schools_components.ex:197
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:156
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:107
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:114
@@ -489,11 +494,12 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:246
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:128
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:126
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:124
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:107
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:90
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:110
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:72
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:336
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:90
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:72
@@ -511,14 +517,14 @@ msgstr ""
 msgid "Delete note"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:69
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:67
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:100
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:88
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:268
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:264
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:275
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:262
 #, elixir-autogen, elixir-format
 msgid "Differentiation"
 msgstr ""
@@ -532,8 +538,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/ilp/settings/ilp_settings_live.html.heex:27
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:41
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:320
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:80
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:78
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:228
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:45
 #: lib/lanttern_web/live/pages/students_records/settings/status_component.ex:61
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:57
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:250
@@ -547,12 +554,12 @@ msgstr ""
 msgid "Goals"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:112
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:110
 #, elixir-autogen, elixir-format
 msgid "Move curriculum item down"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:101
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Move curriculum item up"
 msgstr ""
@@ -574,11 +581,6 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/classes_field_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Select a class"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:56
-#, elixir-autogen, elixir-format
-msgid "Under the hood, goals in Lanttern are defined by assessment points linked directly to the strand — when adding goals, we are adding assessment points which, in turn, hold the curriculum items we'll want to assess along the strand course."
 msgstr ""
 
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:188
@@ -650,7 +652,7 @@ msgstr ""
 msgid "Select strand"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1032
+#: lib/lanttern_web/components/grades_reports_components.ex:1044
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:25
 #, elixir-autogen, elixir-format
 msgid "Strand"
@@ -666,7 +668,7 @@ msgstr ""
 msgid "and search by code wrapping it in parenthesis"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:208
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:206
 #, elixir-autogen, elixir-format
 msgid "Add descriptor"
 msgstr ""
@@ -681,8 +683,8 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:161
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:182
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:159
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:180
 #, elixir-autogen, elixir-format
 msgid "Descriptors"
 msgstr ""
@@ -699,13 +701,13 @@ msgstr ""
 
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:35
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex:35
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:194
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:192
 #, elixir-autogen, elixir-format
 msgid "Score"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:162
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:183
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:160
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Markdown supported in descriptors"
 msgstr ""
@@ -798,7 +800,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:2137
+#: lib/lanttern_web/components/core_components.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -818,7 +820,7 @@ msgstr ""
 msgid "Save moment"
 msgstr ""
 
-#: lib/lanttern/learning_context.ex:678
+#: lib/lanttern/learning_context.ex:679
 #: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:220
@@ -926,30 +928,31 @@ msgid "Already selected"
 msgstr ""
 
 #: lib/lanttern/curricula/curriculum_component.ex:31
+#: lib/lanttern/student_tags/tag.ex:43
 #: lib/lanttern/students_records/student_record_status.ex:45
 #: lib/lanttern/students_records/student_record_tag.ex:43
 #, elixir-autogen, elixir-format
 msgid "Background color format not accepted. Use hex color."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:758
+#: lib/lanttern_web/components/grades_reports_components.ex:770
 #, elixir-autogen, elixir-format
 msgid "Calculate all"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:947
+#: lib/lanttern_web/components/grades_reports_components.ex:959
 #, elixir-autogen, elixir-format
 msgid "Calculate grade"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:574
-#: lib/lanttern_web/components/grades_reports_components.ex:819
+#: lib/lanttern_web/components/grades_reports_components.ex:586
+#: lib/lanttern_web/components/grades_reports_components.ex:831
 #, elixir-autogen, elixir-format
 msgid "Calculate student grades"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:526
-#: lib/lanttern_web/components/grades_reports_components.ex:782
+#: lib/lanttern_web/components/grades_reports_components.ex:538
+#: lib/lanttern_web/components/grades_reports_components.ex:794
 #, elixir-autogen, elixir-format
 msgid "Calculate subject grades"
 msgstr ""
@@ -971,14 +974,14 @@ msgid "Code"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:81
-#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:79
+#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:76
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:276
+#: lib/lanttern_web/components/grades_reports_components.ex:288
 #, elixir-autogen, elixir-format
 msgid "Comp"
 msgstr ""
@@ -1011,7 +1014,7 @@ msgstr ""
 msgid "Curriculum item deleted"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1106
+#: lib/lanttern_web/components/grades_reports_components.ex:1118
 #: lib/lanttern_web/components/reporting_components.ex:152
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:9
@@ -1034,10 +1037,10 @@ msgid "Cycle already added to this grade report"
 msgstr ""
 
 #: lib/lanttern_web/components/reporting_components.ex:355
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:268
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:323
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:353
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:374
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:267
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:322
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:352
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:373
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:78
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:150
 #, elixir-autogen, elixir-format
@@ -1149,8 +1152,8 @@ msgstr ""
 msgid "Filter curriculum items by year"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1066
-#: lib/lanttern_web/components/grades_reports_components.ex:1133
+#: lib/lanttern_web/components/grades_reports_components.ex:1078
+#: lib/lanttern_web/components/grades_reports_components.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Final grade"
 msgstr ""
@@ -1162,7 +1165,7 @@ msgid "Grade calculated succesfully"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:84
-#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:82
+#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:88
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:39
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:39
 #, elixir-autogen, elixir-format
@@ -1205,7 +1208,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:31
-#: lib/lanttern_web/live/shared/menu_component.ex:464
+#: lib/lanttern_web/live/shared/menu_component.ex:465
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr ""
@@ -1249,7 +1252,7 @@ msgstr ""
 msgid "Link strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:128
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:126
 #, elixir-autogen, elixir-format
 msgid "List of report cards linked to this strand."
 msgstr ""
@@ -1259,7 +1262,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:2127
+#: lib/lanttern_web/components/core_components.ex:2137
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1291,8 +1294,8 @@ msgid "No curriculum items found for selected filters."
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:132
-#: lib/lanttern_web/components/grades_reports_components.ex:471
-#: lib/lanttern_web/components/grades_reports_components.ex:793
+#: lib/lanttern_web/components/grades_reports_components.ex:483
+#: lib/lanttern_web/components/grades_reports_components.ex:805
 #, elixir-autogen, elixir-format
 msgid "No cycles linked to this grades report"
 msgstr ""
@@ -1312,8 +1315,8 @@ msgstr ""
 msgid "No strands linked to this report yet"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:617
-#: lib/lanttern_web/components/grades_reports_components.ex:845
+#: lib/lanttern_web/components/grades_reports_components.ex:629
+#: lib/lanttern_web/components/grades_reports_components.ex:857
 #: lib/lanttern_web/components/reporting_components.ex:485
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
@@ -1325,14 +1328,14 @@ msgid "No subjects linked"
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:179
-#: lib/lanttern_web/components/grades_reports_components.ex:540
-#: lib/lanttern_web/components/grades_reports_components.ex:543
+#: lib/lanttern_web/components/grades_reports_components.ex:552
+#: lib/lanttern_web/components/grades_reports_components.ex:555
 #, elixir-autogen, elixir-format
 msgid "No subjects linked to this grades report"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1036
-#: lib/lanttern_web/components/grades_reports_components.ex:1109
+#: lib/lanttern_web/components/grades_reports_components.ex:1048
+#: lib/lanttern_web/components/grades_reports_components.ex:1121
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:50
 #, elixir-autogen, elixir-format
 msgid "Normalized value"
@@ -1357,13 +1360,14 @@ msgid "Partial results"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:309
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:75
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:58
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:922
+#: lib/lanttern_web/components/grades_reports_components.ex:934
 #, elixir-autogen, elixir-format
 msgid "Recalculate grade"
 msgstr ""
@@ -1396,11 +1400,11 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:22
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:25
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:126
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:124
 #: lib/lanttern_web/live/pages/student_report_cards/student_report_cards_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:458
-#: lib/lanttern_web/live/shared/menu_component.ex:477
-#: lib/lanttern_web/live/shared/menu_component.ex:502
+#: lib/lanttern_web/live/shared/menu_component.ex:459
+#: lib/lanttern_web/live/shared/menu_component.ex:478
+#: lib/lanttern_web/live/shared/menu_component.ex:503
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr ""
@@ -1408,7 +1412,7 @@ msgstr ""
 #: lib/lanttern_web/components/reporting_components.ex:83
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:224
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:104
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:72
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "Rubric criteria"
 msgstr ""
@@ -1466,7 +1470,7 @@ msgstr ""
 msgid "Strand already linked to report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:151
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:149
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:56
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format
@@ -1544,6 +1548,7 @@ msgid "Subject grades calculated succesfully"
 msgstr ""
 
 #: lib/lanttern/curricula/curriculum_component.ex:35
+#: lib/lanttern/student_tags/tag.ex:47
 #: lib/lanttern/students_records/student_record_status.ex:49
 #: lib/lanttern/students_records/student_record_tag.ex:47
 #, elixir-autogen, elixir-format
@@ -1566,8 +1571,8 @@ msgstr ""
 msgid "Use the differentiation flag above when creating assessment points related to a curriculum level differentiation."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1035
-#: lib/lanttern_web/components/grades_reports_components.ex:1108
+#: lib/lanttern_web/components/grades_reports_components.ex:1047
+#: lib/lanttern_web/components/grades_reports_components.ex:1120
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Weight"
@@ -1659,7 +1664,7 @@ msgstr ""
 msgid "About this assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:90
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:88
 #, elixir-autogen, elixir-format
 msgid "Report info"
 msgstr ""
@@ -1670,7 +1675,7 @@ msgstr ""
 msgid "Report information"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:686
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:685
 #, elixir-autogen, elixir-format
 msgid "1 entry updated"
 msgid_plural "%{count} entries updated"
@@ -1748,7 +1753,7 @@ msgid_plural "%{count} changes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:142
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:140
 #, elixir-autogen, elixir-format
 msgid "No report cards linked to this strand"
 msgstr ""
@@ -2133,19 +2138,19 @@ msgstr ""
 msgid "Attachments"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:108
+#: lib/lanttern/personalization/profile_settings.ex:111
 #, elixir-autogen, elixir-format
 msgid "Invalid assessment view"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:76
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:74
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:12
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:430
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:429
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:427
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:426
 #, elixir-autogen, elixir-format
 msgid "Teacher"
 msgstr ""
@@ -2163,7 +2168,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/reporting_components.ex:40
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:216
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:294
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:301
 #, elixir-autogen, elixir-format
 msgid "Teacher comment"
 msgstr ""
@@ -2188,17 +2193,17 @@ msgstr ""
 msgid "Visibility in grades reports"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:752
+#: lib/lanttern_web/components/grades_reports_components.ex:764
 #, elixir-autogen, elixir-format
 msgid "Are you sure? All grades will be created, updated, and removed based on their grade composition."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:822
+#: lib/lanttern_web/components/grades_reports_components.ex:834
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Grades related to this student will be created, updated, and removed based on their grade composition."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:785
+#: lib/lanttern_web/components/grades_reports_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Grades related to this subject will be created, updated, and removed based on their grade composition."
 msgstr ""
@@ -2244,12 +2249,12 @@ msgid_plural "%{count} grades partially updated (only compositions, manual grade
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:927
+#: lib/lanttern_web/components/grades_reports_components.ex:939
 #, elixir-autogen, elixir-format
 msgid "There is a manual grade change that will be overwritten by this operation. Are you sure you want to proceed?"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:417
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:416
 #, elixir-autogen, elixir-format
 msgid "(Strand final assessment)"
 msgstr ""
@@ -2291,18 +2296,18 @@ msgstr ""
 msgid "Compare teacher/students"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:415
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:233
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:414
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:231
 #, elixir-autogen, elixir-format
 msgid "Goal assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:280
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:279
 #, elixir-autogen, elixir-format
 msgid "Goals assessment"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:113
+#: lib/lanttern/personalization/profile_settings.ex:116
 #, elixir-autogen, elixir-format
 msgid "Invalid assessment group by option"
 msgstr ""
@@ -2379,7 +2384,7 @@ msgstr ""
 msgid "Strand removed from your starred list"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:309
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:316
 #, elixir-autogen, elixir-format
 msgid "Assessment info"
 msgstr ""
@@ -2407,12 +2412,12 @@ msgid "Formative assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:51
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:247
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:254
 #, elixir-autogen, elixir-format
 msgid "Formative assessment pattern"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:313
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:320
 #, elixir-autogen, elixir-format
 msgid "Has rubric"
 msgstr ""
@@ -2430,7 +2435,7 @@ msgid "No entry"
 msgstr ""
 
 #: lib/lanttern_web/components/reporting_components.ex:44
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:299
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:306
 #, elixir-autogen, elixir-format
 msgid "Student comment"
 msgstr ""
@@ -2470,7 +2475,7 @@ msgstr ""
 msgid "Goals assessment entries"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:123
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:130
 #, elixir-autogen, elixir-format
 msgid "Goals without assessment entries"
 msgstr ""
@@ -2512,22 +2517,22 @@ msgstr ""
 msgid "No teacher assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:93
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:91
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:29
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:96
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:52
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:55
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:124
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:262
 #, elixir-autogen, elixir-format
 msgid "Classes"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:106
+#: lib/lanttern_web/live/pages/school/classes_component.ex:111
 #, elixir-autogen, elixir-format
 msgid "Filter classes by year"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:90
+#: lib/lanttern_web/live/pages/school/classes_component.ex:95
 #, elixir-autogen, elixir-format
 msgid "No students in this class"
 msgstr ""
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "View assessment details"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:304
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:311
 #, elixir-autogen, elixir-format
 msgid "With learning evidences"
 msgstr ""
@@ -2587,28 +2592,28 @@ msgstr ""
 msgid "Edit student record"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:209
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:207
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Filter records by student"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:82
+#: lib/lanttern/personalization/profile_settings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Invalid permissions"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:147
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:199
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:147
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:146
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:197
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:146
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Load more records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:89
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:143
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:89
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:88
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:141
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:88
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "New student record"
@@ -2619,9 +2624,9 @@ msgstr ""
 msgid "No student records found for selected filters."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:39
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:110
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:39
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:38
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:108
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:38
 #: lib/lanttern_web/live/pages/students_records/settings/students_records_settings_live.html.heex:12
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:46
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:72
@@ -2630,15 +2635,15 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:216
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:214
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Type the name of the student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:152
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:232
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:152
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:151
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:230
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:151
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Filter student records by status"
@@ -2666,23 +2671,23 @@ msgstr ""
 msgid "All final grades calculated succesfully"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:448
+#: lib/lanttern_web/components/grades_reports_components.ex:460
 #, elixir-autogen, elixir-format
 msgid "Are you sure? All final grades will be created, updated, and removed based on their grade composition."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:577
+#: lib/lanttern_web/components/grades_reports_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Final grades related to this student will be created, updated, and removed based on their grade composition."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:529
+#: lib/lanttern_web/components/grades_reports_components.ex:541
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Final grades related to this subject will be created, updated, and removed based on their grade composition."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:442
-#: lib/lanttern_web/components/grades_reports_components.ex:452
+#: lib/lanttern_web/components/grades_reports_components.ex:454
+#: lib/lanttern_web/components/grades_reports_components.ex:464
 #, elixir-autogen, elixir-format
 msgid "Calculate final grades"
 msgstr ""
@@ -2735,17 +2740,17 @@ msgstr ""
 msgid "Final grade details"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:438
+#: lib/lanttern_web/components/grades_reports_components.ex:450
 #, elixir-autogen, elixir-format
 msgid "Final grades"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:463
+#: lib/lanttern_web/components/grades_reports_components.ex:475
 #, elixir-autogen, elixir-format
 msgid "Final grades are visible"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:464
+#: lib/lanttern_web/components/grades_reports_components.ex:476
 #, elixir-autogen, elixir-format
 msgid "Final grades not visible"
 msgstr ""
@@ -2760,7 +2765,7 @@ msgstr ""
 msgid "No subcycle entries for this subject"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:456
+#: lib/lanttern_web/components/grades_reports_components.ex:468
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_grid_configuration_overlay_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "Parent cycle visibility"
@@ -2822,18 +2827,18 @@ msgid "Add class"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:32
-#: lib/lanttern_web/live/pages/school/students_component.ex:37
+#: lib/lanttern_web/live/pages/school/students_component.ex:52
 #, elixir-autogen, elixir-format
 msgid "Add student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:133
+#: lib/lanttern_web/live/pages/school/classes_component.ex:138
 #, elixir-autogen, elixir-format
 msgid "Class created successfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.ex:99
-#: lib/lanttern_web/live/pages/school/classes_component.ex:156
+#: lib/lanttern_web/live/pages/school/classes_component.ex:161
 #, elixir-autogen, elixir-format
 msgid "Class deleted successfully"
 msgstr ""
@@ -2844,12 +2849,12 @@ msgid "Class name already in use in this cycle"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.ex:90
-#: lib/lanttern_web/live/pages/school/classes_component.ex:142
+#: lib/lanttern_web/live/pages/school/classes_component.ex:147
 #, elixir-autogen, elixir-format
 msgid "Class updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:220
+#: lib/lanttern_web/live/pages/school/classes_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Create class"
 msgstr ""
@@ -2857,32 +2862,32 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.html.heex:31
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.html.heex:66
 #: lib/lanttern_web/live/pages/school/classes_component.ex:52
-#: lib/lanttern_web/live/pages/school/classes_component.ex:232
+#: lib/lanttern_web/live/pages/school/classes_component.ex:237
 #, elixir-autogen, elixir-format
 msgid "Edit class"
 msgstr ""
 
-#: lib/lanttern_web/components/schools_components.ex:126
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:164
+#: lib/lanttern_web/components/schools_components.ex:138
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:165
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:40
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:88
-#: lib/lanttern_web/live/pages/school/students_component.ex:176
+#: lib/lanttern_web/live/pages/school/students_component.ex:223
 #, elixir-autogen, elixir-format
 msgid "Edit student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students_component.ex:54
+#: lib/lanttern_web/live/pages/school/students_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "Filter students by class"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:156
-#: lib/lanttern_web/live/pages/school/students_component.ex:168
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:157
+#: lib/lanttern_web/live/pages/school/students_component.ex:211
 #, elixir-autogen, elixir-format
 msgid "New student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:98
+#: lib/lanttern_web/live/pages/school/classes_component.ex:103
 #, elixir-autogen, elixir-format
 msgid "No classes matching current filters"
 msgstr ""
@@ -2893,7 +2898,7 @@ msgid "No students added to this class"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:80
-#: lib/lanttern_web/live/pages/school/students_component.ex:84
+#: lib/lanttern_web/live/pages/school/students_component.ex:123
 #, elixir-autogen, elixir-format
 msgid "Student created successfully"
 msgstr ""
@@ -2905,7 +2910,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:81
 #: lib/lanttern_web/live/pages/school/students/id/student_live.ex:82
-#: lib/lanttern_web/live/pages/school/students_component.ex:95
+#: lib/lanttern_web/live/pages/school/students_component.ex:134
 #, elixir-autogen, elixir-format
 msgid "Student updated successfully"
 msgstr ""
@@ -3010,7 +3015,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:111
 #: lib/lanttern_web/live/pages/student_report_cards/student_report_cards_live.ex:108
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:155
-#: lib/lanttern_web/live/shared/menu_component.ex:581
+#: lib/lanttern_web/live/shared/menu_component.ex:582
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr ""
@@ -3238,7 +3243,7 @@ msgstr ""
 msgid "Parent cycle"
 msgstr ""
 
-#: lib/lanttern/schools.ex:361
+#: lib/lanttern/schools.ex:362
 #, elixir-autogen, elixir-format
 msgid "Parent cycle does not exist"
 msgstr ""
@@ -3345,7 +3350,7 @@ msgstr ""
 msgid "Using a parent cycle from a different school is not allowed"
 msgstr ""
 
-#: lib/lanttern/schools.ex:354
+#: lib/lanttern/schools.ex:355
 #, elixir-autogen, elixir-format
 msgid "You can't use a subcycle as a parent cycle"
 msgstr ""
@@ -3360,7 +3365,7 @@ msgstr ""
 msgid "Link strand to report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:225
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:223
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "Filter student records by class"
@@ -3379,9 +3384,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:16
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:19
 #: lib/lanttern_web/live/pages/students_records/settings/students_records_settings_live.html.heex:3
-#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:26
+#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:27
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:434
+#: lib/lanttern_web/live/shared/menu_component.ex:435
 #, elixir-autogen, elixir-format
 msgid "Student records"
 msgstr ""
@@ -3391,12 +3396,12 @@ msgstr ""
 msgid "This record was deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:30
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access to information in this area is restricted to school staff"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:40
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Add school area student info..."
 msgstr ""
@@ -3412,14 +3417,14 @@ msgid "Check the student and school relationship"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/staff_component.ex:64
-#: lib/lanttern_web/live/shared/schools/student_header_component.ex:38
+#: lib/lanttern_web/live/shared/schools/student_header_component.ex:39
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:38
 #, elixir-autogen, elixir-format
 msgid "Edit cycle profile picture"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:57
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:106
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:58
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:107
 #, elixir-autogen, elixir-format
 msgid "Edit information"
 msgstr ""
@@ -3429,23 +3434,23 @@ msgstr ""
 msgid "No classes"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/schools/student_header_component.ex:78
+#: lib/lanttern_web/live/shared/schools/student_header_component.ex:84
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "No classes linked to student in cycle"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:46
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "No information about student in school area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:27
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:28
 #, elixir-autogen, elixir-format
 msgid "School area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:67
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:68
 #, elixir-autogen, elixir-format
 msgid "School area attachments"
 msgstr ""
@@ -3578,27 +3583,27 @@ msgid_plural "%{count} attachments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:89
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:90
 #, elixir-autogen, elixir-format
 msgid "Add student area info..."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:79
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:80
 #, elixir-autogen, elixir-format
 msgid "Information shared with student and guardians"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:95
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:96
 #, elixir-autogen, elixir-format
 msgid "No information in student area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:75
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "Student area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:116
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:117
 #, elixir-autogen, elixir-format
 msgid "Student area attachments"
 msgstr ""
@@ -3688,7 +3693,7 @@ msgid "Edit staff member"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:73
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:67
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:87
 #, elixir-autogen, elixir-format
 msgid "Enables the user to login at Lanttern via Google Sign In"
 msgstr ""
@@ -3710,7 +3715,7 @@ msgid "Invalid staff member"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:68
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Lanttern user email"
 msgstr ""
@@ -3725,9 +3730,9 @@ msgstr ""
 msgid "No staff members found"
 msgstr ""
 
-#: lib/lanttern_web/components/schools_components.ex:179
+#: lib/lanttern_web/components/schools_components.ex:191
 #: lib/lanttern_web/live/pages/school/staff/deactivated/deactivated_staff_live.html.heex:40
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:102
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "Reactivate"
 msgstr ""
@@ -3737,7 +3742,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:446
+#: lib/lanttern_web/live/shared/menu_component.ex:447
 #, elixir-autogen, elixir-format
 msgid "School management"
 msgstr ""
@@ -3771,7 +3776,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:86
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:81
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:101
 #, elixir-autogen, elixir-format
 msgid "Deactivate"
 msgstr ""
@@ -3812,14 +3817,14 @@ msgstr ""
 msgid "Assigned to"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:48
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:63
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:46
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "Assigned to %{staff_member}"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:72
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:72
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:71
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:71
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Assignee"
@@ -3836,8 +3841,8 @@ msgstr ""
 msgid "Created by"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:188
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:188
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:187
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:187
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Filter records by assignee"
@@ -3849,8 +3854,8 @@ msgstr ""
 msgid "Internal student record tracking"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:119
-#: lib/lanttern/personalization/profile_settings.ex:124
+#: lib/lanttern/personalization/profile_settings.ex:122
+#: lib/lanttern/personalization/profile_settings.ex:127
 #, elixir-autogen, elixir-format
 msgid "Invalid view option"
 msgstr ""
@@ -3860,9 +3865,9 @@ msgstr ""
 msgid "My area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:95
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:149
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:95
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:94
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:147
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:94
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Showing 1 result for selected filters"
@@ -3875,8 +3880,8 @@ msgstr[1] ""
 msgid "Staff member deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:195
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:195
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:194
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:194
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:233
 #, elixir-autogen, elixir-format
 msgid "Type the name of the assignee"
@@ -3887,8 +3892,8 @@ msgstr ""
 msgid "View more"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:45
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:57
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:43
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Created by %{staff_member}"
 msgstr ""
@@ -3909,6 +3914,7 @@ msgstr ""
 msgid "At least 1 tag is required"
 msgstr ""
 
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:45
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:45
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:45
 #, elixir-autogen, elixir-format
@@ -3925,9 +3931,9 @@ msgstr ""
 msgid "Edit tag"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:166
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:246
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:166
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:165
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:244
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:165
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Filter student records by tag"
@@ -3956,6 +3962,7 @@ msgstr ""
 msgid "New status"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:24
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:26
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:136
 #, elixir-autogen, elixir-format
@@ -4005,24 +4012,28 @@ msgstr ""
 msgid "Student records settings"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:80
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:88
 #, elixir-autogen, elixir-format
 msgid "Tag created successfully"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:82
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:90
 #, elixir-autogen, elixir-format
 msgid "Tag deleted successfully"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:81
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:89
 #, elixir-autogen, elixir-format
 msgid "Tag updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:64
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:135
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:64
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:63
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:133
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:63
+#: lib/lanttern_web/live/pages/school/students_component.ex:43
 #: lib/lanttern_web/live/pages/students_records/settings/students_records_settings_live.html.heex:15
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:71
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:85
@@ -4031,23 +4042,24 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:52
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:52
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:52
 #, elixir-autogen, elixir-format
 msgid "Text color (hex)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:104
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:158
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:104
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:103
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:156
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:103
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "All records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:115
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:169
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:115
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:114
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:167
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:114
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "All records, newest first"
@@ -4084,17 +4096,17 @@ msgstr ""
 msgid "If active, assigning this status to an existing record will close it and calculate the time since its creation."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:105
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:159
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:105
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:104
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:157
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:104
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Only open"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:119
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:173
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:119
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:118
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:171
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:118
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Only open, oldest first"
@@ -4170,27 +4182,27 @@ msgstr ""
 msgid "%{school}'s deactivated students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:206
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:207
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "%{student} deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:182
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:183
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "%{student} reactivated"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1916
-#: lib/lanttern_web/components/core_components.ex:1924
+#: lib/lanttern_web/components/core_components.ex:1917
+#: lib/lanttern_web/components/core_components.ex:1925
 #, elixir-autogen, elixir-format
 msgid "(Deactivated)"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:17
 #: lib/lanttern_web/live/pages/school/classes_component.ex:60
-#: lib/lanttern_web/live/pages/school/students_component.ex:26
+#: lib/lanttern_web/live/pages/school/students_component.ex:45
 #, elixir-autogen, elixir-format
 msgid "1 active student"
 msgid_plural "%{count} active students"
@@ -4207,18 +4219,18 @@ msgstr[1] ""
 
 #: lib/lanttern_web/live/pages/school/message_board/archive/archived_messages_live.html.heex:13
 #: lib/lanttern_web/live/pages/school/message_board_component.ex:32
-#: lib/lanttern_web/live/pages/school/students_component.ex:24
+#: lib/lanttern_web/live/pages/school/students_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "All classes"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:79
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Are you sure? You can reactive the student later."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:84
-#: lib/lanttern_web/live/shared/schools/student_header_component.ex:64
+#: lib/lanttern_web/live/pages/school/classes_component.ex:89
+#: lib/lanttern_web/live/shared/schools/student_header_component.ex:65
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Deactivated"
@@ -4229,20 +4241,20 @@ msgstr ""
 msgid "Deactivated students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:213
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:214
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Failed to delete student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:189
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:190
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Failed to reactivate student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:192
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:216
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:193
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:217
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:77
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:102
 #, elixir-autogen, elixir-format
@@ -4256,7 +4268,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:82
 #: lib/lanttern_web/live/pages/school/students/id/student_live.ex:91
-#: lib/lanttern_web/live/pages/school/students_component.ex:96
+#: lib/lanttern_web/live/pages/school/students_component.ex:135
 #, elixir-autogen, elixir-format
 msgid "Student deactivated successfully"
 msgstr ""
@@ -4266,7 +4278,7 @@ msgstr ""
 msgid "Student reactivated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students_component.ex:28
+#: lib/lanttern_web/live/pages/school/students_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "View deactivated students"
 msgstr ""
@@ -4365,8 +4377,8 @@ msgstr ""
 msgid "Filter messages by class"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:471
-#: lib/lanttern_web/live/shared/menu_component.ex:496
+#: lib/lanttern_web/live/shared/menu_component.ex:472
+#: lib/lanttern_web/live/shared/menu_component.ex:497
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -4420,6 +4432,7 @@ msgid "No messages matching current filters created yet"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/schools/classes_field_component.ex:48
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "No selected classes"
 msgstr ""
@@ -4545,13 +4558,13 @@ msgstr ""
 msgid "Add section"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:71
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:72
 #, elixir-autogen, elixir-format
 msgid "Create %{student}'s %{cycle} ILP"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:126
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:366
+#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:127
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:367
 #, elixir-autogen, elixir-format
 msgid "Create ILP"
 msgstr ""
@@ -4566,7 +4579,7 @@ msgstr ""
 msgid "Delete template"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:377
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:378
 #, elixir-autogen, elixir-format
 msgid "Edit ILP"
 msgstr ""
@@ -4575,18 +4588,18 @@ msgstr ""
 #: lib/lanttern_web/live/pages/ilp/settings/ilp_settings_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:13
 #: lib/lanttern_web/live/pages/student_ilp/student_ilp_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:440
-#: lib/lanttern_web/live/shared/menu_component.ex:514
+#: lib/lanttern_web/live/shared/menu_component.ex:441
+#: lib/lanttern_web/live/shared/menu_component.ex:515
 #, elixir-autogen, elixir-format
 msgid "ILP"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:204
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:205
 #, elixir-autogen, elixir-format
 msgid "ILP created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:206
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:207
 #, elixir-autogen, elixir-format
 msgid "ILP deleted successfully"
 msgstr ""
@@ -4618,7 +4631,7 @@ msgstr ""
 msgid "ILP template updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:205
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:206
 #, elixir-autogen, elixir-format
 msgid "ILP updated successfully"
 msgstr ""
@@ -4636,7 +4649,7 @@ msgid "No ILP model selected"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:68
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:59
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "No ILP template selected"
 msgstr ""
@@ -4648,7 +4661,7 @@ msgstr ""
 msgid "No ILP templates registered in your school. Talk to your Lanttern school manager."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:62
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "No student ILP created yet"
 msgstr ""
@@ -4699,12 +4712,12 @@ msgstr ""
 msgid "You don't have access to ILP settings page"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:232
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:230
 #, elixir-autogen, elixir-format
 msgid "%{curriculum} final assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:104
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:102
 #, elixir-autogen, elixir-format
 msgid "About rubrics and assessment points relationships"
 msgstr ""
@@ -4724,28 +4737,28 @@ msgstr ""
 msgid "Add diff rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:188
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:186
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:92
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:144
 #, elixir-autogen, elixir-format
 msgid "Assessment point and entries deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:179
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:177
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:83
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:135
 #, elixir-autogen, elixir-format
 msgid "Assessment point created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:185
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:183
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:89
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:141
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:182
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:180
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:86
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:138
 #, elixir-autogen, elixir-format
@@ -4764,7 +4777,7 @@ msgid "Curriculum item"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:291
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:53
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Differentiation rubric"
 msgstr ""
@@ -4784,17 +4797,17 @@ msgstr ""
 msgid "Edit rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:690
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:689
 #, elixir-autogen, elixir-format
 msgid "Error updating assessment point entries"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:112
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:110
 #, elixir-autogen, elixir-format
 msgid "In case of differentiation rubrics, we can also link them directly to a student via assessment point entry."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:78
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "Link rubric to assessment points"
 msgstr ""
@@ -4804,7 +4817,7 @@ msgstr ""
 msgid "Linked students"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:226
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:224
 #, elixir-autogen, elixir-format
 msgid "Moment %{moment}"
 msgstr ""
@@ -4819,7 +4832,7 @@ msgstr ""
 msgid "New rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:80
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:78
 #, elixir-autogen, elixir-format
 msgid "No assessment point matching curriculum, scale, and differentiation flag"
 msgstr ""
@@ -4861,12 +4874,12 @@ msgstr ""
 msgid "Rubric deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:41
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:39
 #, elixir-autogen, elixir-format
 msgid "Rubric for curriculum item"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:107
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:105
 #, elixir-autogen, elixir-format
 msgid "Rubrics can be linked to assessment points with matching curriculum item, scale, and differentiation type."
 msgstr ""
@@ -4897,7 +4910,7 @@ msgstr ""
 msgid "There are two ways to \"connect\" students and differentiation rubrics:"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:66
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:64
 #, elixir-autogen, elixir-format
 msgid "Uses rubric in final assessment"
 msgstr ""
@@ -4961,7 +4974,7 @@ msgstr ""
 msgid "Metrics"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:489
+#: lib/lanttern_web/live/shared/menu_component.ex:490
 #, elixir-autogen, elixir-format
 msgid "My ILP"
 msgstr ""
@@ -4983,24 +4996,24 @@ msgstr ""
 msgid "Template instructions (visible to staff only)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:93
+#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:94
 #, elixir-autogen, elixir-format
 msgid "View ILP"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:115
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:116
 #, elixir-autogen, elixir-format
 msgid "(1 minute left until next revision request)"
 msgid_plural "(%{count} minutes left until next revision request)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:112
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "AI revision can be requested every %{minute} minutes"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:407
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:408
 #, elixir-autogen, elixir-format
 msgid "AI revision failed"
 msgstr ""
@@ -5015,47 +5028,47 @@ msgstr ""
 msgid "Add instructions on how Lanttern should revise this ILP."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:412
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:413
 #, elixir-autogen, elixir-format
 msgid "Age should be a number between 0 and 100"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:97
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:98
 #, elixir-autogen, elixir-format
 msgid "Generated in %{datetime}"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:136
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:137
 #, elixir-autogen, elixir-format
 msgid "Inform the approximated age of the student (in years), and ask for Lanttern AI revision."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:132
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:133
 #, elixir-autogen, elixir-format
 msgid "Inform the approximated age of the student (in years), and ask for an updated Lanttern AI revision."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:94
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lanttern AI revision"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:105
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:106
 #, elixir-autogen, elixir-format
 msgid "Remember that AI make mistakes. Always double-check generated responses."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:152
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:153
 #, elixir-autogen, elixir-format
 msgid "Request AI review"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:151
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:152
 #, elixir-autogen, elixir-format
 msgid "Request AI review update"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:145
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:146
 #, elixir-autogen, elixir-format
 msgid "Student age"
 msgstr ""
@@ -5113,4 +5126,55 @@ msgstr ""
 #: lib/lanttern_web/live/shared/grading/scale_info_table_component.ex:23
 #, elixir-autogen, elixir-format
 msgid "Scale ranges"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:137
+#, elixir-autogen, elixir-format
+msgid "Edit student tag"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students_component.ex:83
+#, elixir-autogen, elixir-format
+msgid "Filter students by tag"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:17
+#, elixir-autogen, elixir-format
+msgid "Manage student tags below"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:128
+#, elixir-autogen, elixir-format
+msgid "New student tag"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:52
+#, elixir-autogen, elixir-format
+msgid "No student tags created yet"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/students_settings_live.ex:14
+#, elixir-autogen, elixir-format
+msgid "Student settings"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:62
+#, elixir-autogen, elixir-format
+msgid "Student tags"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students_component.ex:56
+#: lib/lanttern_web/live/pages/students/settings/students_settings_live.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "Students settings"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/students_settings_live.ex:28
+#, elixir-autogen, elixir-format
+msgid "You don't have access to students settings page"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:56
+#, elixir-autogen, elixir-format
+msgid "Use this area to manage the strand curriculum."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -12,13 +12,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: lib/lanttern_web/components/core_components.ex:938
-#: lib/lanttern_web/components/core_components.ex:2187
-#: lib/lanttern_web/components/core_components.ex:2249
+#: lib/lanttern_web/components/core_components.ex:2197
+#: lib/lanttern_web/components/core_components.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1033
+#: lib/lanttern_web/components/grades_reports_components.ex:1045
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:3
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.ex:11
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.html.heex:2
@@ -26,13 +26,13 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:52
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:72
-#: lib/lanttern_web/live/shared/menu_component.ex:452
+#: lib/lanttern_web/live/shared/menu_component.ex:453
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:427
+#: lib/lanttern_web/live/shared/menu_component.ex:428
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr ""
@@ -50,9 +50,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/strands_live.ex:18
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:429
-#: lib/lanttern_web/live/shared/menu_component.ex:483
-#: lib/lanttern_web/live/shared/menu_component.ex:508
+#: lib/lanttern_web/live/shared/menu_component.ex:430
+#: lib/lanttern_web/live/shared/menu_component.ex:484
+#: lib/lanttern_web/live/shared/menu_component.ex:509
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr ""
@@ -126,12 +126,13 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:202
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:161
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:138
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:136
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:114
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:96
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:112
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:132
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:40
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:196
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:102
@@ -187,12 +188,13 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:205
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:164
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:147
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:145
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:61
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:105
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:115
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:141
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:93
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:43
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:205
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:111
@@ -247,7 +249,8 @@ msgstr ""
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:45
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:53
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:44
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:47
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:38
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:49
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:38
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:38
@@ -274,12 +277,13 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:126
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:21
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:39
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:67
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:65
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:40
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:29
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:26
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:35
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:42
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:33
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:44
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:184
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:33
@@ -392,8 +396,8 @@ msgstr ""
 msgid "About"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1034
-#: lib/lanttern_web/components/grades_reports_components.ex:1107
+#: lib/lanttern_web/components/grades_reports_components.ex:1046
+#: lib/lanttern_web/components/grades_reports_components.ex:1119
 #: lib/lanttern_web/live/pages/strand_report/id/student_strand_report_live.html.heex:21
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:17
 #: lib/lanttern_web/live/pages/student_report_cards/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:25
@@ -407,7 +411,7 @@ msgid "Couldn't find strand"
 msgstr ""
 
 #: lib/lanttern_web/components/message_board_components.ex:52
-#: lib/lanttern_web/components/schools_components.ex:187
+#: lib/lanttern_web/components/schools_components.ex:199
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:158
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:109
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:116
@@ -422,11 +426,12 @@ msgstr ""
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:103
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:248
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:130
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:128
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:126
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:109
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:92
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:112
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:338
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:92
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:74
@@ -469,7 +474,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/form_components.ex:742
 #: lib/lanttern_web/components/message_board_components.ex:40
-#: lib/lanttern_web/components/schools_components.ex:185
+#: lib/lanttern_web/components/schools_components.ex:197
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:156
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:107
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:114
@@ -489,11 +494,12 @@ msgstr ""
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:246
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:128
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:126
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:124
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:107
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:90
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:110
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:72
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:336
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:90
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:72
@@ -511,14 +517,14 @@ msgstr ""
 msgid "Delete note"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:69
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:67
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:100
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:88
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:268
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:264
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:275
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:262
 #, elixir-autogen, elixir-format
 msgid "Differentiation"
 msgstr ""
@@ -532,8 +538,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/ilp/settings/ilp_settings_live.html.heex:27
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:41
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:320
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:80
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:78
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:228
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:45
 #: lib/lanttern_web/live/pages/students_records/settings/status_component.ex:61
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:57
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:250
@@ -547,12 +554,12 @@ msgstr ""
 msgid "Goals"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:112
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:110
 #, elixir-autogen, elixir-format
 msgid "Move curriculum item down"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:101
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Move curriculum item up"
 msgstr ""
@@ -574,11 +581,6 @@ msgstr ""
 #: lib/lanttern_web/live/shared/schools/classes_field_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Select a class"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:56
-#, elixir-autogen, elixir-format
-msgid "Under the hood, goals in Lanttern are defined by assessment points linked directly to the strand — when adding goals, we are adding assessment points which, in turn, hold the curriculum items we'll want to assess along the strand course."
 msgstr ""
 
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:188
@@ -650,7 +652,7 @@ msgstr ""
 msgid "Select strand"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1032
+#: lib/lanttern_web/components/grades_reports_components.ex:1044
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:25
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strand"
@@ -666,7 +668,7 @@ msgstr ""
 msgid "and search by code wrapping it in parenthesis"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:208
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:206
 #, elixir-autogen, elixir-format
 msgid "Add descriptor"
 msgstr ""
@@ -681,8 +683,8 @@ msgstr ""
 msgid "Criteria"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:161
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:182
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:159
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:180
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Descriptors"
 msgstr ""
@@ -699,13 +701,13 @@ msgstr ""
 
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:35
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex:35
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:194
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:192
 #, elixir-autogen, elixir-format
 msgid "Score"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:162
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:183
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:160
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:181
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Markdown supported in descriptors"
 msgstr ""
@@ -798,7 +800,7 @@ msgstr ""
 msgid "Moments"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:2137
+#: lib/lanttern_web/components/core_components.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr ""
@@ -818,7 +820,7 @@ msgstr ""
 msgid "Save moment"
 msgstr ""
 
-#: lib/lanttern/learning_context.ex:678
+#: lib/lanttern/learning_context.ex:679
 #: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:220
@@ -926,30 +928,31 @@ msgid "Already selected"
 msgstr ""
 
 #: lib/lanttern/curricula/curriculum_component.ex:31
+#: lib/lanttern/student_tags/tag.ex:43
 #: lib/lanttern/students_records/student_record_status.ex:45
 #: lib/lanttern/students_records/student_record_tag.ex:43
 #, elixir-autogen, elixir-format
 msgid "Background color format not accepted. Use hex color."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:758
+#: lib/lanttern_web/components/grades_reports_components.ex:770
 #, elixir-autogen, elixir-format
 msgid "Calculate all"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:947
+#: lib/lanttern_web/components/grades_reports_components.ex:959
 #, elixir-autogen, elixir-format
 msgid "Calculate grade"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:574
-#: lib/lanttern_web/components/grades_reports_components.ex:819
+#: lib/lanttern_web/components/grades_reports_components.ex:586
+#: lib/lanttern_web/components/grades_reports_components.ex:831
 #, elixir-autogen, elixir-format
 msgid "Calculate student grades"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:526
-#: lib/lanttern_web/components/grades_reports_components.ex:782
+#: lib/lanttern_web/components/grades_reports_components.ex:538
+#: lib/lanttern_web/components/grades_reports_components.ex:794
 #, elixir-autogen, elixir-format
 msgid "Calculate subject grades"
 msgstr ""
@@ -971,14 +974,14 @@ msgid "Code"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:81
-#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:79
+#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:76
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex:49
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Comment"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:276
+#: lib/lanttern_web/components/grades_reports_components.ex:288
 #, elixir-autogen, elixir-format
 msgid "Comp"
 msgstr ""
@@ -1011,7 +1014,7 @@ msgstr ""
 msgid "Curriculum item deleted"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1106
+#: lib/lanttern_web/components/grades_reports_components.ex:1118
 #: lib/lanttern_web/components/reporting_components.ex:152
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:9
@@ -1034,10 +1037,10 @@ msgid "Cycle already added to this grade report"
 msgstr ""
 
 #: lib/lanttern_web/components/reporting_components.ex:355
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:268
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:323
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:353
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:374
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:267
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:322
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:352
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:373
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:78
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:150
 #, elixir-autogen, elixir-format
@@ -1149,8 +1152,8 @@ msgstr ""
 msgid "Filter curriculum items by year"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1066
-#: lib/lanttern_web/components/grades_reports_components.ex:1133
+#: lib/lanttern_web/components/grades_reports_components.ex:1078
+#: lib/lanttern_web/components/grades_reports_components.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Final grade"
 msgstr ""
@@ -1162,7 +1165,7 @@ msgid "Grade calculated succesfully"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:84
-#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:82
+#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:88
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:39
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:39
 #, elixir-autogen, elixir-format
@@ -1205,7 +1208,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:31
-#: lib/lanttern_web/live/shared/menu_component.ex:464
+#: lib/lanttern_web/live/shared/menu_component.ex:465
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr ""
@@ -1249,7 +1252,7 @@ msgstr ""
 msgid "Link strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:128
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:126
 #, elixir-autogen, elixir-format
 msgid "List of report cards linked to this strand."
 msgstr ""
@@ -1259,7 +1262,7 @@ msgstr ""
 msgid "Move down"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:2127
+#: lib/lanttern_web/components/core_components.ex:2137
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1291,8 +1294,8 @@ msgid "No curriculum items found for selected filters."
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:132
-#: lib/lanttern_web/components/grades_reports_components.ex:471
-#: lib/lanttern_web/components/grades_reports_components.ex:793
+#: lib/lanttern_web/components/grades_reports_components.ex:483
+#: lib/lanttern_web/components/grades_reports_components.ex:805
 #, elixir-autogen, elixir-format
 msgid "No cycles linked to this grades report"
 msgstr ""
@@ -1312,8 +1315,8 @@ msgstr ""
 msgid "No strands linked to this report yet"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:617
-#: lib/lanttern_web/components/grades_reports_components.ex:845
+#: lib/lanttern_web/components/grades_reports_components.ex:629
+#: lib/lanttern_web/components/grades_reports_components.ex:857
 #: lib/lanttern_web/components/reporting_components.ex:485
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
@@ -1325,14 +1328,14 @@ msgid "No subjects linked"
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:179
-#: lib/lanttern_web/components/grades_reports_components.ex:540
-#: lib/lanttern_web/components/grades_reports_components.ex:543
+#: lib/lanttern_web/components/grades_reports_components.ex:552
+#: lib/lanttern_web/components/grades_reports_components.ex:555
 #, elixir-autogen, elixir-format
 msgid "No subjects linked to this grades report"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1036
-#: lib/lanttern_web/components/grades_reports_components.ex:1109
+#: lib/lanttern_web/components/grades_reports_components.ex:1048
+#: lib/lanttern_web/components/grades_reports_components.ex:1121
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:50
 #, elixir-autogen, elixir-format
 msgid "Normalized value"
@@ -1357,13 +1360,14 @@ msgid "Partial results"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:309
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:75
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:58
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:922
+#: lib/lanttern_web/components/grades_reports_components.ex:934
 #, elixir-autogen, elixir-format
 msgid "Recalculate grade"
 msgstr ""
@@ -1396,11 +1400,11 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:22
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:25
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:126
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:124
 #: lib/lanttern_web/live/pages/student_report_cards/student_report_cards_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:458
-#: lib/lanttern_web/live/shared/menu_component.ex:477
-#: lib/lanttern_web/live/shared/menu_component.ex:502
+#: lib/lanttern_web/live/shared/menu_component.ex:459
+#: lib/lanttern_web/live/shared/menu_component.ex:478
+#: lib/lanttern_web/live/shared/menu_component.ex:503
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr ""
@@ -1408,7 +1412,7 @@ msgstr ""
 #: lib/lanttern_web/components/reporting_components.ex:83
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:224
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:104
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:72
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:70
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Rubric criteria"
 msgstr ""
@@ -1466,7 +1470,7 @@ msgstr ""
 msgid "Strand already linked to report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:151
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:149
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:56
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format, fuzzy
@@ -1544,6 +1548,7 @@ msgid "Subject grades calculated succesfully"
 msgstr ""
 
 #: lib/lanttern/curricula/curriculum_component.ex:35
+#: lib/lanttern/student_tags/tag.ex:47
 #: lib/lanttern/students_records/student_record_status.ex:49
 #: lib/lanttern/students_records/student_record_tag.ex:47
 #, elixir-autogen, elixir-format
@@ -1566,8 +1571,8 @@ msgstr ""
 msgid "Use the differentiation flag above when creating assessment points related to a curriculum level differentiation."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1035
-#: lib/lanttern_web/components/grades_reports_components.ex:1108
+#: lib/lanttern_web/components/grades_reports_components.ex:1047
+#: lib/lanttern_web/components/grades_reports_components.ex:1120
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Weight"
@@ -1659,7 +1664,7 @@ msgstr ""
 msgid "About this assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:90
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Report info"
 msgstr ""
@@ -1670,7 +1675,7 @@ msgstr ""
 msgid "Report information"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:686
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:685
 #, elixir-autogen, elixir-format
 msgid "1 entry updated"
 msgid_plural "%{count} entries updated"
@@ -1748,7 +1753,7 @@ msgid_plural "%{count} changes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:142
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:140
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No report cards linked to this strand"
 msgstr ""
@@ -2133,19 +2138,19 @@ msgstr ""
 msgid "Attachments"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:108
+#: lib/lanttern/personalization/profile_settings.ex:111
 #, elixir-autogen, elixir-format
 msgid "Invalid assessment view"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:76
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:74
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:12
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:430
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:429
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:427
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:426
 #, elixir-autogen, elixir-format
 msgid "Teacher"
 msgstr ""
@@ -2163,7 +2168,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/reporting_components.ex:40
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:216
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:294
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:301
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Teacher comment"
 msgstr ""
@@ -2188,17 +2193,17 @@ msgstr ""
 msgid "Visibility in grades reports"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:752
+#: lib/lanttern_web/components/grades_reports_components.ex:764
 #, elixir-autogen, elixir-format
 msgid "Are you sure? All grades will be created, updated, and removed based on their grade composition."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:822
+#: lib/lanttern_web/components/grades_reports_components.ex:834
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Grades related to this student will be created, updated, and removed based on their grade composition."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:785
+#: lib/lanttern_web/components/grades_reports_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Grades related to this subject will be created, updated, and removed based on their grade composition."
 msgstr ""
@@ -2244,12 +2249,12 @@ msgid_plural "%{count} grades partially updated (only compositions, manual grade
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:927
+#: lib/lanttern_web/components/grades_reports_components.ex:939
 #, elixir-autogen, elixir-format
 msgid "There is a manual grade change that will be overwritten by this operation. Are you sure you want to proceed?"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:417
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:416
 #, elixir-autogen, elixir-format
 msgid "(Strand final assessment)"
 msgstr ""
@@ -2291,18 +2296,18 @@ msgstr ""
 msgid "Compare teacher/students"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:415
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:233
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:414
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:231
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Goal assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:280
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:279
 #, elixir-autogen, elixir-format
 msgid "Goals assessment"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:113
+#: lib/lanttern/personalization/profile_settings.ex:116
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Invalid assessment group by option"
 msgstr ""
@@ -2379,7 +2384,7 @@ msgstr ""
 msgid "Strand removed from your starred list"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:309
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:316
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment info"
 msgstr ""
@@ -2407,12 +2412,12 @@ msgid "Formative assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:51
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:247
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:254
 #, elixir-autogen, elixir-format
 msgid "Formative assessment pattern"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:313
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:320
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Has rubric"
 msgstr ""
@@ -2430,7 +2435,7 @@ msgid "No entry"
 msgstr ""
 
 #: lib/lanttern_web/components/reporting_components.ex:44
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:299
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:306
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student comment"
 msgstr ""
@@ -2470,7 +2475,7 @@ msgstr ""
 msgid "Goals assessment entries"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:123
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:130
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Goals without assessment entries"
 msgstr ""
@@ -2512,22 +2517,22 @@ msgstr ""
 msgid "No teacher assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:93
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:91
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:29
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:96
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:52
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:55
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:124
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:262
 #, elixir-autogen, elixir-format
 msgid "Classes"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:106
+#: lib/lanttern_web/live/pages/school/classes_component.ex:111
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter classes by year"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:90
+#: lib/lanttern_web/live/pages/school/classes_component.ex:95
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No students in this class"
 msgstr ""
@@ -2562,7 +2567,7 @@ msgstr ""
 msgid "View assessment details"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:304
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:311
 #, elixir-autogen, elixir-format
 msgid "With learning evidences"
 msgstr ""
@@ -2587,28 +2592,28 @@ msgstr ""
 msgid "Edit student record"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:209
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:207
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Filter records by student"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:82
+#: lib/lanttern/personalization/profile_settings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Invalid permissions"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:147
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:199
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:147
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:146
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:197
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:146
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:157
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Load more records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:89
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:143
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:89
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:88
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:141
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:88
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "New student record"
@@ -2619,9 +2624,9 @@ msgstr ""
 msgid "No student records found for selected filters."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:39
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:110
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:39
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:38
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:108
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:38
 #: lib/lanttern_web/live/pages/students_records/settings/students_records_settings_live.html.heex:12
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:46
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:72
@@ -2630,15 +2635,15 @@ msgstr ""
 msgid "Status"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:216
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:214
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Type the name of the student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:152
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:232
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:152
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:151
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:230
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:151
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:207
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter student records by status"
@@ -2666,23 +2671,23 @@ msgstr ""
 msgid "All final grades calculated succesfully"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:448
+#: lib/lanttern_web/components/grades_reports_components.ex:460
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure? All final grades will be created, updated, and removed based on their grade composition."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:577
+#: lib/lanttern_web/components/grades_reports_components.ex:589
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure? Final grades related to this student will be created, updated, and removed based on their grade composition."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:529
+#: lib/lanttern_web/components/grades_reports_components.ex:541
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure? Final grades related to this subject will be created, updated, and removed based on their grade composition."
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:442
-#: lib/lanttern_web/components/grades_reports_components.ex:452
+#: lib/lanttern_web/components/grades_reports_components.ex:454
+#: lib/lanttern_web/components/grades_reports_components.ex:464
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Calculate final grades"
 msgstr ""
@@ -2735,17 +2740,17 @@ msgstr ""
 msgid "Final grade details"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:438
+#: lib/lanttern_web/components/grades_reports_components.ex:450
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Final grades"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:463
+#: lib/lanttern_web/components/grades_reports_components.ex:475
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Final grades are visible"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:464
+#: lib/lanttern_web/components/grades_reports_components.ex:476
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Final grades not visible"
 msgstr ""
@@ -2760,7 +2765,7 @@ msgstr ""
 msgid "No subcycle entries for this subject"
 msgstr ""
 
-#: lib/lanttern_web/components/grades_reports_components.ex:456
+#: lib/lanttern_web/components/grades_reports_components.ex:468
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_grid_configuration_overlay_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "Parent cycle visibility"
@@ -2822,18 +2827,18 @@ msgid "Add class"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:32
-#: lib/lanttern_web/live/pages/school/students_component.ex:37
+#: lib/lanttern_web/live/pages/school/students_component.ex:52
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:133
+#: lib/lanttern_web/live/pages/school/classes_component.ex:138
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Class created successfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.ex:99
-#: lib/lanttern_web/live/pages/school/classes_component.ex:156
+#: lib/lanttern_web/live/pages/school/classes_component.ex:161
 #, elixir-autogen, elixir-format
 msgid "Class deleted successfully"
 msgstr ""
@@ -2844,12 +2849,12 @@ msgid "Class name already in use in this cycle"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.ex:90
-#: lib/lanttern_web/live/pages/school/classes_component.ex:142
+#: lib/lanttern_web/live/pages/school/classes_component.ex:147
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Class updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:220
+#: lib/lanttern_web/live/pages/school/classes_component.ex:225
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Create class"
 msgstr ""
@@ -2857,32 +2862,32 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.html.heex:31
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.html.heex:66
 #: lib/lanttern_web/live/pages/school/classes_component.ex:52
-#: lib/lanttern_web/live/pages/school/classes_component.ex:232
+#: lib/lanttern_web/live/pages/school/classes_component.ex:237
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit class"
 msgstr ""
 
-#: lib/lanttern_web/components/schools_components.ex:126
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:164
+#: lib/lanttern_web/components/schools_components.ex:138
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:165
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:40
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:88
-#: lib/lanttern_web/live/pages/school/students_component.ex:176
+#: lib/lanttern_web/live/pages/school/students_component.ex:223
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students_component.ex:54
+#: lib/lanttern_web/live/pages/school/students_component.ex:76
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter students by class"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:156
-#: lib/lanttern_web/live/pages/school/students_component.ex:168
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:157
+#: lib/lanttern_web/live/pages/school/students_component.ex:211
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:98
+#: lib/lanttern_web/live/pages/school/classes_component.ex:103
 #, elixir-autogen, elixir-format
 msgid "No classes matching current filters"
 msgstr ""
@@ -2893,7 +2898,7 @@ msgid "No students added to this class"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:80
-#: lib/lanttern_web/live/pages/school/students_component.ex:84
+#: lib/lanttern_web/live/pages/school/students_component.ex:123
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student created successfully"
 msgstr ""
@@ -2905,7 +2910,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:81
 #: lib/lanttern_web/live/pages/school/students/id/student_live.ex:82
-#: lib/lanttern_web/live/pages/school/students_component.ex:95
+#: lib/lanttern_web/live/pages/school/students_component.ex:134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student updated successfully"
 msgstr ""
@@ -3010,7 +3015,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:111
 #: lib/lanttern_web/live/pages/student_report_cards/student_report_cards_live.ex:108
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:155
-#: lib/lanttern_web/live/shared/menu_component.ex:581
+#: lib/lanttern_web/live/shared/menu_component.ex:582
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr ""
@@ -3238,7 +3243,7 @@ msgstr ""
 msgid "Parent cycle"
 msgstr ""
 
-#: lib/lanttern/schools.ex:361
+#: lib/lanttern/schools.ex:362
 #, elixir-autogen, elixir-format
 msgid "Parent cycle does not exist"
 msgstr ""
@@ -3345,7 +3350,7 @@ msgstr ""
 msgid "Using a parent cycle from a different school is not allowed"
 msgstr ""
 
-#: lib/lanttern/schools.ex:354
+#: lib/lanttern/schools.ex:355
 #, elixir-autogen, elixir-format
 msgid "You can't use a subcycle as a parent cycle"
 msgstr ""
@@ -3360,7 +3365,7 @@ msgstr ""
 msgid "Link strand to report"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:225
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:223
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:183
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter student records by class"
@@ -3379,9 +3384,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:16
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:19
 #: lib/lanttern_web/live/pages/students_records/settings/students_records_settings_live.html.heex:3
-#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:26
+#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:27
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:434
+#: lib/lanttern_web/live/shared/menu_component.ex:435
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student records"
 msgstr ""
@@ -3391,12 +3396,12 @@ msgstr ""
 msgid "This record was deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:30
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access to information in this area is restricted to school staff"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:40
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Add school area student info..."
 msgstr ""
@@ -3412,14 +3417,14 @@ msgid "Check the student and school relationship"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/staff_component.ex:64
-#: lib/lanttern_web/live/shared/schools/student_header_component.ex:38
+#: lib/lanttern_web/live/shared/schools/student_header_component.ex:39
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:38
 #, elixir-autogen, elixir-format
 msgid "Edit cycle profile picture"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:57
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:106
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:58
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:107
 #, elixir-autogen, elixir-format
 msgid "Edit information"
 msgstr ""
@@ -3429,23 +3434,23 @@ msgstr ""
 msgid "No classes"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/schools/student_header_component.ex:78
+#: lib/lanttern_web/live/shared/schools/student_header_component.ex:84
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "No classes linked to student in cycle"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:46
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "No information about student in school area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:27
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:28
 #, elixir-autogen, elixir-format, fuzzy
 msgid "School area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:67
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:68
 #, elixir-autogen, elixir-format
 msgid "School area attachments"
 msgstr ""
@@ -3578,27 +3583,27 @@ msgid_plural "%{count} attachments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:89
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:90
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add student area info..."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:79
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:80
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Information shared with student and guardians"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:95
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:96
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No information in student area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:75
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:76
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:116
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:117
 #, elixir-autogen, elixir-format
 msgid "Student area attachments"
 msgstr ""
@@ -3688,7 +3693,7 @@ msgid "Edit staff member"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:73
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:67
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:87
 #, elixir-autogen, elixir-format
 msgid "Enables the user to login at Lanttern via Google Sign In"
 msgstr ""
@@ -3710,7 +3715,7 @@ msgid "Invalid staff member"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:68
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Lanttern user email"
 msgstr ""
@@ -3725,9 +3730,9 @@ msgstr ""
 msgid "No staff members found"
 msgstr ""
 
-#: lib/lanttern_web/components/schools_components.ex:179
+#: lib/lanttern_web/components/schools_components.ex:191
 #: lib/lanttern_web/live/pages/school/staff/deactivated/deactivated_staff_live.html.heex:40
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:102
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "Reactivate"
 msgstr ""
@@ -3737,7 +3742,7 @@ msgstr ""
 msgid "Role"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:446
+#: lib/lanttern_web/live/shared/menu_component.ex:447
 #, elixir-autogen, elixir-format
 msgid "School management"
 msgstr ""
@@ -3771,7 +3776,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:86
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:81
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Deactivate"
 msgstr ""
@@ -3812,14 +3817,14 @@ msgstr ""
 msgid "Assigned to"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:48
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:63
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:46
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "Assigned to %{staff_member}"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:72
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:72
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:71
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:71
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Assignee"
@@ -3836,8 +3841,8 @@ msgstr ""
 msgid "Created by"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:188
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:188
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:187
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:187
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:226
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter records by assignee"
@@ -3849,8 +3854,8 @@ msgstr ""
 msgid "Internal student record tracking"
 msgstr ""
 
-#: lib/lanttern/personalization/profile_settings.ex:119
-#: lib/lanttern/personalization/profile_settings.ex:124
+#: lib/lanttern/personalization/profile_settings.ex:122
+#: lib/lanttern/personalization/profile_settings.ex:127
 #, elixir-autogen, elixir-format
 msgid "Invalid view option"
 msgstr ""
@@ -3860,9 +3865,9 @@ msgstr ""
 msgid "My area"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:95
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:149
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:95
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:94
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:147
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:94
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:111
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Showing 1 result for selected filters"
@@ -3875,8 +3880,8 @@ msgstr[1] ""
 msgid "Staff member deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:195
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:195
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:194
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:194
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:233
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Type the name of the assignee"
@@ -3887,8 +3892,8 @@ msgstr ""
 msgid "View more"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:45
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:57
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:43
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:55
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Created by %{staff_member}"
 msgstr ""
@@ -3909,6 +3914,7 @@ msgstr ""
 msgid "At least 1 tag is required"
 msgstr ""
 
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:45
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:45
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:45
 #, elixir-autogen, elixir-format
@@ -3925,9 +3931,9 @@ msgstr ""
 msgid "Edit tag"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:166
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:246
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:166
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:165
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:244
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:165
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:190
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter student records by tag"
@@ -3956,6 +3962,7 @@ msgstr ""
 msgid "New status"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:24
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:26
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:136
 #, elixir-autogen, elixir-format, fuzzy
@@ -4005,24 +4012,28 @@ msgstr ""
 msgid "Student records settings"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:80
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:88
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Tag created successfully"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:82
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:90
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Tag deleted successfully"
 msgstr ""
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:81
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:89
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Tag updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:64
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:135
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:64
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:63
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:133
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:63
+#: lib/lanttern_web/live/pages/school/students_component.ex:43
 #: lib/lanttern_web/live/pages/students_records/settings/students_records_settings_live.html.heex:15
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:71
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:85
@@ -4031,23 +4042,24 @@ msgstr ""
 msgid "Tags"
 msgstr ""
 
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:52
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:52
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:52
 #, elixir-autogen, elixir-format
 msgid "Text color (hex)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:104
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:158
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:104
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:103
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:156
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:103
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "All records"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:115
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:169
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:115
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:114
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:167
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:114
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "All records, newest first"
@@ -4084,17 +4096,17 @@ msgstr ""
 msgid "If active, assigning this status to an existing record will close it and calculate the time since its creation."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:105
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:159
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:105
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:104
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:157
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:104
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Only open"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:119
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:173
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:119
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:118
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:171
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:118
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Only open, oldest first"
@@ -4170,27 +4182,27 @@ msgstr ""
 msgid "%{school}'s deactivated students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:206
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:207
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:91
 #, elixir-autogen, elixir-format, fuzzy
 msgid "%{student} deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:182
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:183
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "%{student} reactivated"
 msgstr ""
 
-#: lib/lanttern_web/components/core_components.ex:1916
-#: lib/lanttern_web/components/core_components.ex:1924
+#: lib/lanttern_web/components/core_components.ex:1917
+#: lib/lanttern_web/components/core_components.ex:1925
 #, elixir-autogen, elixir-format, fuzzy
 msgid "(Deactivated)"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:17
 #: lib/lanttern_web/live/pages/school/classes_component.ex:60
-#: lib/lanttern_web/live/pages/school/students_component.ex:26
+#: lib/lanttern_web/live/pages/school/students_component.ex:45
 #, elixir-autogen, elixir-format
 msgid "1 active student"
 msgid_plural "%{count} active students"
@@ -4207,18 +4219,18 @@ msgstr[1] ""
 
 #: lib/lanttern_web/live/pages/school/message_board/archive/archived_messages_live.html.heex:13
 #: lib/lanttern_web/live/pages/school/message_board_component.ex:32
-#: lib/lanttern_web/live/pages/school/students_component.ex:24
+#: lib/lanttern_web/live/pages/school/students_component.ex:27
 #, elixir-autogen, elixir-format, fuzzy
 msgid "All classes"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:79
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:99
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Are you sure? You can reactive the student later."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:84
-#: lib/lanttern_web/live/shared/schools/student_header_component.ex:64
+#: lib/lanttern_web/live/pages/school/classes_component.ex:89
+#: lib/lanttern_web/live/shared/schools/student_header_component.ex:65
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:55
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Deactivated"
@@ -4229,20 +4241,20 @@ msgstr ""
 msgid "Deactivated students"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:213
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:214
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:99
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to delete student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:189
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:190
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:74
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Failed to reactivate student"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:192
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:216
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:193
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:217
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:77
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:102
 #, elixir-autogen, elixir-format, fuzzy
@@ -4256,7 +4268,7 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:82
 #: lib/lanttern_web/live/pages/school/students/id/student_live.ex:91
-#: lib/lanttern_web/live/pages/school/students_component.ex:96
+#: lib/lanttern_web/live/pages/school/students_component.ex:135
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student deactivated successfully"
 msgstr ""
@@ -4266,7 +4278,7 @@ msgstr ""
 msgid "Student reactivated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/students_component.ex:28
+#: lib/lanttern_web/live/pages/school/students_component.ex:47
 #, elixir-autogen, elixir-format, fuzzy
 msgid "View deactivated students"
 msgstr ""
@@ -4365,8 +4377,8 @@ msgstr ""
 msgid "Filter messages by class"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:471
-#: lib/lanttern_web/live/shared/menu_component.ex:496
+#: lib/lanttern_web/live/shared/menu_component.ex:472
+#: lib/lanttern_web/live/shared/menu_component.ex:497
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr ""
@@ -4420,6 +4432,7 @@ msgid "No messages matching current filters created yet"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/schools/classes_field_component.ex:48
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:75
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No selected classes"
 msgstr ""
@@ -4545,13 +4558,13 @@ msgstr ""
 msgid "Add section"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:71
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:72
 #, elixir-autogen, elixir-format
 msgid "Create %{student}'s %{cycle} ILP"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:126
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:366
+#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:127
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:367
 #, elixir-autogen, elixir-format
 msgid "Create ILP"
 msgstr ""
@@ -4566,7 +4579,7 @@ msgstr ""
 msgid "Delete template"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:377
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:378
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit ILP"
 msgstr ""
@@ -4575,18 +4588,18 @@ msgstr ""
 #: lib/lanttern_web/live/pages/ilp/settings/ilp_settings_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:13
 #: lib/lanttern_web/live/pages/student_ilp/student_ilp_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:440
-#: lib/lanttern_web/live/shared/menu_component.ex:514
+#: lib/lanttern_web/live/shared/menu_component.ex:441
+#: lib/lanttern_web/live/shared/menu_component.ex:515
 #, elixir-autogen, elixir-format
 msgid "ILP"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:204
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:205
 #, elixir-autogen, elixir-format, fuzzy
 msgid "ILP created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:206
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:207
 #, elixir-autogen, elixir-format, fuzzy
 msgid "ILP deleted successfully"
 msgstr ""
@@ -4618,7 +4631,7 @@ msgstr ""
 msgid "ILP template updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:205
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:206
 #, elixir-autogen, elixir-format, fuzzy
 msgid "ILP updated successfully"
 msgstr ""
@@ -4636,7 +4649,7 @@ msgid "No ILP model selected"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:68
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:59
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "No ILP template selected"
 msgstr ""
@@ -4648,7 +4661,7 @@ msgstr ""
 msgid "No ILP templates registered in your school. Talk to your Lanttern school manager."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:62
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "No student ILP created yet"
 msgstr ""
@@ -4699,12 +4712,12 @@ msgstr ""
 msgid "You don't have access to ILP settings page"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:232
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:230
 #, elixir-autogen, elixir-format
 msgid "%{curriculum} final assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:104
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:102
 #, elixir-autogen, elixir-format
 msgid "About rubrics and assessment points relationships"
 msgstr ""
@@ -4724,28 +4737,28 @@ msgstr ""
 msgid "Add diff rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:188
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:186
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:92
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:144
 #, elixir-autogen, elixir-format
 msgid "Assessment point and entries deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:179
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:177
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:83
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:135
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:185
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:183
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:89
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:141
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:182
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:180
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:86
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:138
 #, elixir-autogen, elixir-format, fuzzy
@@ -4764,7 +4777,7 @@ msgid "Curriculum item"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:291
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:53
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:51
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Differentiation rubric"
 msgstr ""
@@ -4784,17 +4797,17 @@ msgstr ""
 msgid "Edit rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:690
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:689
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error updating assessment point entries"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:112
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:110
 #, elixir-autogen, elixir-format
 msgid "In case of differentiation rubrics, we can also link them directly to a student via assessment point entry."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:78
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "Link rubric to assessment points"
 msgstr ""
@@ -4804,7 +4817,7 @@ msgstr ""
 msgid "Linked students"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:226
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:224
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Moment %{moment}"
 msgstr ""
@@ -4819,7 +4832,7 @@ msgstr ""
 msgid "New rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:80
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:78
 #, elixir-autogen, elixir-format
 msgid "No assessment point matching curriculum, scale, and differentiation flag"
 msgstr ""
@@ -4861,12 +4874,12 @@ msgstr ""
 msgid "Rubric deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:41
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:39
 #, elixir-autogen, elixir-format
 msgid "Rubric for curriculum item"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:107
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:105
 #, elixir-autogen, elixir-format
 msgid "Rubrics can be linked to assessment points with matching curriculum item, scale, and differentiation type."
 msgstr ""
@@ -4897,7 +4910,7 @@ msgstr ""
 msgid "There are two ways to \"connect\" students and differentiation rubrics:"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:66
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:64
 #, elixir-autogen, elixir-format
 msgid "Uses rubric in final assessment"
 msgstr ""
@@ -4961,7 +4974,7 @@ msgstr ""
 msgid "Metrics"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/menu_component.ex:489
+#: lib/lanttern_web/live/shared/menu_component.ex:490
 #, elixir-autogen, elixir-format
 msgid "My ILP"
 msgstr ""
@@ -4983,24 +4996,24 @@ msgstr ""
 msgid "Template instructions (visible to staff only)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:93
+#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:94
 #, elixir-autogen, elixir-format
 msgid "View ILP"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:115
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:116
 #, elixir-autogen, elixir-format
 msgid "(1 minute left until next revision request)"
 msgid_plural "(%{count} minutes left until next revision request)"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:112
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "AI revision can be requested every %{minute} minutes"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:407
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:408
 #, elixir-autogen, elixir-format
 msgid "AI revision failed"
 msgstr ""
@@ -5015,47 +5028,47 @@ msgstr ""
 msgid "Add instructions on how Lanttern should revise this ILP."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:412
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:413
 #, elixir-autogen, elixir-format
 msgid "Age should be a number between 0 and 100"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:97
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:98
 #, elixir-autogen, elixir-format
 msgid "Generated in %{datetime}"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:136
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:137
 #, elixir-autogen, elixir-format
 msgid "Inform the approximated age of the student (in years), and ask for Lanttern AI revision."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:132
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:133
 #, elixir-autogen, elixir-format
 msgid "Inform the approximated age of the student (in years), and ask for an updated Lanttern AI revision."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:94
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lanttern AI revision"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:105
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:106
 #, elixir-autogen, elixir-format
 msgid "Remember that AI make mistakes. Always double-check generated responses."
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:152
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:153
 #, elixir-autogen, elixir-format
 msgid "Request AI review"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:151
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:152
 #, elixir-autogen, elixir-format
 msgid "Request AI review update"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:145
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:146
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student age"
 msgstr ""
@@ -5113,4 +5126,55 @@ msgstr ""
 #: lib/lanttern_web/live/shared/grading/scale_info_table_component.ex:23
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Scale ranges"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:137
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Edit student tag"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students_component.ex:83
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Filter students by tag"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:17
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Manage student tags below"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:128
+#, elixir-autogen, elixir-format, fuzzy
+msgid "New student tag"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:52
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No student tags created yet"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/students_settings_live.ex:14
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Student settings"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:62
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Student tags"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/school/students_component.ex:56
+#: lib/lanttern_web/live/pages/students/settings/students_settings_live.html.heex:5
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Students settings"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/students/settings/students_settings_live.ex:28
+#, elixir-autogen, elixir-format, fuzzy
+msgid "You don't have access to students settings page"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:56
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Use this area to manage the strand curriculum."
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -12,13 +12,13 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n>1);\n"
 
 #: lib/lanttern_web/components/core_components.ex:938
-#: lib/lanttern_web/components/core_components.ex:2187
-#: lib/lanttern_web/components/core_components.ex:2249
+#: lib/lanttern_web/components/core_components.ex:2197
+#: lib/lanttern_web/components/core_components.ex:2259
 #, elixir-autogen, elixir-format
 msgid "Actions"
 msgstr "Ações"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1033
+#: lib/lanttern_web/components/grades_reports_components.ex:1045
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:3
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.ex:11
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.html.heex:2
@@ -26,13 +26,13 @@ msgstr "Ações"
 #: lib/lanttern_web/live/pages/strands/moment/id/overview_component.ex:30
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:52
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:72
-#: lib/lanttern_web/live/shared/menu_component.ex:452
+#: lib/lanttern_web/live/shared/menu_component.ex:453
 #, elixir-autogen, elixir-format
 msgid "Curriculum"
 msgstr "Currículo"
 
 #: lib/lanttern_web/live/pages/dashboard/dashboard_live.ex:19
-#: lib/lanttern_web/live/shared/menu_component.ex:427
+#: lib/lanttern_web/live/shared/menu_component.ex:428
 #, elixir-autogen, elixir-format
 msgid "Dashboard"
 msgstr "Dashboard"
@@ -50,9 +50,9 @@ msgstr "Rubricas"
 #: lib/lanttern_web/live/pages/strands/strands_live.ex:18
 #: lib/lanttern_web/live/pages/strands/strands_live.html.heex:2
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:429
-#: lib/lanttern_web/live/shared/menu_component.ex:483
-#: lib/lanttern_web/live/shared/menu_component.ex:508
+#: lib/lanttern_web/live/shared/menu_component.ex:430
+#: lib/lanttern_web/live/shared/menu_component.ex:484
+#: lib/lanttern_web/live/shared/menu_component.ex:509
 #, elixir-autogen, elixir-format
 msgid "Strands"
 msgstr "Trilhas"
@@ -126,12 +126,13 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:202
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:161
 #: lib/lanttern_web/live/shared/notes/note_component.ex:60
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:138
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:136
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:81
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:114
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:96
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:112
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:132
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:40
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:196
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:102
@@ -187,12 +188,13 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:205
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:164
 #: lib/lanttern_web/live/shared/notes/note_component.ex:63
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:147
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:145
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:61
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:105
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:115
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:141
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:93
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_form_component.ex:43
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:205
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:111
@@ -247,7 +249,8 @@ msgstr "O arquivo \"%{file}\" é inválido."
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:45
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:53
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:44
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:47
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:38
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:49
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:38
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:38
@@ -274,12 +277,13 @@ msgstr "Nenhum ano selecionado"
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:126
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:21
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:39
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:67
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:65
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:40
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:29
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:26
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:35
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:39
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:42
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:33
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:44
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:184
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:33
@@ -392,8 +396,8 @@ msgstr "Algo deu errado!"
 msgid "About"
 msgstr "Sobre"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1034
-#: lib/lanttern_web/components/grades_reports_components.ex:1107
+#: lib/lanttern_web/components/grades_reports_components.ex:1046
+#: lib/lanttern_web/components/grades_reports_components.ex:1119
 #: lib/lanttern_web/live/pages/strand_report/id/student_strand_report_live.html.heex:21
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:17
 #: lib/lanttern_web/live/pages/student_report_cards/id/strand_report/strand_report_id/student_report_card_strand_report_live.html.heex:25
@@ -407,7 +411,7 @@ msgid "Couldn't find strand"
 msgstr "Não foi possível encontrar a trilha"
 
 #: lib/lanttern_web/components/message_board_components.ex:52
-#: lib/lanttern_web/components/schools_components.ex:187
+#: lib/lanttern_web/components/schools_components.ex:199
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:158
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:109
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:116
@@ -422,11 +426,12 @@ msgstr "Não foi possível encontrar a trilha"
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:103
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:248
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:130
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:128
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:126
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:113
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:109
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:53
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:92
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:112
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:338
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:92
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:74
@@ -469,7 +474,7 @@ msgstr "Adicione suas anotações..."
 
 #: lib/lanttern_web/components/form_components.ex:742
 #: lib/lanttern_web/components/message_board_components.ex:40
-#: lib/lanttern_web/components/schools_components.ex:185
+#: lib/lanttern_web/components/schools_components.ex:197
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:156
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:107
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:114
@@ -489,11 +494,12 @@ msgstr "Adicione suas anotações..."
 #: lib/lanttern_web/live/shared/learning_context/moment_card_overlay_component.ex:246
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:128
 #: lib/lanttern_web/live/shared/notes/note_component.ex:53
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:126
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:124
 #: lib/lanttern_web/live/shared/school_config/moment_card_template_overlay_component.ex:111
 #: lib/lanttern_web/live/shared/schools/class_form_overlay_component.ex:107
 #: lib/lanttern_web/live/shared/schools/cycle_form_overlay_component.ex:51
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:90
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:110
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:72
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:336
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:90
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:72
@@ -511,14 +517,14 @@ msgstr "Pontos de avaliação atuais"
 msgid "Delete note"
 msgstr "Deletar anotação"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:69
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:67
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:100
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_component.ex:88
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:117
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:66
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:268
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:264
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:275
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:262
 #, elixir-autogen, elixir-format
 msgid "Differentiation"
 msgstr "Diferenciação"
@@ -532,8 +538,9 @@ msgstr "Diferenciação"
 #: lib/lanttern_web/live/pages/ilp/settings/ilp_settings_live.html.heex:27
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:41
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:320
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:80
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:78
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:228
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:45
 #: lib/lanttern_web/live/pages/students_records/settings/status_component.ex:61
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:57
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:250
@@ -547,12 +554,12 @@ msgstr "Editar"
 msgid "Goals"
 msgstr "Objetivos"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:112
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:110
 #, elixir-autogen, elixir-format
 msgid "Move curriculum item down"
 msgstr "Mover item curricular para baixo"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:101
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Move curriculum item up"
 msgstr "Mover item curricular para cima"
@@ -575,11 +582,6 @@ msgstr "Reordenar"
 #, elixir-autogen, elixir-format
 msgid "Select a class"
 msgstr "Selecione uma turma"
-
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:56
-#, elixir-autogen, elixir-format
-msgid "Under the hood, goals in Lanttern are defined by assessment points linked directly to the strand — when adding goals, we are adding assessment points which, in turn, hold the curriculum items we'll want to assess along the strand course."
-msgstr "Por baixo dos panos, objetivos no Lanttern são definidos por pontos de avaliação vinculados diretamente à trilha — ao adicionar objetivos, nós estamos adicionando pontos de avaliação que, por sua vez, contém os itens curriculares que nós queremos avaliar ao longo da trilha."
 
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:188
 #, elixir-autogen, elixir-format
@@ -650,7 +652,7 @@ msgstr "Selecionar item curricular"
 msgid "Select strand"
 msgstr "Selecionar trilha"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1032
+#: lib/lanttern_web/components/grades_reports_components.ex:1044
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:25
 #, elixir-autogen, elixir-format
 msgid "Strand"
@@ -666,7 +668,7 @@ msgstr "Você pode buscar pelo id adicionando # antes do id"
 msgid "and search by code wrapping it in parenthesis"
 msgstr "e buscar pelo código colocando parênteses"
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:208
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:206
 #, elixir-autogen, elixir-format
 msgid "Add descriptor"
 msgstr "Adicionar descritor"
@@ -681,8 +683,8 @@ msgstr "Adicionar descritor"
 msgid "Criteria"
 msgstr "Critério"
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:161
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:182
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:159
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:180
 #, elixir-autogen, elixir-format
 msgid "Descriptors"
 msgstr "Descritores"
@@ -699,13 +701,13 @@ msgstr "Rubrica atualizada com sucesso"
 
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:35
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex:35
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:194
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:192
 #, elixir-autogen, elixir-format
 msgid "Score"
 msgstr "Score"
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:162
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:183
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:160
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:181
 #, elixir-autogen, elixir-format
 msgid "Markdown supported in descriptors"
 msgstr "Suporta Markdown nos descritores"
@@ -798,7 +800,7 @@ msgstr "Momento atualizado com sucesso"
 msgid "Moments"
 msgstr "Momentos"
 
-#: lib/lanttern_web/components/core_components.ex:2137
+#: lib/lanttern_web/components/core_components.ex:2147
 #, elixir-autogen, elixir-format
 msgid "Move moment down"
 msgstr "Mover momento para baixo"
@@ -818,7 +820,7 @@ msgstr "Nenhum momento para esta trilha ainda"
 msgid "Save moment"
 msgstr "Salvar momento"
 
-#: lib/lanttern/learning_context.ex:678
+#: lib/lanttern/learning_context.ex:679
 #: lib/lanttern/repo_helpers.ex:191
 #: lib/lanttern_web/controllers/privacy_policy_controller.ex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:220
@@ -926,30 +928,31 @@ msgid "Already selected"
 msgstr "Já selecionado"
 
 #: lib/lanttern/curricula/curriculum_component.ex:31
+#: lib/lanttern/student_tags/tag.ex:43
 #: lib/lanttern/students_records/student_record_status.ex:45
 #: lib/lanttern/students_records/student_record_tag.ex:43
 #, elixir-autogen, elixir-format
 msgid "Background color format not accepted. Use hex color."
 msgstr "Cor de fundo inválida. Utilize cores hex."
 
-#: lib/lanttern_web/components/grades_reports_components.ex:758
+#: lib/lanttern_web/components/grades_reports_components.ex:770
 #, elixir-autogen, elixir-format
 msgid "Calculate all"
 msgstr "Calcular tudo"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:947
+#: lib/lanttern_web/components/grades_reports_components.ex:959
 #, elixir-autogen, elixir-format
 msgid "Calculate grade"
 msgstr "Calcular nota"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:574
-#: lib/lanttern_web/components/grades_reports_components.ex:819
+#: lib/lanttern_web/components/grades_reports_components.ex:586
+#: lib/lanttern_web/components/grades_reports_components.ex:831
 #, elixir-autogen, elixir-format
 msgid "Calculate student grades"
 msgstr "Calcular notas do estudante"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:526
-#: lib/lanttern_web/components/grades_reports_components.ex:782
+#: lib/lanttern_web/components/grades_reports_components.ex:538
+#: lib/lanttern_web/components/grades_reports_components.ex:794
 #, elixir-autogen, elixir-format
 msgid "Calculate subject grades"
 msgstr "Calcular notas da disciplina"
@@ -971,14 +974,14 @@ msgid "Code"
 msgstr "Código"
 
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:81
-#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:79
+#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:84
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:76
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Comment"
 msgstr "Comentário"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:276
+#: lib/lanttern_web/components/grades_reports_components.ex:288
 #, elixir-autogen, elixir-format
 msgid "Comp"
 msgstr "Comp"
@@ -1011,7 +1014,7 @@ msgstr "Diferenciação curricular"
 msgid "Curriculum item deleted"
 msgstr "Item curricular removido"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1106
+#: lib/lanttern_web/components/grades_reports_components.ex:1118
 #: lib/lanttern_web/components/reporting_components.ex:152
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:53
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:9
@@ -1034,10 +1037,10 @@ msgid "Cycle already added to this grade report"
 msgstr "Ciclo já adicionado à este relatório de nota"
 
 #: lib/lanttern_web/components/reporting_components.ex:355
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:268
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:323
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:353
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:374
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:267
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:322
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:352
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:373
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:78
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:150
 #, elixir-autogen, elixir-format
@@ -1149,8 +1152,8 @@ msgstr "Filtrar itens curriculares por disciplina"
 msgid "Filter curriculum items by year"
 msgstr "Filtrar itens curriculares por ano"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1066
-#: lib/lanttern_web/components/grades_reports_components.ex:1133
+#: lib/lanttern_web/components/grades_reports_components.ex:1078
+#: lib/lanttern_web/components/grades_reports_components.ex:1145
 #, elixir-autogen, elixir-format
 msgid "Final grade"
 msgstr "Nota final"
@@ -1162,7 +1165,7 @@ msgid "Grade calculated succesfully"
 msgstr "Nota calculada com sucesso"
 
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:84
-#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:82
+#: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:88
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:39
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:39
 #, elixir-autogen, elixir-format
@@ -1205,7 +1208,7 @@ msgstr "Relatório de notas atualizado com sucesso"
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:27
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:31
-#: lib/lanttern_web/live/shared/menu_component.ex:464
+#: lib/lanttern_web/live/shared/menu_component.ex:465
 #, elixir-autogen, elixir-format
 msgid "Grades reports"
 msgstr "Relatórios de notas"
@@ -1249,7 +1252,7 @@ msgstr "Nível"
 msgid "Link strand"
 msgstr "Vincular trilha"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:128
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:126
 #, elixir-autogen, elixir-format
 msgid "List of report cards linked to this strand."
 msgstr "Lista de report cards vinculados a esta trilha"
@@ -1259,7 +1262,7 @@ msgstr "Lista de report cards vinculados a esta trilha"
 msgid "Move down"
 msgstr "Mover para baixo"
 
-#: lib/lanttern_web/components/core_components.ex:2127
+#: lib/lanttern_web/components/core_components.ex:2137
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Move up"
@@ -1291,8 +1294,8 @@ msgid "No curriculum items found for selected filters."
 msgstr "Nenhum item curricular encontrado para os filtros selecionados."
 
 #: lib/lanttern_web/components/grades_reports_components.ex:132
-#: lib/lanttern_web/components/grades_reports_components.ex:471
-#: lib/lanttern_web/components/grades_reports_components.ex:793
+#: lib/lanttern_web/components/grades_reports_components.ex:483
+#: lib/lanttern_web/components/grades_reports_components.ex:805
 #, elixir-autogen, elixir-format
 msgid "No cycles linked to this grades report"
 msgstr "Nenhum ciclo vinculado a este relatório de notas"
@@ -1312,8 +1315,8 @@ msgstr "Nenhum report card criado ainda"
 msgid "No strands linked to this report yet"
 msgstr "Nenhuma trilha vinculada a este relatório ainda"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:617
-#: lib/lanttern_web/components/grades_reports_components.ex:845
+#: lib/lanttern_web/components/grades_reports_components.ex:629
+#: lib/lanttern_web/components/grades_reports_components.ex:857
 #: lib/lanttern_web/components/reporting_components.ex:485
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
@@ -1325,14 +1328,14 @@ msgid "No subjects linked"
 msgstr "Nenhuma disciplina vinculada"
 
 #: lib/lanttern_web/components/grades_reports_components.ex:179
-#: lib/lanttern_web/components/grades_reports_components.ex:540
-#: lib/lanttern_web/components/grades_reports_components.ex:543
+#: lib/lanttern_web/components/grades_reports_components.ex:552
+#: lib/lanttern_web/components/grades_reports_components.ex:555
 #, elixir-autogen, elixir-format
 msgid "No subjects linked to this grades report"
 msgstr "Nenhuma disciplina vinculada a este relatório de notas"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1036
-#: lib/lanttern_web/components/grades_reports_components.ex:1109
+#: lib/lanttern_web/components/grades_reports_components.ex:1048
+#: lib/lanttern_web/components/grades_reports_components.ex:1121
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:50
 #, elixir-autogen, elixir-format
 msgid "Normalized value"
@@ -1357,13 +1360,14 @@ msgid "Partial results"
 msgstr "Resultados parciais"
 
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:309
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:58
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:75
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:58
 #, elixir-autogen, elixir-format
 msgid "Preview"
 msgstr "Prévia"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:922
+#: lib/lanttern_web/components/grades_reports_components.ex:934
 #, elixir-autogen, elixir-format
 msgid "Recalculate grade"
 msgstr "Recalcular nota"
@@ -1396,11 +1400,11 @@ msgstr "Id do report card"
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:22
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:2
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:25
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:126
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:124
 #: lib/lanttern_web/live/pages/student_report_cards/student_report_cards_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:458
-#: lib/lanttern_web/live/shared/menu_component.ex:477
-#: lib/lanttern_web/live/shared/menu_component.ex:502
+#: lib/lanttern_web/live/shared/menu_component.ex:459
+#: lib/lanttern_web/live/shared/menu_component.ex:478
+#: lib/lanttern_web/live/shared/menu_component.ex:503
 #, elixir-autogen, elixir-format
 msgid "Report cards"
 msgstr "Report cards"
@@ -1408,7 +1412,7 @@ msgstr "Report cards"
 #: lib/lanttern_web/components/reporting_components.ex:83
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:224
 #: lib/lanttern_web/live/shared/reporting/strand_report_overview_component.ex:104
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:72
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "Rubric criteria"
 msgstr "Critério da rubrica"
@@ -1466,7 +1470,7 @@ msgstr "Favoritar trilha"
 msgid "Strand already linked to report card"
 msgstr "Trilha já vinculada ao report card"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:151
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:149
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:56
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format
@@ -1544,6 +1548,7 @@ msgid "Subject grades calculated succesfully"
 msgstr "Notas da disciplina calculadas com sucesso"
 
 #: lib/lanttern/curricula/curriculum_component.ex:35
+#: lib/lanttern/student_tags/tag.ex:47
 #: lib/lanttern/students_records/student_record_status.ex:49
 #: lib/lanttern/students_records/student_record_tag.ex:47
 #, elixir-autogen, elixir-format
@@ -1566,8 +1571,8 @@ msgstr "Tipo"
 msgid "Use the differentiation flag above when creating assessment points related to a curriculum level differentiation."
 msgstr "Utilize a marcação de diferenciação ao criar pontos de avaliação relacionados à diferenciação no nível do currículo."
 
-#: lib/lanttern_web/components/grades_reports_components.ex:1035
-#: lib/lanttern_web/components/grades_reports_components.ex:1108
+#: lib/lanttern_web/components/grades_reports_components.ex:1047
+#: lib/lanttern_web/components/grades_reports_components.ex:1120
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Weight"
@@ -1659,7 +1664,7 @@ msgstr "Você precisa estar logado para acessar esta página."
 msgid "About this assessment"
 msgstr "Sobre esta avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:90
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:88
 #, elixir-autogen, elixir-format
 msgid "Report info"
 msgstr "Informações do relatório"
@@ -1670,7 +1675,7 @@ msgstr "Informações do relatório"
 msgid "Report information"
 msgstr "Informações do relatório"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:686
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:685
 #, elixir-autogen, elixir-format
 msgid "1 entry updated"
 msgid_plural "%{count} entries updated"
@@ -1748,7 +1753,7 @@ msgid_plural "%{count} changes"
 msgstr[0] "1 alteração"
 msgstr[1] "%{count} alterações"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:142
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:140
 #, elixir-autogen, elixir-format
 msgid "No report cards linked to this strand"
 msgstr "Nenhum report card vinculado a esta trilha"
@@ -2133,19 +2138,19 @@ msgstr "Upload de arquivo"
 msgid "Attachments"
 msgstr "Anexos"
 
-#: lib/lanttern/personalization/profile_settings.ex:108
+#: lib/lanttern/personalization/profile_settings.ex:111
 #, elixir-autogen, elixir-format
 msgid "Invalid assessment view"
 msgstr "Visualização de avaliação inválida"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:76
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:74
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:12
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:430
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:429
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Estudante"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:427
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:426
 #, elixir-autogen, elixir-format
 msgid "Teacher"
 msgstr "Professor"
@@ -2163,7 +2168,7 @@ msgstr "Autoavaliação do estudante"
 
 #: lib/lanttern_web/components/reporting_components.ex:40
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:216
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:294
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:301
 #, elixir-autogen, elixir-format
 msgid "Teacher comment"
 msgstr "Comentário do professor"
@@ -2188,17 +2193,17 @@ msgstr "Nenhuma descrição de relatório da trilha"
 msgid "Visibility in grades reports"
 msgstr "Visibilidade nos relatórios de notas"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:752
+#: lib/lanttern_web/components/grades_reports_components.ex:764
 #, elixir-autogen, elixir-format
 msgid "Are you sure? All grades will be created, updated, and removed based on their grade composition."
 msgstr "Você tem certeza? Todas as notas serão criadas, atualizadas e removidas com base em suas composições."
 
-#: lib/lanttern_web/components/grades_reports_components.ex:822
+#: lib/lanttern_web/components/grades_reports_components.ex:834
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Grades related to this student will be created, updated, and removed based on their grade composition."
 msgstr "Você tem certeza? Notas relacionadas ao estudante serão criadas, atualizadas e removidas com base em suas composições."
 
-#: lib/lanttern_web/components/grades_reports_components.ex:785
+#: lib/lanttern_web/components/grades_reports_components.ex:797
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Grades related to this subject will be created, updated, and removed based on their grade composition."
 msgstr "Você tem certeza? Notas relacionadas à disciplina serão criadas, atualizadas e removidas com base em suas composições."
@@ -2244,12 +2249,12 @@ msgid_plural "%{count} grades partially updated (only compositions, manual grade
 msgstr[0] "1 nota parcialmente atualizada (apenas composição, nota manual não alterada)"
 msgstr[1] "%{count} notas parcialmente atualizadas (apenas composições, notas manuais não alteradas)"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:927
+#: lib/lanttern_web/components/grades_reports_components.ex:939
 #, elixir-autogen, elixir-format
 msgid "There is a manual grade change that will be overwritten by this operation. Are you sure you want to proceed?"
 msgstr "A nota atribuída manualmente será sobrescrita por esta operação. Você tem certeza que deseja proceder?"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:417
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:416
 #, elixir-autogen, elixir-format
 msgid "(Strand final assessment)"
 msgstr "(Avaliação final da trilha)"
@@ -2291,18 +2296,18 @@ msgstr "Comparar avaliações de professor e estudantes"
 msgid "Compare teacher/students"
 msgstr "Comparar professor/estudantes"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:415
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:233
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:414
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:231
 #, elixir-autogen, elixir-format
 msgid "Goal assessment"
 msgstr "Avaliação de objetivo"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:280
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:279
 #, elixir-autogen, elixir-format
 msgid "Goals assessment"
 msgstr "Avaliação de objetivos"
 
-#: lib/lanttern/personalization/profile_settings.ex:113
+#: lib/lanttern/personalization/profile_settings.ex:116
 #, elixir-autogen, elixir-format
 msgid "Invalid assessment group by option"
 msgstr "Opção de agrupamento de avaliação inválida"
@@ -2379,7 +2384,7 @@ msgstr "Nenhuma trilha favoritada ainda"
 msgid "Strand removed from your starred list"
 msgstr "Trilha removida da sua lista de favoritas"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:309
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:316
 #, elixir-autogen, elixir-format
 msgid "Assessment info"
 msgstr "Informações da avaliação"
@@ -2407,12 +2412,12 @@ msgid "Formative assessment"
 msgstr "Avaliação formativa"
 
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.html.heex:51
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:247
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:254
 #, elixir-autogen, elixir-format
 msgid "Formative assessment pattern"
 msgstr "Padrão da avaliação formativa"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:313
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:320
 #, elixir-autogen, elixir-format
 msgid "Has rubric"
 msgstr "Possui rubrica"
@@ -2430,7 +2435,7 @@ msgid "No entry"
 msgstr "Sem registro"
 
 #: lib/lanttern_web/components/reporting_components.ex:44
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:299
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:306
 #, elixir-autogen, elixir-format
 msgid "Student comment"
 msgstr "Comentário do estudante"
@@ -2470,7 +2475,7 @@ msgstr "A avaliação final ainda não está disponível"
 msgid "Goals assessment entries"
 msgstr "Registros da avaliação de objetivos"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:123
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:130
 #, elixir-autogen, elixir-format
 msgid "Goals without assessment entries"
 msgstr "Objetivos sem registros de avaliação"
@@ -2512,22 +2517,22 @@ msgstr "Sem autoavaliação do estudante"
 msgid "No teacher assessment"
 msgstr "Sem avaliação do professor"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:93
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:91
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:29
 #: lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex:96
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:52
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:55
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:124
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:262
 #, elixir-autogen, elixir-format
 msgid "Classes"
 msgstr "Turmas"
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:106
+#: lib/lanttern_web/live/pages/school/classes_component.ex:111
 #, elixir-autogen, elixir-format
 msgid "Filter classes by year"
 msgstr "Filtrar turmas por ano"
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:90
+#: lib/lanttern_web/live/pages/school/classes_component.ex:95
 #, elixir-autogen, elixir-format
 msgid "No students in this class"
 msgstr "Nenhum estudante nesta turma"
@@ -2562,7 +2567,7 @@ msgstr "Evidências de aprendizagem"
 msgid "View assessment details"
 msgstr "Ver detalhes da avaliação"
 
-#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:304
+#: lib/lanttern_web/live/shared/reporting/strand_report_assessment_component.ex:311
 #, elixir-autogen, elixir-format
 msgid "With learning evidences"
 msgstr "Possui evidências de aprendizagem"
@@ -2587,28 +2592,28 @@ msgstr "Data"
 msgid "Edit student record"
 msgstr "Editar registro de estudante"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:209
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:207
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:167
 #, elixir-autogen, elixir-format
 msgid "Filter records by student"
 msgstr "Filtrar registros por estudante"
 
-#: lib/lanttern/personalization/profile_settings.ex:82
+#: lib/lanttern/personalization/profile_settings.ex:84
 #, elixir-autogen, elixir-format
 msgid "Invalid permissions"
 msgstr "Permissões inválidas"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:147
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:199
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:147
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:146
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:197
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:146
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:157
 #, elixir-autogen, elixir-format
 msgid "Load more records"
 msgstr "Carregar mais registros"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:89
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:143
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:89
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:88
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:141
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:88
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:97
 #, elixir-autogen, elixir-format
 msgid "New student record"
@@ -2619,9 +2624,9 @@ msgstr "Novo registro de estudante"
 msgid "No student records found for selected filters."
 msgstr "Nenhum registro de estudante encontrado para os filtros selecionados."
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:39
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:110
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:39
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:38
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:108
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:38
 #: lib/lanttern_web/live/pages/students_records/settings/students_records_settings_live.html.heex:12
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:46
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:72
@@ -2630,15 +2635,15 @@ msgstr "Nenhum registro de estudante encontrado para os filtros selecionados."
 msgid "Status"
 msgstr "Status"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:216
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:214
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:174
 #, elixir-autogen, elixir-format
 msgid "Type the name of the student"
 msgstr "Digite o nome do estudante"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:152
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:232
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:152
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:151
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:230
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:151
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:207
 #, elixir-autogen, elixir-format
 msgid "Filter student records by status"
@@ -2666,23 +2671,23 @@ msgstr "configuração da matriz de %{grades_report}"
 msgid "All final grades calculated succesfully"
 msgstr "Todas notas finais calculadas com sucesso"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:448
+#: lib/lanttern_web/components/grades_reports_components.ex:460
 #, elixir-autogen, elixir-format
 msgid "Are you sure? All final grades will be created, updated, and removed based on their grade composition."
 msgstr "Você tem certeza? Todas as notas finais serão criadas, atualizadas e removidas com base em suas composições."
 
-#: lib/lanttern_web/components/grades_reports_components.ex:577
+#: lib/lanttern_web/components/grades_reports_components.ex:589
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Final grades related to this student will be created, updated, and removed based on their grade composition."
 msgstr "Você tem certeza? Notas finais relacionadas ao estudante serão criadas, atualizadas e removidas com base em suas composições."
 
-#: lib/lanttern_web/components/grades_reports_components.ex:529
+#: lib/lanttern_web/components/grades_reports_components.ex:541
 #, elixir-autogen, elixir-format
 msgid "Are you sure? Final grades related to this subject will be created, updated, and removed based on their grade composition."
 msgstr "Você tem certeza? Notas finais relacionadas à disciplina serão criadas, atualizadas e removidas com base em suas composições."
 
-#: lib/lanttern_web/components/grades_reports_components.ex:442
-#: lib/lanttern_web/components/grades_reports_components.ex:452
+#: lib/lanttern_web/components/grades_reports_components.ex:454
+#: lib/lanttern_web/components/grades_reports_components.ex:464
 #, elixir-autogen, elixir-format
 msgid "Calculate final grades"
 msgstr "Calcular notas finais"
@@ -2735,17 +2740,17 @@ msgstr "Erro ao atualizar visibilidade das notas finais"
 msgid "Final grade details"
 msgstr "Detalhes da nota final"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:438
+#: lib/lanttern_web/components/grades_reports_components.ex:450
 #, elixir-autogen, elixir-format
 msgid "Final grades"
 msgstr "Notas finais"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:463
+#: lib/lanttern_web/components/grades_reports_components.ex:475
 #, elixir-autogen, elixir-format
 msgid "Final grades are visible"
 msgstr "Notas finais estão visíveis"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:464
+#: lib/lanttern_web/components/grades_reports_components.ex:476
 #, elixir-autogen, elixir-format
 msgid "Final grades not visible"
 msgstr "Notas finais não estão visíveis"
@@ -2760,7 +2765,7 @@ msgstr "Visibilidade das notas finais"
 msgid "No subcycle entries for this subject"
 msgstr "Nenhum registro de subciclo para esta disciplina"
 
-#: lib/lanttern_web/components/grades_reports_components.ex:456
+#: lib/lanttern_web/components/grades_reports_components.ex:468
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_grid_configuration_overlay_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "Parent cycle visibility"
@@ -2822,18 +2827,18 @@ msgid "Add class"
 msgstr "Adicionar turma"
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:32
-#: lib/lanttern_web/live/pages/school/students_component.ex:37
+#: lib/lanttern_web/live/pages/school/students_component.ex:52
 #, elixir-autogen, elixir-format
 msgid "Add student"
 msgstr "Adicionar estudante"
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:133
+#: lib/lanttern_web/live/pages/school/classes_component.ex:138
 #, elixir-autogen, elixir-format
 msgid "Class created successfully"
 msgstr "Turma criada com sucesso"
 
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.ex:99
-#: lib/lanttern_web/live/pages/school/classes_component.ex:156
+#: lib/lanttern_web/live/pages/school/classes_component.ex:161
 #, elixir-autogen, elixir-format
 msgid "Class deleted successfully"
 msgstr "Turma deletada com sucesso"
@@ -2844,12 +2849,12 @@ msgid "Class name already in use in this cycle"
 msgstr "Nome da turma já está em uso neste ciclo"
 
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.ex:90
-#: lib/lanttern_web/live/pages/school/classes_component.ex:142
+#: lib/lanttern_web/live/pages/school/classes_component.ex:147
 #, elixir-autogen, elixir-format
 msgid "Class updated successfully"
 msgstr "Turma atualizada com sucesso"
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:220
+#: lib/lanttern_web/live/pages/school/classes_component.ex:225
 #, elixir-autogen, elixir-format
 msgid "Create class"
 msgstr "Criar turma"
@@ -2857,32 +2862,32 @@ msgstr "Criar turma"
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.html.heex:31
 #: lib/lanttern_web/live/pages/school/classes/id/class_live.html.heex:66
 #: lib/lanttern_web/live/pages/school/classes_component.ex:52
-#: lib/lanttern_web/live/pages/school/classes_component.ex:232
+#: lib/lanttern_web/live/pages/school/classes_component.ex:237
 #, elixir-autogen, elixir-format
 msgid "Edit class"
 msgstr "Editar turma"
 
-#: lib/lanttern_web/components/schools_components.ex:126
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:164
+#: lib/lanttern_web/components/schools_components.ex:138
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:165
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:40
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:88
-#: lib/lanttern_web/live/pages/school/students_component.ex:176
+#: lib/lanttern_web/live/pages/school/students_component.ex:223
 #, elixir-autogen, elixir-format
 msgid "Edit student"
 msgstr "Editar estudante"
 
-#: lib/lanttern_web/live/pages/school/students_component.ex:54
+#: lib/lanttern_web/live/pages/school/students_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "Filter students by class"
 msgstr "Filtrar estudantes por turma"
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:156
-#: lib/lanttern_web/live/pages/school/students_component.ex:168
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:157
+#: lib/lanttern_web/live/pages/school/students_component.ex:211
 #, elixir-autogen, elixir-format
 msgid "New student"
 msgstr "Novo estudante"
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:98
+#: lib/lanttern_web/live/pages/school/classes_component.ex:103
 #, elixir-autogen, elixir-format
 msgid "No classes matching current filters"
 msgstr "Nenhuma turma correspondente aos filtros selecionados"
@@ -2893,7 +2898,7 @@ msgid "No students added to this class"
 msgstr "Nenhum estudante adicionado à esta turma"
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:80
-#: lib/lanttern_web/live/pages/school/students_component.ex:84
+#: lib/lanttern_web/live/pages/school/students_component.ex:123
 #, elixir-autogen, elixir-format
 msgid "Student created successfully"
 msgstr "Estudante criado com sucesso"
@@ -2905,7 +2910,7 @@ msgstr "Estudante deletado com sucesso"
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:81
 #: lib/lanttern_web/live/pages/school/students/id/student_live.ex:82
-#: lib/lanttern_web/live/pages/school/students_component.ex:95
+#: lib/lanttern_web/live/pages/school/students_component.ex:134
 #, elixir-autogen, elixir-format
 msgid "Student updated successfully"
 msgstr "Estudante atualizado com sucesso"
@@ -3010,7 +3015,7 @@ msgstr "Criar trilha"
 #: lib/lanttern_web/live/pages/student/student_home_live.ex:111
 #: lib/lanttern_web/live/pages/student_report_cards/student_report_cards_live.ex:108
 #: lib/lanttern_web/live/pages/student_strands/student_strands_live.ex:155
-#: lib/lanttern_web/live/shared/menu_component.ex:581
+#: lib/lanttern_web/live/shared/menu_component.ex:582
 #, elixir-autogen, elixir-format
 msgid "Current cycle changed"
 msgstr "Ciclo atual alterado"
@@ -3238,7 +3243,7 @@ msgstr "Turmas de outros ciclos"
 msgid "Parent cycle"
 msgstr "Ciclo pai"
 
-#: lib/lanttern/schools.ex:361
+#: lib/lanttern/schools.ex:362
 #, elixir-autogen, elixir-format
 msgid "Parent cycle does not exist"
 msgstr "Ciclo pai não existe"
@@ -3345,7 +3350,7 @@ msgstr "Utilize cards para adicionar uma camada extra de organização aos momen
 msgid "Using a parent cycle from a different school is not allowed"
 msgstr "Utilizar um ciclo pai de uma escola diferente não é permitido"
 
-#: lib/lanttern/schools.ex:354
+#: lib/lanttern/schools.ex:355
 #, elixir-autogen, elixir-format
 msgid "You can't use a subcycle as a parent cycle"
 msgstr "Você não pode utilizar um subciclo como um ciclo pai"
@@ -3360,7 +3365,7 @@ msgstr "turmas"
 msgid "Link strand to report"
 msgstr "Vincular trilha ao report"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:225
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:223
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:183
 #, elixir-autogen, elixir-format
 msgid "Filter student records by class"
@@ -3379,9 +3384,9 @@ msgstr "Registro de estudante não encontrado"
 #: lib/lanttern_web/live/pages/school/staff/id/staff_member_live.html.heex:16
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:19
 #: lib/lanttern_web/live/pages/students_records/settings/students_records_settings_live.html.heex:3
-#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:26
+#: lib/lanttern_web/live/pages/students_records/students_records_live.ex:27
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:434
+#: lib/lanttern_web/live/shared/menu_component.ex:435
 #, elixir-autogen, elixir-format
 msgid "Student records"
 msgstr "Registros de estudante"
@@ -3391,12 +3396,12 @@ msgstr "Registros de estudante"
 msgid "This record was deleted"
 msgstr "Este registro foi deletado"
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:30
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:31
 #, elixir-autogen, elixir-format
 msgid "Access to information in this area is restricted to school staff"
 msgstr "O acesso às informações nesta área é restrito à equipe da escola"
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:40
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:41
 #, elixir-autogen, elixir-format
 msgid "Add school area student info..."
 msgstr "Adicionar informações de estudante na área da escola..."
@@ -3412,14 +3417,14 @@ msgid "Check the student and school relationship"
 msgstr "Confira a relação entre estudante e escola"
 
 #: lib/lanttern_web/live/pages/school/staff_component.ex:64
-#: lib/lanttern_web/live/shared/schools/student_header_component.ex:38
+#: lib/lanttern_web/live/shared/schools/student_header_component.ex:39
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:38
 #, elixir-autogen, elixir-format
 msgid "Edit cycle profile picture"
 msgstr "Editar foto de perfil do ciclo"
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:57
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:106
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:58
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:107
 #, elixir-autogen, elixir-format
 msgid "Edit information"
 msgstr "Editar informação"
@@ -3429,23 +3434,23 @@ msgstr "Editar informação"
 msgid "No classes"
 msgstr "Nenhuma turma"
 
-#: lib/lanttern_web/live/shared/schools/student_header_component.ex:78
+#: lib/lanttern_web/live/shared/schools/student_header_component.ex:84
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "No classes linked to student in cycle"
 msgstr "Nenhuma turma vinculada ao estudante no ciclo"
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:46
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "No information about student in school area"
 msgstr "Nenhuma informação sobre o estudante na área da escola"
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:27
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:28
 #, elixir-autogen, elixir-format
 msgid "School area"
 msgstr "Área da escola"
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:67
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:68
 #, elixir-autogen, elixir-format
 msgid "School area attachments"
 msgstr "Anexos da área da escola"
@@ -3578,27 +3583,27 @@ msgid_plural "%{count} attachments"
 msgstr[0] "1 anexo"
 msgstr[1] "%{count} anexos"
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:89
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:90
 #, elixir-autogen, elixir-format
 msgid "Add student area info..."
 msgstr "Adicionar informações da área de estudante..."
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:79
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:80
 #, elixir-autogen, elixir-format
 msgid "Information shared with student and guardians"
 msgstr "Informação compartilhada com estudante e responsáveis"
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:95
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:96
 #, elixir-autogen, elixir-format
 msgid "No information in student area"
 msgstr "Nenhuma informação na área de estudante"
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:75
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "Student area"
 msgstr "Área de estudante"
 
-#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:116
+#: lib/lanttern_web/live/pages/school/students/id/about_component.ex:117
 #, elixir-autogen, elixir-format
 msgid "Student area attachments"
 msgstr "Anexos da área de estudante"
@@ -3688,7 +3693,7 @@ msgid "Edit staff member"
 msgstr "Editar colaborador"
 
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:73
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:67
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:87
 #, elixir-autogen, elixir-format
 msgid "Enables the user to login at Lanttern via Google Sign In"
 msgstr "Possibilita o usuário a fazer login no Lanttern via Google Sign In"
@@ -3710,7 +3715,7 @@ msgid "Invalid staff member"
 msgstr "Colaborador inválido"
 
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:68
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Lanttern user email"
 msgstr "Email de usuário Lanttern"
@@ -3725,9 +3730,9 @@ msgstr "Novo colaborador"
 msgid "No staff members found"
 msgstr "Nenhum colaborador encontrado"
 
-#: lib/lanttern_web/components/schools_components.ex:179
+#: lib/lanttern_web/components/schools_components.ex:191
 #: lib/lanttern_web/live/pages/school/staff/deactivated/deactivated_staff_live.html.heex:40
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:102
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:122
 #, elixir-autogen, elixir-format
 msgid "Reactivate"
 msgstr "Reativar"
@@ -3737,7 +3742,7 @@ msgstr "Reativar"
 msgid "Role"
 msgstr "Função"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:446
+#: lib/lanttern_web/live/shared/menu_component.ex:447
 #, elixir-autogen, elixir-format
 msgid "School management"
 msgstr "Gerenciamento da escola"
@@ -3771,7 +3776,7 @@ msgstr[0] "1 colaborador desativado"
 msgstr[1] "%{count} colaboradores desativados"
 
 #: lib/lanttern_web/live/shared/schools/staff_member_form_overlay_component.ex:86
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:81
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:101
 #, elixir-autogen, elixir-format
 msgid "Deactivate"
 msgstr "Desativar"
@@ -3812,14 +3817,14 @@ msgstr "Estudantes de %{school}"
 msgid "Assigned to"
 msgstr "Atribuído a"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:48
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:63
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:46
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:61
 #, elixir-autogen, elixir-format
 msgid "Assigned to %{staff_member}"
 msgstr "Atribuído a %{staff_member}"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:72
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:72
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:71
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:71
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "Assignee"
@@ -3836,8 +3841,8 @@ msgstr "Responsáveis"
 msgid "Created by"
 msgstr "Criado por"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:188
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:188
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:187
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:187
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:226
 #, elixir-autogen, elixir-format
 msgid "Filter records by assignee"
@@ -3849,8 +3854,8 @@ msgstr "Filtrar registros por responsável"
 msgid "Internal student record tracking"
 msgstr "Acompanhamento interno de registro de estudante"
 
-#: lib/lanttern/personalization/profile_settings.ex:119
-#: lib/lanttern/personalization/profile_settings.ex:124
+#: lib/lanttern/personalization/profile_settings.ex:122
+#: lib/lanttern/personalization/profile_settings.ex:127
 #, elixir-autogen, elixir-format
 msgid "Invalid view option"
 msgstr "Opção de visualização inválida"
@@ -3860,9 +3865,9 @@ msgstr "Opção de visualização inválida"
 msgid "My area"
 msgstr "Minha área"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:95
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:149
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:95
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:94
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:147
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:94
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:111
 #, elixir-autogen, elixir-format
 msgid "Showing 1 result for selected filters"
@@ -3875,8 +3880,8 @@ msgstr[1] "Mostrando %{count} resultados para os filtros selecionados"
 msgid "Staff member deleted successfully"
 msgstr "Colaborador deletado com sucesso"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:195
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:195
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:194
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:194
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:233
 #, elixir-autogen, elixir-format
 msgid "Type the name of the assignee"
@@ -3887,8 +3892,8 @@ msgstr "Digite o nome do responsável"
 msgid "View more"
 msgstr "Ver mais"
 
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:45
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:57
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:43
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Created by %{staff_member}"
 msgstr "Criado por %{staff_member}"
@@ -3909,6 +3914,7 @@ msgstr "Visível para toda a equipe da escola"
 msgid "At least 1 tag is required"
 msgstr "Obrigatório vincular ao menos 1 tag"
 
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:45
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:45
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:45
 #, elixir-autogen, elixir-format
@@ -3925,9 +3931,9 @@ msgstr "Editar status"
 msgid "Edit tag"
 msgstr "Editar tag"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:166
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:246
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:166
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:165
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:244
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:165
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:190
 #, elixir-autogen, elixir-format
 msgid "Filter student records by tag"
@@ -3956,6 +3962,7 @@ msgstr "Gerencie as tags dos registros de estudantes abaixo"
 msgid "New status"
 msgstr "Novo status"
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:24
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:26
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:136
 #, elixir-autogen, elixir-format
@@ -4005,24 +4012,28 @@ msgstr "Status atualizado com sucesso"
 msgid "Student records settings"
 msgstr "Configurações de registros de estudantes"
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:80
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:88
 #, elixir-autogen, elixir-format
 msgid "Tag created successfully"
 msgstr "Tag criada com sucesso"
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:82
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:90
 #, elixir-autogen, elixir-format
 msgid "Tag deleted successfully"
 msgstr "Tag deletada com sucesso"
 
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:81
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:89
 #, elixir-autogen, elixir-format
 msgid "Tag updated successfully"
 msgstr "Tag atualizada com sucesso"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:64
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:135
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:64
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:63
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:133
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:63
+#: lib/lanttern_web/live/pages/school/students_component.ex:43
 #: lib/lanttern_web/live/pages/students_records/settings/students_records_settings_live.html.heex:15
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:71
 #: lib/lanttern_web/live/shared/students_records/student_record_overlay_component.ex:85
@@ -4031,23 +4042,24 @@ msgstr "Tag atualizada com sucesso"
 msgid "Tags"
 msgstr "Tags"
 
+#: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:52
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:52
 #: lib/lanttern_web/live/shared/students_records/student_record_tag_form_overlay_component.ex:52
 #, elixir-autogen, elixir-format
 msgid "Text color (hex)"
 msgstr "Cor de texto (hex)"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:104
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:158
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:104
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:103
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:156
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:103
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:120
 #, elixir-autogen, elixir-format
 msgid "All records"
 msgstr "Todos os registros"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:115
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:169
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:115
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:114
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:167
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:114
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:131
 #, elixir-autogen, elixir-format
 msgid "All records, newest first"
@@ -4084,17 +4096,17 @@ msgstr "Criado em %{datetime}"
 msgid "If active, assigning this status to an existing record will close it and calculate the time since its creation."
 msgstr "Se ativo, atribuir este status a um registro existente irá encerrá-lo e calcular o tempo desde a sua criação."
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:105
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:159
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:105
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:104
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:157
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:104
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:121
 #, elixir-autogen, elixir-format
 msgid "Only open"
 msgstr "Apenas abertos"
 
-#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:119
-#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:173
-#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:119
+#: lib/lanttern_web/live/pages/school/classes/id/student_records_component.ex:118
+#: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:171
+#: lib/lanttern_web/live/pages/school/students/id/student_records_component.ex:118
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:135
 #, elixir-autogen, elixir-format
 msgid "Only open, oldest first"
@@ -4170,27 +4182,27 @@ msgstr "Você tem certeza que deseja reabrir este registro de estudante?"
 msgid "%{school}'s deactivated students"
 msgstr "Estudantes desativados de %{school}"
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:206
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:207
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:91
 #, elixir-autogen, elixir-format
 msgid "%{student} deleted"
 msgstr "%{student} deletado"
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:182
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:183
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:66
 #, elixir-autogen, elixir-format
 msgid "%{student} reactivated"
 msgstr "%{student} reativado"
 
-#: lib/lanttern_web/components/core_components.ex:1916
-#: lib/lanttern_web/components/core_components.ex:1924
+#: lib/lanttern_web/components/core_components.ex:1917
+#: lib/lanttern_web/components/core_components.ex:1925
 #, elixir-autogen, elixir-format
 msgid "(Deactivated)"
 msgstr "(Desativado)"
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:17
 #: lib/lanttern_web/live/pages/school/classes_component.ex:60
-#: lib/lanttern_web/live/pages/school/students_component.ex:26
+#: lib/lanttern_web/live/pages/school/students_component.ex:45
 #, elixir-autogen, elixir-format
 msgid "1 active student"
 msgid_plural "%{count} active students"
@@ -4207,18 +4219,18 @@ msgstr[1] "%{count} estudantes desativados"
 
 #: lib/lanttern_web/live/pages/school/message_board/archive/archived_messages_live.html.heex:13
 #: lib/lanttern_web/live/pages/school/message_board_component.ex:32
-#: lib/lanttern_web/live/pages/school/students_component.ex:24
+#: lib/lanttern_web/live/pages/school/students_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "All classes"
 msgstr "Todas turmas"
 
-#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:79
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:99
 #, elixir-autogen, elixir-format
 msgid "Are you sure? You can reactive the student later."
 msgstr "Você tem certeza? Você pode reativar o estudante mais tarde."
 
-#: lib/lanttern_web/live/pages/school/classes_component.ex:84
-#: lib/lanttern_web/live/shared/schools/student_header_component.ex:64
+#: lib/lanttern_web/live/pages/school/classes_component.ex:89
+#: lib/lanttern_web/live/shared/schools/student_header_component.ex:65
 #: lib/lanttern_web/live/shared/students_cycle_info/student_cycle_info_header_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "Deactivated"
@@ -4229,20 +4241,20 @@ msgstr "Desativado"
 msgid "Deactivated students"
 msgstr "Estudantes desativados"
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:213
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:214
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:99
 #, elixir-autogen, elixir-format
 msgid "Failed to delete student"
 msgstr "Falha ao deletar estudante"
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:189
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:190
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:74
 #, elixir-autogen, elixir-format
 msgid "Failed to reactivate student"
 msgstr "Falha ao reativar estudante"
 
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:192
-#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:216
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:193
+#: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:217
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:77
 #: lib/lanttern_web/live/pages/school/students/deactivated/deactivated_students_live.ex:102
 #, elixir-autogen, elixir-format
@@ -4256,7 +4268,7 @@ msgstr "Nenhum estudante desativado encontrado"
 
 #: lib/lanttern_web/live/pages/school/classes/id/students_component.ex:82
 #: lib/lanttern_web/live/pages/school/students/id/student_live.ex:91
-#: lib/lanttern_web/live/pages/school/students_component.ex:96
+#: lib/lanttern_web/live/pages/school/students_component.ex:135
 #, elixir-autogen, elixir-format
 msgid "Student deactivated successfully"
 msgstr "Estudante desativado com sucesso"
@@ -4266,7 +4278,7 @@ msgstr "Estudante desativado com sucesso"
 msgid "Student reactivated successfully"
 msgstr "Estudante reativado com sucesso"
 
-#: lib/lanttern_web/live/pages/school/students_component.ex:28
+#: lib/lanttern_web/live/pages/school/students_component.ex:47
 #, elixir-autogen, elixir-format
 msgid "View deactivated students"
 msgstr "Ver estudantes desativados"
@@ -4365,8 +4377,8 @@ msgstr "Falha ao desarquivar mensagem"
 msgid "Filter messages by class"
 msgstr "Filtrar mensagens por turma"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:471
-#: lib/lanttern_web/live/shared/menu_component.ex:496
+#: lib/lanttern_web/live/shared/menu_component.ex:472
+#: lib/lanttern_web/live/shared/menu_component.ex:497
 #, elixir-autogen, elixir-format
 msgid "Home"
 msgstr "Home"
@@ -4420,6 +4432,7 @@ msgid "No messages matching current filters created yet"
 msgstr "Nenhuma mensagem correspondente aos filtros selecionados"
 
 #: lib/lanttern_web/live/shared/schools/classes_field_component.ex:48
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:75
 #, elixir-autogen, elixir-format
 msgid "No selected classes"
 msgstr "Nenhuma turma selecionada"
@@ -4545,13 +4558,13 @@ msgstr "Adicionar componente"
 msgid "Add section"
 msgstr "Adicionar seção"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:71
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:72
 #, elixir-autogen, elixir-format
 msgid "Create %{student}'s %{cycle} ILP"
 msgstr "Criar ILP de %{student} para %{cycle}"
 
-#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:126
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:366
+#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:127
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:367
 #, elixir-autogen, elixir-format
 msgid "Create ILP"
 msgstr "Criar ILP"
@@ -4566,7 +4579,7 @@ msgstr "Criar novo modelo de ILP"
 msgid "Delete template"
 msgstr "Deletar modelo"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:377
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:378
 #, elixir-autogen, elixir-format
 msgid "Edit ILP"
 msgstr "Editar ILP"
@@ -4575,18 +4588,18 @@ msgstr "Editar ILP"
 #: lib/lanttern_web/live/pages/ilp/settings/ilp_settings_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:13
 #: lib/lanttern_web/live/pages/student_ilp/student_ilp_live.html.heex:2
-#: lib/lanttern_web/live/shared/menu_component.ex:440
-#: lib/lanttern_web/live/shared/menu_component.ex:514
+#: lib/lanttern_web/live/shared/menu_component.ex:441
+#: lib/lanttern_web/live/shared/menu_component.ex:515
 #, elixir-autogen, elixir-format
 msgid "ILP"
 msgstr "ILP"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:204
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:205
 #, elixir-autogen, elixir-format
 msgid "ILP created successfully"
 msgstr "ILP criado com sucesso"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:206
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:207
 #, elixir-autogen, elixir-format
 msgid "ILP deleted successfully"
 msgstr "ILP deletado com sucesso"
@@ -4618,7 +4631,7 @@ msgstr "Modelo de ILP deletado com sucesso"
 msgid "ILP template updated successfully"
 msgstr "Modelo de ILP atualizado com sucesso"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:205
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:206
 #, elixir-autogen, elixir-format
 msgid "ILP updated successfully"
 msgstr "ILP atualizado com sucesso"
@@ -4636,7 +4649,7 @@ msgid "No ILP model selected"
 msgstr "Nenhum modelo de ILP selecionado"
 
 #: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:68
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:59
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "No ILP template selected"
 msgstr "Nenhum modelo de ILP selecionado"
@@ -4648,7 +4661,7 @@ msgstr "Nenhum modelo de ILP selecionado"
 msgid "No ILP templates registered in your school. Talk to your Lanttern school manager."
 msgstr "Nenhum modelo de ILP registrado na sua escola. Fale com o gestor Lanttern da sua escola."
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:62
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:63
 #, elixir-autogen, elixir-format
 msgid "No student ILP created yet"
 msgstr "Nenhum ILP de estudante criado ainda"
@@ -4699,12 +4712,12 @@ msgstr "Nome do modelo"
 msgid "You don't have access to ILP settings page"
 msgstr "Você não tem acesso à página de configurações de ILP"
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:232
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:230
 #, elixir-autogen, elixir-format
 msgid "%{curriculum} final assessment"
 msgstr "Avaliação final de %{curriculum}"
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:104
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:102
 #, elixir-autogen, elixir-format
 msgid "About rubrics and assessment points relationships"
 msgstr "Sobre a relação entre rubricas e pontos de avaliação"
@@ -4724,28 +4737,28 @@ msgstr "Adicionar outra rubrica para avaliar este objetivo"
 msgid "Add diff rubric"
 msgstr "Adicionar rubrica de diferenciação"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:188
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:186
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:92
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:144
 #, elixir-autogen, elixir-format
 msgid "Assessment point and entries deleted successfully"
 msgstr "Ponto de avaliação e registros deletados com sucesso"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:179
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:177
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:83
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:135
 #, elixir-autogen, elixir-format
 msgid "Assessment point created successfully"
 msgstr "Ponto de avaliação criado com sucesso"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:185
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:183
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:89
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:141
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted successfully"
 msgstr "Ponto de avaliação deletado com sucesso"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:182
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:180
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:86
 #: lib/lanttern_web/live/pages/strands/moment/id/assessment_component.ex:138
 #, elixir-autogen, elixir-format
@@ -4764,7 +4777,7 @@ msgid "Curriculum item"
 msgstr "Item curricular"
 
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:291
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:53
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Differentiation rubric"
 msgstr "Rubrica de diferenciação"
@@ -4784,17 +4797,17 @@ msgstr "Editar rubrica de diferenciação"
 msgid "Edit rubric"
 msgstr "Editar rubrica"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:690
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:689
 #, elixir-autogen, elixir-format
 msgid "Error updating assessment point entries"
 msgstr "Erro ao atualizar registros de ponto de avaliação"
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:112
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:110
 #, elixir-autogen, elixir-format
 msgid "In case of differentiation rubrics, we can also link them directly to a student via assessment point entry."
 msgstr "No caso de rubricas de diferenciação, também podemos vinculá-las diretamente a um estudante por meio do registro de ponto de avaliação."
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:78
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:76
 #, elixir-autogen, elixir-format
 msgid "Link rubric to assessment points"
 msgstr "Vincular rubrica aos pontos de avaliação"
@@ -4804,7 +4817,7 @@ msgstr "Vincular rubrica aos pontos de avaliação"
 msgid "Linked students"
 msgstr "Estudantes vinculados"
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:226
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:224
 #, elixir-autogen, elixir-format
 msgid "Moment %{moment}"
 msgstr "Momento %{moment}"
@@ -4819,7 +4832,7 @@ msgstr "Nova rubrica de diferenciação"
 msgid "New rubric"
 msgstr "Nova rubrica"
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:80
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:78
 #, elixir-autogen, elixir-format
 msgid "No assessment point matching curriculum, scale, and differentiation flag"
 msgstr "Nenhum ponto de avaliação compatível com currículo, escala e marcação de diferenciação"
@@ -4861,12 +4874,12 @@ msgstr "Nenhuma rubrica correspondente ao item curricular e escala"
 msgid "Rubric deleted successfully"
 msgstr "Rubrica deletada com sucesso"
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:41
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:39
 #, elixir-autogen, elixir-format
 msgid "Rubric for curriculum item"
 msgstr "Rubrica para item curricular"
 
-#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:107
+#: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:105
 #, elixir-autogen, elixir-format
 msgid "Rubrics can be linked to assessment points with matching curriculum item, scale, and differentiation type."
 msgstr "Rubricas podem ser vinculadas a pontos de avaliação com item curricular, escala e tipo de diferenciação correspondentes."
@@ -4897,7 +4910,7 @@ msgstr "Estudantes atualmente vinculados à rubrica selecionada"
 msgid "There are two ways to \"connect\" students and differentiation rubrics:"
 msgstr "Existem duas formas de \"conectar\" estudantes e rubricas de diferenciação:"
 
-#: lib/lanttern_web/live/pages/strands/id/about_component.ex:66
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:64
 #, elixir-autogen, elixir-format
 msgid "Uses rubric in final assessment"
 msgstr "Usa rubrica na avaliação final"
@@ -4961,7 +4974,7 @@ msgstr "Procurando por outro ciclo? Você pode alterar pelo menu."
 msgid "Metrics"
 msgstr "Métricas"
 
-#: lib/lanttern_web/live/shared/menu_component.ex:489
+#: lib/lanttern_web/live/shared/menu_component.ex:490
 #, elixir-autogen, elixir-format
 msgid "My ILP"
 msgstr "Meu ILP"
@@ -4983,24 +4996,24 @@ msgstr "Leia o ILP"
 msgid "Template instructions (visible to staff only)"
 msgstr "Instruções do template (visível somente para o staff)"
 
-#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:93
+#: lib/lanttern_web/live/pages/school/classes/id/ilp_component.ex:94
 #, elixir-autogen, elixir-format
 msgid "View ILP"
 msgstr "Ver ILP"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:115
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:116
 #, elixir-autogen, elixir-format
 msgid "(1 minute left until next revision request)"
 msgid_plural "(%{count} minutes left until next revision request)"
 msgstr[0] "(1 minuto até o próximo pedido de revisão)"
 msgstr[1] "(%{count} minutos até o próximo pedido de revisão)"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:112
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "AI revision can be requested every %{minute} minutes"
 msgstr "A revisão por IA pode ser solicitada a cada %{minute} minutos"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:407
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:408
 #, elixir-autogen, elixir-format
 msgid "AI revision failed"
 msgstr "A revisão por IA falhou"
@@ -5015,47 +5028,47 @@ msgstr "Instruções da revisão por IA"
 msgid "Add instructions on how Lanttern should revise this ILP."
 msgstr "Adicione instruções sobre como a Lanttern deve revisar este ILP."
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:412
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:413
 #, elixir-autogen, elixir-format
 msgid "Age should be a number between 0 and 100"
 msgstr "Idade deve ser um número entre 0 e 100"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:97
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:98
 #, elixir-autogen, elixir-format
 msgid "Generated in %{datetime}"
 msgstr "Gerado em %{datetime}"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:136
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:137
 #, elixir-autogen, elixir-format
 msgid "Inform the approximated age of the student (in years), and ask for Lanttern AI revision."
 msgstr "Informe a idade aproximada do estudante (em anos) e solicite revisão da Lanttern AI."
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:132
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:133
 #, elixir-autogen, elixir-format
 msgid "Inform the approximated age of the student (in years), and ask for an updated Lanttern AI revision."
 msgstr "Informe a idade aproximada do estudante (em anos) e solicite uma revisão atualizada da Lanttern AI."
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:94
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:95
 #, elixir-autogen, elixir-format
 msgid "Lanttern AI revision"
 msgstr "Revisão da Lanttern AI"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:105
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:106
 #, elixir-autogen, elixir-format
 msgid "Remember that AI make mistakes. Always double-check generated responses."
 msgstr "Lembre-se de que a IA comete erros. Sempre verifique as respostas geradas."
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:152
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:153
 #, elixir-autogen, elixir-format
 msgid "Request AI review"
 msgstr "Solicitar revisão da IA"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:151
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:152
 #, elixir-autogen, elixir-format
 msgid "Request AI review update"
 msgstr "Solicitar atualização da revisão da IA"
 
-#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:145
+#: lib/lanttern_web/live/shared/ilp/student_ilp_manager_component.ex:146
 #, elixir-autogen, elixir-format
 msgid "Student age"
 msgstr "Idade do estudante"
@@ -5114,3 +5127,54 @@ msgstr "Maior que ou igual a"
 #, elixir-autogen, elixir-format
 msgid "Scale ranges"
 msgstr "Intervalos da escala"
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:137
+#, elixir-autogen, elixir-format
+msgid "Edit student tag"
+msgstr "Editar tag de estudante"
+
+#: lib/lanttern_web/live/pages/school/students_component.ex:83
+#, elixir-autogen, elixir-format
+msgid "Filter students by tag"
+msgstr "Filtrar estudantes por tag"
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:17
+#, elixir-autogen, elixir-format
+msgid "Manage student tags below"
+msgstr "Gerencie as tags de estudantes abaixo"
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:128
+#, elixir-autogen, elixir-format
+msgid "New student tag"
+msgstr "Nova tag de estudante"
+
+#: lib/lanttern_web/live/pages/students/settings/tags_component.ex:52
+#, elixir-autogen, elixir-format
+msgid "No student tags created yet"
+msgstr "Nenhuma tag de estudante criada ainda"
+
+#: lib/lanttern_web/live/pages/students/settings/students_settings_live.ex:14
+#, elixir-autogen, elixir-format
+msgid "Student settings"
+msgstr "Configurações de estudante"
+
+#: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:62
+#, elixir-autogen, elixir-format
+msgid "Student tags"
+msgstr "Tags de estudante"
+
+#: lib/lanttern_web/live/pages/school/students_component.ex:56
+#: lib/lanttern_web/live/pages/students/settings/students_settings_live.html.heex:5
+#, elixir-autogen, elixir-format
+msgid "Students settings"
+msgstr "Configurações de estudantes"
+
+#: lib/lanttern_web/live/pages/students/settings/students_settings_live.ex:28
+#, elixir-autogen, elixir-format
+msgid "You don't have access to students settings page"
+msgstr "Você não tem acesso à página de configurações de estudantes"
+
+#: lib/lanttern_web/live/pages/strands/id/about_component.ex:56
+#, elixir-autogen, elixir-format
+msgid "Use this area to manage the strand curriculum."
+msgstr "Use esta área para gerenciar o currículo da trilha."

--- a/priv/repo/migrations/20230928160952_create_assessment_points_filter_views.exs
+++ b/priv/repo/migrations/20230928160952_create_assessment_points_filter_views.exs
@@ -12,19 +12,31 @@ defmodule Lanttern.Repo.Migrations.CreateAssessmentPointsFilterViews do
     create index(:assessment_points_filter_views, [:profile_id])
 
     create table(:assessment_points_filter_views_classes, primary_key: false) do
-      add :assessment_points_filter_view_id, references(:assessment_points_filter_views, on_delete: :delete_all)
+      add :assessment_points_filter_view_id,
+          references(:assessment_points_filter_views, on_delete: :delete_all)
+
       add :class_id, references(:classes, on_delete: :delete_all)
     end
 
     create index(:assessment_points_filter_views_classes, [:class_id])
-    create unique_index(:assessment_points_filter_views_classes, [:assessment_points_filter_view_id, :class_id])
+
+    create unique_index(:assessment_points_filter_views_classes, [
+             :assessment_points_filter_view_id,
+             :class_id
+           ])
 
     create table(:assessment_points_filter_views_subjects, primary_key: false) do
-      add :assessment_points_filter_view_id, references(:assessment_points_filter_views, on_delete: :delete_all)
+      add :assessment_points_filter_view_id,
+          references(:assessment_points_filter_views, on_delete: :delete_all)
+
       add :subject_id, references(:subjects, on_delete: :delete_all)
     end
 
     create index(:assessment_points_filter_views_subjects, [:subject_id])
-    create unique_index(:assessment_points_filter_views_subjects, [:assessment_points_filter_view_id, :subject_id])
+
+    create unique_index(:assessment_points_filter_views_subjects, [
+             :assessment_points_filter_view_id,
+             :subject_id
+           ])
   end
 end

--- a/priv/repo/migrations/20250422162113_create_student_tags.exs
+++ b/priv/repo/migrations/20250422162113_create_student_tags.exs
@@ -1,0 +1,52 @@
+defmodule Lanttern.Repo.Migrations.CreateStudentTags do
+  use Ecto.Migration
+
+  def up do
+    # Create schools_student_tags table
+    create table(:schools_student_tags) do
+      add :name, :text, null: false
+      add :bg_color, :string, null: false
+      add :text_color, :string, null: false
+      add :school_id, references(:schools, on_delete: :nothing), null: false
+      add :position, :integer, null: false, default: 0
+
+      timestamps()
+    end
+
+    create index(:schools_student_tags, [:position])
+    create unique_index(:schools_student_tags, [:school_id, :id])
+
+    create constraint(
+             :schools_student_tags,
+             :schools_student_tags_bg_color_should_be_hex,
+             check: "bg_color ~* '^#[a-f0-9]{6}$'"
+           )
+
+    create constraint(
+             :schools_student_tags,
+             :schools_student_tags_text_color_should_be_hex,
+             check: "text_color ~* '^#[a-f0-9]{6}$'"
+           )
+
+    # Create relationship table students_tags
+    create table(:students_tags, primary_key: false) do
+      add :student_id,
+          references(:students, with: [school_id: :school_id], on_delete: :delete_all),
+          primary_key: true
+
+      add :tag_id,
+          references(:schools_student_tags,
+            with: [school_id: :school_id],
+            on_delete: :nothing
+          ),
+          primary_key: true
+
+      add :school_id, references(:schools, on_delete: :nothing), null: false
+    end
+  end
+
+  def down do
+    drop table(:students_tags)
+    drop table(:schools_student_tags)
+  end
+end

--- a/test/lanttern/assessments_test.exs
+++ b/test/lanttern/assessments_test.exs
@@ -2,6 +2,7 @@ defmodule Lanttern.AssessmentsTest do
   use Lanttern.DataCase
 
   alias Lanttern.Repo
+
   alias Lanttern.Assessments
 
   describe "assessment_points" do
@@ -305,10 +306,11 @@ defmodule Lanttern.AssessmentsTest do
     alias Lanttern.Assessments.AssessmentPoint
 
     import Lanttern.AssessmentsFixtures
-    alias Lanttern.LearningContextFixtures
+
     alias Lanttern.CurriculaFixtures
     alias Lanttern.GradingFixtures
     alias Lanttern.IdentityFixtures
+    alias Lanttern.LearningContextFixtures
     alias Lanttern.SchoolsFixtures
 
     test "create_assessment_point/2 with valid data creates an assessment point linked to a moment" do

--- a/test/lanttern/conversation_test.exs
+++ b/test/lanttern/conversation_test.exs
@@ -1,10 +1,11 @@
 defmodule Lanttern.ConversationTest do
   use Lanttern.DataCase
 
+  alias Lanttern.Assessments
   alias Lanttern.Conversation
+  alias Lanttern.Conversation.Comment
 
   describe "comments" do
-    alias Lanttern.Conversation.Comment
     import Lanttern.ConversationFixtures
 
     @invalid_attrs %{comment: nil}
@@ -115,8 +116,8 @@ defmodule Lanttern.ConversationTest do
   end
 
   describe "feedback_comments" do
-    alias Lanttern.Conversation.Comment
     alias Lanttern.Assessments
+    alias Lanttern.Conversation.Comment
 
     test "create_feedback_comment/2 with valid data creates a comment linked to feedback" do
       feedback = Lanttern.AssessmentsFixtures.feedback_fixture()

--- a/test/lanttern/grades_reports_test.exs
+++ b/test/lanttern/grades_reports_test.exs
@@ -1686,7 +1686,7 @@ defmodule Lanttern.GradesReportsTest do
           ordinal_value_id: ov_eme.id
         })
 
-      _entry_3_diff =
+      _entry_3_3 =
         AssessmentsFixtures.assessment_point_entry_fixture(%{
           student_id: std.id,
           assessment_point_id: goal_3_3.id,
@@ -4675,15 +4675,24 @@ defmodule Lanttern.GradesReportsTest do
         grades_report_subject_fixture(%{grades_report_id: grades_report.id})
 
       grades_report_cycle =
-        grades_report_cycle_fixture(%{grades_report_id: grades_report.id, is_visible: true})
+        grades_report_cycle_fixture(%{
+          grades_report_id: grades_report.id,
+          is_visible: true
+        })
 
       strand = LearningContextFixtures.strand_fixture()
 
       strand_ap_1 =
-        AssessmentsFixtures.assessment_point_fixture(%{strand_id: strand.id, type: "numeric"})
+        AssessmentsFixtures.assessment_point_fixture(%{
+          strand_id: strand.id,
+          type: "numeric"
+        })
 
       strand_ap_2 =
-        AssessmentsFixtures.assessment_point_fixture(%{strand_id: strand.id, type: "numeric"})
+        AssessmentsFixtures.assessment_point_fixture(%{
+          strand_id: strand.id,
+          type: "numeric"
+        })
 
       _grade_component_1 =
         GradingFixtures.grade_component_fixture(%{
@@ -4732,7 +4741,10 @@ defmodule Lanttern.GradesReportsTest do
         grades_report_subject_fixture(%{grades_report_id: grades_report.id})
 
       strand_ap_3 =
-        AssessmentsFixtures.assessment_point_fixture(%{strand_id: strand.id, type: "numeric"})
+        AssessmentsFixtures.assessment_point_fixture(%{
+          strand_id: strand.id,
+          type: "numeric"
+        })
 
       _grade_component_1_3_other_cycle =
         GradingFixtures.grade_component_fixture(%{

--- a/test/lanttern/learning_context_test.exs
+++ b/test/lanttern/learning_context_test.exs
@@ -7,8 +7,8 @@ defmodule Lanttern.LearningContextTest do
   describe "strands" do
     alias Lanttern.LearningContext.Strand
 
-    alias Lanttern.SchoolsFixtures
     alias Lanttern.ReportingFixtures
+    alias Lanttern.SchoolsFixtures
     import Lanttern.TaxonomyFixtures
     import Lanttern.AssessmentsFixtures
 

--- a/test/lanttern/message_board_test.exs
+++ b/test/lanttern/message_board_test.exs
@@ -2,6 +2,7 @@ defmodule Lanttern.MessageBoardTest do
   use Lanttern.DataCase
 
   alias Lanttern.Repo
+
   alias Lanttern.MessageBoard
 
   describe "board_messages" do

--- a/test/lanttern/student_tags_test.exs
+++ b/test/lanttern/student_tags_test.exs
@@ -1,0 +1,96 @@
+defmodule Lanttern.StudentTagsTest do
+  use Lanttern.DataCase
+
+  alias Lanttern.StudentTags
+
+  describe "student_tags" do
+    alias Lanttern.StudentTags.Tag
+
+    import Lanttern.SchoolsFixtures
+    import Lanttern.StudentTagsFixtures
+
+    @invalid_attrs %{name: nil, bg_color: nil, text_color: nil, school_id: nil}
+
+    test "list_student_tags/0 returns all student_tags" do
+      tag = student_tag_fixture()
+      assert StudentTags.list_student_tags() == [tag]
+    end
+
+    test "list_student_tags/1 with school_id returns school's student_tags" do
+      school = school_fixture()
+      tag = student_tag_fixture(%{school_id: school.id})
+      _other_tag = student_tag_fixture()
+
+      assert StudentTags.list_student_tags(school_id: school.id) == [tag]
+    end
+
+    test "get_student_tag!/1 returns the student_tag with given id" do
+      tag = student_tag_fixture()
+      assert StudentTags.get_student_tag!(tag.id) == tag
+    end
+
+    test "create_student_tag/1 with valid data creates a student_tag" do
+      school = school_fixture()
+
+      valid_attrs = %{
+        name: "some name",
+        bg_color: "#000000",
+        text_color: "#ffffff",
+        school_id: school.id
+      }
+
+      assert {:ok, %Tag{} = tag} = StudentTags.create_student_tag(valid_attrs)
+      assert tag.name == "some name"
+      assert tag.bg_color == "#000000"
+      assert tag.text_color == "#ffffff"
+      assert tag.school_id == school.id
+    end
+
+    test "create_student_tag/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = StudentTags.create_student_tag(@invalid_attrs)
+    end
+
+    test "update_student_tag/2 with valid data updates the student_tag" do
+      tag = student_tag_fixture()
+      update_attrs = %{name: "some updated name", bg_color: "#111111", text_color: "#eeeeee"}
+
+      assert {:ok, %Tag{} = tag} = StudentTags.update_student_tag(tag, update_attrs)
+      assert tag.name == "some updated name"
+      assert tag.bg_color == "#111111"
+      assert tag.text_color == "#eeeeee"
+    end
+
+    test "update_student_tag/2 with invalid data returns error changeset" do
+      tag = student_tag_fixture()
+      assert {:error, %Ecto.Changeset{}} = StudentTags.update_student_tag(tag, @invalid_attrs)
+      assert tag == StudentTags.get_student_tag!(tag.id)
+    end
+
+    test "delete_student_tag/1 deletes the student_tag" do
+      tag = student_tag_fixture()
+      assert {:ok, %Tag{}} = StudentTags.delete_student_tag(tag)
+      assert_raise Ecto.NoResultsError, fn -> StudentTags.get_student_tag!(tag.id) end
+    end
+
+    test "change_student_tag/1 returns a student_tag changeset" do
+      tag = student_tag_fixture()
+      assert %Ecto.Changeset{} = StudentTags.change_student_tag(tag)
+    end
+
+    test "update_student_tags_positions/1 updates positions" do
+      tag1 = student_tag_fixture(%{position: 0})
+      tag2 = student_tag_fixture(%{position: 1})
+      tag3 = student_tag_fixture(%{position: 2})
+
+      assert :ok = StudentTags.update_student_tags_positions([tag3.id, tag1.id, tag2.id])
+
+      [updated_tag3, updated_tag1, updated_tag2] = StudentTags.list_student_tags()
+      assert updated_tag3.id == tag3.id
+      assert updated_tag3.position == 0
+      assert updated_tag1.id == tag1.id
+      assert updated_tag1.position == 1
+      assert updated_tag2.id == tag2.id
+      assert updated_tag2.position == 2
+    end
+  end
+end

--- a/test/lanttern/students_cycle_info_test.exs
+++ b/test/lanttern/students_cycle_info_test.exs
@@ -4,12 +4,13 @@ defmodule Lanttern.StudentsCycleInfoTest do
   alias Lanttern.StudentsCycleInfo
 
   describe "students_cycle_info" do
+    import Lanttern.StudentsCycleInfoFixtures
+
     alias Lanttern.StudentsCycleInfo.StudentCycleInfo
     alias Lanttern.StudentsCycleInfoLog.StudentCycleInfoLog
 
-    import Lanttern.StudentsCycleInfoFixtures
-    alias Lanttern.SchoolsFixtures
     alias Lanttern.IdentityFixtures
+    alias Lanttern.SchoolsFixtures
 
     @invalid_attrs %{school_info: nil, shared_info: nil, profile_picture_url: nil}
 

--- a/test/lanttern/students_records_test.exs
+++ b/test/lanttern/students_records_test.exs
@@ -4,13 +4,14 @@ defmodule Lanttern.StudentsRecordsTest do
   alias Lanttern.StudentsRecords
 
   describe "students_records" do
+    import Lanttern.StudentsRecordsFixtures
+
     alias Lanttern.StudentsRecords.StudentRecord
     alias Lanttern.StudentsRecordsLog.StudentRecordLog
 
-    import Lanttern.StudentsRecordsFixtures
-    alias Lanttern.SchoolsFixtures
-    alias Lanttern.RepoHelpers.Page
     alias Lanttern.Identity.Profile
+    alias Lanttern.RepoHelpers.Page
+    alias Lanttern.SchoolsFixtures
 
     @invalid_attrs %{name: nil, date: nil, time: nil, description: nil}
 

--- a/test/lanttern_web/live/pages/grades_reports/id/grades_report_live_test.exs
+++ b/test/lanttern_web/live/pages/grades_reports/id/grades_report_live_test.exs
@@ -1,9 +1,9 @@
 defmodule LantternWeb.GradesReportLiveTest do
   use LantternWeb.ConnCase
 
-  import Lanttern.GradesReportsFixtures
-  alias Lanttern.SchoolsFixtures
   alias Lanttern.GradingFixtures
+  alias Lanttern.SchoolsFixtures
+  import Lanttern.GradesReportsFixtures
 
   @live_view_base_path "/grades_reports"
 

--- a/test/lanttern_web/live/pages/school/message_board/archive/archived_messages_live_test.exs
+++ b/test/lanttern_web/live/pages/school/message_board/archive/archived_messages_live_test.exs
@@ -1,8 +1,8 @@
 defmodule LantternWeb.ArchivedMessagesLiveTest do
   use LantternWeb.ConnCase
 
-  alias Lanttern.MessageBoardFixtures
   alias Lanttern.MessageBoard
+  alias Lanttern.MessageBoardFixtures
 
   @live_view_path "/school/message_board/archive"
 

--- a/test/lanttern_web/live/pages/school/school_live_test.exs
+++ b/test/lanttern_web/live/pages/school/school_live_test.exs
@@ -1,8 +1,8 @@
 defmodule LantternWeb.SchoolLiveTest do
   use LantternWeb.ConnCase
 
-  alias Lanttern.SchoolsFixtures
   alias Lanttern.SchoolConfigFixtures
+  alias Lanttern.SchoolsFixtures
 
   @live_view_base_path "/school"
 

--- a/test/lanttern_web/live/pages/school/students/settings/students_settings_live_test.exs
+++ b/test/lanttern_web/live/pages/school/students/settings/students_settings_live_test.exs
@@ -1,0 +1,44 @@
+defmodule LantternWeb.StudentsSettingsLiveTest do
+  use LantternWeb.ConnCase
+
+  alias Lanttern.StudentTagsFixtures
+
+  @live_view_path "/school/students/settings"
+
+  setup [:register_and_log_in_staff_member]
+
+  describe "Students settings live view basic navigation" do
+    test "school manager disconnected and connected mount", context do
+      %{conn: conn} = set_user_permissions(["school_management"], context)
+      conn = get(conn, @live_view_path)
+      assert html_response(conn, 200) =~ ~r/<h1 .+>\s*Students settings\s*<\/h1>/
+
+      {:ok, _view, _html} = live(conn)
+    end
+
+    test "list tags", context do
+      %{conn: conn, user: user} = set_user_permissions(["school_management"], context)
+
+      school_id = user.current_profile.school_id
+
+      _student_tag =
+        StudentTagsFixtures.student_tag_fixture(%{school_id: school_id, name: "student tag abc"})
+
+      {:ok, view, _html} = live(conn, @live_view_path)
+
+      assert view |> has_element?("span", "student tag abc")
+    end
+  end
+
+  describe "Students settings live view access" do
+    test "user without school management can't access settings page", %{conn: conn} do
+      {:error,
+       {:live_redirect,
+        %{
+          to: "/school/students",
+          flash: %{"error" => "You don't have access to students settings page"}
+        }}} =
+        live(conn, @live_view_path)
+    end
+  end
+end

--- a/test/lanttern_web/live/shared/assessments/feedback_comment_form_component_test.exs
+++ b/test/lanttern_web/live/shared/assessments/feedback_comment_form_component_test.exs
@@ -2,9 +2,10 @@ defmodule LantternWeb.Assessments.FeedbackCommentFormComponentTest do
   use LantternWeb.ConnCase
 
   alias Lanttern.Repo
-  alias Lanttern.SchoolsFixtures
+
   alias Lanttern.AssessmentsFixtures
   alias Lanttern.ConversationFixtures
+  alias Lanttern.SchoolsFixtures
 
   @live_view_path_base "/assessment_points"
   @overlay_selector "#feedback-overlay"

--- a/test/lanttern_web/live/shared/assessments/feedback_form_component_test.exs
+++ b/test/lanttern_web/live/shared/assessments/feedback_form_component_test.exs
@@ -2,8 +2,9 @@ defmodule LantternWeb.Assessments.FeedbackFormComponentTest do
   use LantternWeb.ConnCase
 
   alias Lanttern.Repo
-  alias Lanttern.SchoolsFixtures
+
   alias Lanttern.AssessmentsFixtures
+  alias Lanttern.SchoolsFixtures
 
   @live_view_path_base "/assessment_points"
   @overlay_selector "#feedback-overlay"

--- a/test/lanttern_web/user_auth_test.exs
+++ b/test/lanttern_web/user_auth_test.exs
@@ -1,9 +1,10 @@
 defmodule LantternWeb.UserAuthTest do
   use LantternWeb.ConnCase, async: true
 
-  alias Lanttern.SchoolsFixtures
   alias Phoenix.LiveView
+
   alias Lanttern.Identity
+  alias Lanttern.SchoolsFixtures
   alias LantternWeb.UserAuth
   import Lanttern.IdentityFixtures
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -67,7 +67,7 @@ defmodule Lanttern.DataCase do
       end)
 
   """
-  def assert_supervised_tasks_are_down() do
+  def assert_supervised_tasks_are_down do
     for pid <- Task.Supervisor.children(Lanttern.TaskSupervisor) do
       # # check for message queue len to avoid
       # # awaiting on empty message boxes

--- a/test/support/fixtures/bncc_fixtures.ex
+++ b/test/support/fixtures/bncc_fixtures.ex
@@ -7,9 +7,9 @@ defmodule Lanttern.BNCCFixtures do
   import Lanttern.CurriculaFixtures
   import Lanttern.TaxonomyFixtures
 
-  alias Lanttern.Repo
   alias Lanttern.Curricula.Curriculum
   alias Lanttern.Curricula.CurriculumComponent
+  alias Lanttern.Repo
 
   @doc """
   Generate a "Habilidade BNCC EF".

--- a/test/support/fixtures/rubrics_fixtures.ex
+++ b/test/support/fixtures/rubrics_fixtures.ex
@@ -4,9 +4,9 @@ defmodule Lanttern.RubricsFixtures do
   entities via the `Lanttern.Rubrics` context.
   """
 
-  alias Lanttern.LearningContextFixtures
   alias Lanttern.CurriculaFixtures
   alias Lanttern.GradingFixtures
+  alias Lanttern.LearningContextFixtures
 
   @doc """
   Generate a rubric.

--- a/test/support/fixtures/student_tags_fixtures.ex
+++ b/test/support/fixtures/student_tags_fixtures.ex
@@ -1,0 +1,25 @@
+defmodule Lanttern.StudentTagsFixtures do
+  @moduledoc """
+  This module defines test helpers for creating
+  entities via the `Lanttern.StudentTags` context.
+  """
+
+  import Lanttern.SchoolsFixtures
+
+  @doc """
+  Generate a student tag.
+  """
+  def student_tag_fixture(attrs \\ %{}) do
+    {:ok, tag} =
+      attrs
+      |> Enum.into(%{
+        name: "some name",
+        bg_color: "#000000",
+        text_color: "#ffffff",
+        school_id: maybe_gen_school_id(attrs)
+      })
+      |> Lanttern.StudentTags.create_student_tag()
+
+    tag
+  end
+end


### PR DESCRIPTION
This PR adds support to student tags, a feature that won't do much by itself, but it's a requirement to the addition of future features (see #325 for examples).

In this PR, we also implemented all the adjustments suggested by `credo --strict`, which led to some minor changes in the project as a whole.

Last but not least, we added some visual hints to grades with comments in student/guardian view, which resolves #326.

---

# Copilot summary

This pull request introduces several changes across multiple files, focusing on code cleanup, consistency improvements, and minor feature additions. The most significant changes include the addition of a Credo configuration file, the removal of redundant parentheses in function definitions, reordering of aliases for consistency, and the introduction of a new option for preloading student tags in ILP queries.

### Configuration Addition:
* [`.credo.exs`](diffhunk://#diff-c44b474280f99dde56e6b80c90554ced12592de34aaa8d42186984126d5521d9R1-R33): Added a new Credo configuration file to define linting rules and disable specific checks, such as `AliasUsage` and `MaxLineLength`.

### Code Consistency Improvements:
* Removed redundant parentheses in function definitions across multiple files for better adherence to Elixir style conventions:
  - [`lib/lanttern/assessments.ex`](diffhunk://#diff-c43ff8d0e2959e6085e6fb1c0ea5c6a7a67569c62e0c46ca11edbc2df89945f9L244-R244): Updated `new_assessment_point_changeset` to remove parentheses.
  - [`lib/lanttern/bncc.ex`](diffhunk://#diff-ab477e2cbfaaa19ca550cc0c27207fdd5cc47b4e57613f5b66ddbca2180748cfL67-R68): Updated several functions, including `bncc_registered?`, `seed_bncc`, and others, to remove parentheses. [[1]](diffhunk://#diff-ab477e2cbfaaa19ca550cc0c27207fdd5cc47b4e57613f5b66ddbca2180748cfL67-R68) [[2]](diffhunk://#diff-ab477e2cbfaaa19ca550cc0c27207fdd5cc47b4e57613f5b66ddbca2180748cfL126-R127) [[3]](diffhunk://#diff-ab477e2cbfaaa19ca550cc0c27207fdd5cc47b4e57613f5b66ddbca2180748cfL144-R145) [[4]](diffhunk://#diff-ab477e2cbfaaa19ca550cc0c27207fdd5cc47b4e57613f5b66ddbca2180748cfL466-R467) [[5]](diffhunk://#diff-ab477e2cbfaaa19ca550cc0c27207fdd5cc47b4e57613f5b66ddbca2180748cfL483-R484)
  - [`lib/lanttern/google_token.ex`](diffhunk://#diff-a1b89e1770177b7b5115bcbc76b46e41e0422a2ed8bb4da4ca36135f24a82259L24-R24): Updated `generate_exp` to remove parentheses.

### Alias Reordering for Readability:
* Reordered aliases in various modules to improve readability and maintain consistent grouping:
  - [`lib/lanttern/assessments/assessment_point.ex`](diffhunk://#diff-1844ed05cc65b607e27a5c78804dd4e09cd39c20cf8c4aa37c0c7a49398bc894R16-L19): Reordered `GradeComponent` alias.
  - [`lib/lanttern/assessments/assessment_point_entry.ex`](diffhunk://#diff-137722e8c4749491c1f0d6788ef41511a4592098de2d1f26cec0c868db6ad273L30-R33): Reordered `Scale` and `Student` aliases.
  - [`lib/lanttern/attachments/attachment.ex`](diffhunk://#diff-a8b73119b081843af018f628dfa476be26c46fb12458571727bc375d4e7cb00dR13-L18): Reordered `MomentCard` and `MomentCardAttachment` aliases.

### Minor Feature Addition:
* [`lib/lanttern/ilp.ex`](diffhunk://#diff-146cebb03784089d1f91908b613fc15a13cc05cbe75489af6019f5be92dd977bR596): Added a new option `:preload_student_tags` to the `apply_list_students_and_ilps_opts` function, enabling preloading of student tags in ILP queries. [[1]](diffhunk://#diff-146cebb03784089d1f91908b613fc15a13cc05cbe75489af6019f5be92dd977bR596) [[2]](diffhunk://#diff-146cebb03784089d1f91908b613fc15a13cc05cbe75489af6019f5be92dd977bR646-R653)

### Minor Fixes:
* [`lib/lanttern/attachments/attachment.ex`](diffhunk://#diff-a8b73119b081843af018f628dfa476be26c46fb12458571727bc375d4e7cb00dL79-R79): Updated error message formatting for invalid links to use a more idiomatic approach with `~s`.