### PR TITLE
create base quiz-related schemas

### DIFF
--- a/lib/lanttern/quizzes.ex
+++ b/lib/lanttern/quizzes.ex
@@ -1,0 +1,104 @@
+defmodule Lanttern.Quizzes do
+  @moduledoc """
+  The Quizzes context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Lanttern.Repo
+
+  alias Lanttern.Quizzes.Quiz
+
+  @doc """
+  Returns the list of quizzes.
+
+  ## Examples
+
+      iex> list_quizzes()
+      [%Quiz{}, ...]
+
+  """
+  def list_quizzes do
+    Repo.all(Quiz)
+  end
+
+  @doc """
+  Gets a single quiz.
+
+  Raises `Ecto.NoResultsError` if the Quiz does not exist.
+
+  ## Examples
+
+      iex> get_quiz!(123)
+      %Quiz{}
+
+      iex> get_quiz!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_quiz!(id), do: Repo.get!(Quiz, id)
+
+  @doc """
+  Creates a quiz.
+
+  ## Examples
+
+      iex> create_quiz(%{field: value})
+      {:ok, %Quiz{}}
+
+      iex> create_quiz(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_quiz(attrs \\ %{}) do
+    %Quiz{}
+    |> Quiz.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a quiz.
+
+  ## Examples
+
+      iex> update_quiz(quiz, %{field: new_value})
+      {:ok, %Quiz{}}
+
+      iex> update_quiz(quiz, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_quiz(%Quiz{} = quiz, attrs) do
+    quiz
+    |> Quiz.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a quiz.
+
+  ## Examples
+
+      iex> delete_quiz(quiz)
+      {:ok, %Quiz{}}
+
+      iex> delete_quiz(quiz)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_quiz(%Quiz{} = quiz) do
+    Repo.delete(quiz)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking quiz changes.
+
+  ## Examples
+
+      iex> change_quiz(quiz)
+      %Ecto.Changeset{data: %Quiz{}}
+
+  """
+  def change_quiz(%Quiz{} = quiz, attrs \\ %{}) do
+    Quiz.changeset(quiz, attrs)
+  end
+end

--- a/lib/lanttern/quizzes.ex
+++ b/lib/lanttern/quizzes.ex
@@ -7,6 +7,7 @@ defmodule Lanttern.Quizzes do
   alias Lanttern.Repo
 
   alias Lanttern.Quizzes.Quiz
+  alias Lanttern.Quizzes.QuizItem
 
   @doc """
   Returns the list of quizzes.
@@ -100,5 +101,99 @@ defmodule Lanttern.Quizzes do
   """
   def change_quiz(%Quiz{} = quiz, attrs \\ %{}) do
     Quiz.changeset(quiz, attrs)
+  end
+
+  @doc """
+  Returns the list of quiz_items.
+
+  ## Examples
+
+      iex> list_quiz_items()
+      [%QuizItem{}, ...]
+
+  """
+  def list_quiz_items do
+    Repo.all(QuizItem)
+  end
+
+  @doc """
+  Gets a single quiz_item.
+
+  Raises `Ecto.NoResultsError` if the Quiz item does not exist.
+
+  ## Examples
+
+      iex> get_quiz_item!(123)
+      %QuizItem{}
+
+      iex> get_quiz_item!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_quiz_item!(id), do: Repo.get!(QuizItem, id)
+
+  @doc """
+  Creates a quiz_item.
+
+  ## Examples
+
+      iex> create_quiz_item(%{field: value})
+      {:ok, %QuizItem{}}
+
+      iex> create_quiz_item(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_quiz_item(attrs \\ %{}) do
+    %QuizItem{}
+    |> QuizItem.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a quiz_item.
+
+  ## Examples
+
+      iex> update_quiz_item(quiz_item, %{field: new_value})
+      {:ok, %QuizItem{}}
+
+      iex> update_quiz_item(quiz_item, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_quiz_item(%QuizItem{} = quiz_item, attrs) do
+    quiz_item
+    |> QuizItem.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a quiz_item.
+
+  ## Examples
+
+      iex> delete_quiz_item(quiz_item)
+      {:ok, %QuizItem{}}
+
+      iex> delete_quiz_item(quiz_item)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_quiz_item(%QuizItem{} = quiz_item) do
+    Repo.delete(quiz_item)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking quiz_item changes.
+
+  ## Examples
+
+      iex> change_quiz_item(quiz_item)
+      %Ecto.Changeset{data: %QuizItem{}}
+
+  """
+  def change_quiz_item(%QuizItem{} = quiz_item, attrs \\ %{}) do
+    QuizItem.changeset(quiz_item, attrs)
   end
 end

--- a/lib/lanttern/quizzes.ex
+++ b/lib/lanttern/quizzes.ex
@@ -8,6 +8,7 @@ defmodule Lanttern.Quizzes do
 
   alias Lanttern.Quizzes.Quiz
   alias Lanttern.Quizzes.QuizItem
+  alias Lanttern.Quizzes.QuizItemAlternative
 
   @doc """
   Returns the list of quizzes.
@@ -195,5 +196,99 @@ defmodule Lanttern.Quizzes do
   """
   def change_quiz_item(%QuizItem{} = quiz_item, attrs \\ %{}) do
     QuizItem.changeset(quiz_item, attrs)
+  end
+
+  @doc """
+  Returns the list of quiz_item_alternatives.
+
+  ## Examples
+
+      iex> list_quiz_item_alternatives()
+      [%QuizItemAlternative{}, ...]
+
+  """
+  def list_quiz_item_alternatives do
+    Repo.all(QuizItemAlternative)
+  end
+
+  @doc """
+  Gets a single quiz_item_alternative.
+
+  Raises `Ecto.NoResultsError` if the Quiz item alternative does not exist.
+
+  ## Examples
+
+      iex> get_quiz_item_alternative!(123)
+      %QuizItemAlternative{}
+
+      iex> get_quiz_item_alternative!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_quiz_item_alternative!(id), do: Repo.get!(QuizItemAlternative, id)
+
+  @doc """
+  Creates a quiz_item_alternative.
+
+  ## Examples
+
+      iex> create_quiz_item_alternative(%{field: value})
+      {:ok, %QuizItemAlternative{}}
+
+      iex> create_quiz_item_alternative(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_quiz_item_alternative(attrs \\ %{}) do
+    %QuizItemAlternative{}
+    |> QuizItemAlternative.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a quiz_item_alternative.
+
+  ## Examples
+
+      iex> update_quiz_item_alternative(quiz_item_alternative, %{field: new_value})
+      {:ok, %QuizItemAlternative{}}
+
+      iex> update_quiz_item_alternative(quiz_item_alternative, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_quiz_item_alternative(%QuizItemAlternative{} = quiz_item_alternative, attrs) do
+    quiz_item_alternative
+    |> QuizItemAlternative.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a quiz_item_alternative.
+
+  ## Examples
+
+      iex> delete_quiz_item_alternative(quiz_item_alternative)
+      {:ok, %QuizItemAlternative{}}
+
+      iex> delete_quiz_item_alternative(quiz_item_alternative)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_quiz_item_alternative(%QuizItemAlternative{} = quiz_item_alternative) do
+    Repo.delete(quiz_item_alternative)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking quiz_item_alternative changes.
+
+  ## Examples
+
+      iex> change_quiz_item_alternative(quiz_item_alternative)
+      %Ecto.Changeset{data: %QuizItemAlternative{}}
+
+  """
+  def change_quiz_item_alternative(%QuizItemAlternative{} = quiz_item_alternative, attrs \\ %{}) do
+    QuizItemAlternative.changeset(quiz_item_alternative, attrs)
   end
 end

--- a/lib/lanttern/quizzes.ex
+++ b/lib/lanttern/quizzes.ex
@@ -9,6 +9,7 @@ defmodule Lanttern.Quizzes do
   alias Lanttern.Quizzes.Quiz
   alias Lanttern.Quizzes.QuizItem
   alias Lanttern.Quizzes.QuizItemAlternative
+  alias Lanttern.Quizzes.QuizItemStudentEntry
 
   @doc """
   Returns the list of quizzes.
@@ -290,5 +291,102 @@ defmodule Lanttern.Quizzes do
   """
   def change_quiz_item_alternative(%QuizItemAlternative{} = quiz_item_alternative, attrs \\ %{}) do
     QuizItemAlternative.changeset(quiz_item_alternative, attrs)
+  end
+
+  @doc """
+  Returns the list of quiz_item_student_entries.
+
+  ## Examples
+
+      iex> list_quiz_item_student_entries()
+      [%QuizItemStudentEntry{}, ...]
+
+  """
+  def list_quiz_item_student_entries do
+    Repo.all(QuizItemStudentEntry)
+  end
+
+  @doc """
+  Gets a single quiz_item_student_entry.
+
+  Raises `Ecto.NoResultsError` if the Quiz item student entry does not exist.
+
+  ## Examples
+
+      iex> get_quiz_item_student_entry!(123)
+      %QuizItemStudentEntry{}
+
+      iex> get_quiz_item_student_entry!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_quiz_item_student_entry!(id), do: Repo.get!(QuizItemStudentEntry, id)
+
+  @doc """
+  Creates a quiz_item_student_entry.
+
+  ## Examples
+
+      iex> create_quiz_item_student_entry(%{field: value})
+      {:ok, %QuizItemStudentEntry{}}
+
+      iex> create_quiz_item_student_entry(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_quiz_item_student_entry(attrs \\ %{}) do
+    %QuizItemStudentEntry{}
+    |> QuizItemStudentEntry.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a quiz_item_student_entry.
+
+  ## Examples
+
+      iex> update_quiz_item_student_entry(quiz_item_student_entry, %{field: new_value})
+      {:ok, %QuizItemStudentEntry{}}
+
+      iex> update_quiz_item_student_entry(quiz_item_student_entry, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_quiz_item_student_entry(%QuizItemStudentEntry{} = quiz_item_student_entry, attrs) do
+    quiz_item_student_entry
+    |> QuizItemStudentEntry.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a quiz_item_student_entry.
+
+  ## Examples
+
+      iex> delete_quiz_item_student_entry(quiz_item_student_entry)
+      {:ok, %QuizItemStudentEntry{}}
+
+      iex> delete_quiz_item_student_entry(quiz_item_student_entry)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_quiz_item_student_entry(%QuizItemStudentEntry{} = quiz_item_student_entry) do
+    Repo.delete(quiz_item_student_entry)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking quiz_item_student_entry changes.
+
+  ## Examples
+
+      iex> change_quiz_item_student_entry(quiz_item_student_entry)
+      %Ecto.Changeset{data: %QuizItemStudentEntry{}}
+
+  """
+  def change_quiz_item_student_entry(
+        %QuizItemStudentEntry{} = quiz_item_student_entry,
+        attrs \\ %{}
+      ) do
+    QuizItemStudentEntry.changeset(quiz_item_student_entry, attrs)
   end
 end

--- a/lib/lanttern/quizzes/quiz.ex
+++ b/lib/lanttern/quizzes/quiz.ex
@@ -1,0 +1,40 @@
+defmodule Lanttern.Quizzes.Quiz do
+  @moduledoc """
+  The `Quiz` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  use Gettext, backend: Lanttern.Gettext
+
+  alias Lanttern.LearningContext.Moment
+
+  @type t :: %__MODULE__{
+          id: pos_integer(),
+          position: non_neg_integer(),
+          title: String.t(),
+          description: String.t(),
+          moment: Moment.t() | Ecto.Association.NotLoaded.t(),
+          moment_id: pos_integer(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "quizzes" do
+    field :position, :integer, default: 0
+    field :title, :string
+    field :description, :string
+
+    belongs_to :moment, Moment
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(quiz, attrs) do
+    quiz
+    |> cast(attrs, [:position, :title, :description, :moment_id])
+    |> validate_required([:title, :description, :moment_id])
+  end
+end

--- a/lib/lanttern/quizzes/quiz_item.ex
+++ b/lib/lanttern/quizzes/quiz_item.ex
@@ -1,0 +1,43 @@
+defmodule Lanttern.Quizzes.QuizItem do
+  @moduledoc """
+  The `QuizItem` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  use Gettext, backend: Lanttern.Gettext
+
+  alias Lanttern.Quizzes.Quiz
+
+  @type t :: %__MODULE__{
+          id: pos_integer(),
+          position: non_neg_integer(),
+          type: String.t(),
+          description: String.t(),
+          quiz: Quiz.t() | Ecto.Association.NotLoaded.t(),
+          quiz_id: pos_integer(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "quiz_items" do
+    field :position, :integer, default: 0
+    field :type, :string
+    field :description, :string
+
+    belongs_to :quiz, Quiz
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(quiz_item, attrs) do
+    quiz_item
+    |> cast(attrs, [:position, :description, :type, :quiz_id])
+    |> validate_required([:description, :type, :quiz_id])
+    |> check_constraint(:type,
+      name: :valid_types,
+      message: gettext(~s(Invalid question type \(should be "multiple choice" or "text"\)))
+    )
+  end
+end

--- a/lib/lanttern/quizzes/quiz_item_alternative.ex
+++ b/lib/lanttern/quizzes/quiz_item_alternative.ex
@@ -1,0 +1,43 @@
+defmodule Lanttern.Quizzes.QuizItemAlternative do
+  @moduledoc """
+  The `QuizItemAlternative` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  use Gettext, backend: Lanttern.Gettext
+
+  alias Lanttern.Quizzes.QuizItem
+
+  @type t :: %__MODULE__{
+          id: pos_integer(),
+          position: non_neg_integer(),
+          description: String.t(),
+          is_correct: boolean(),
+          quiz_item: QuizItem.t() | Ecto.Association.NotLoaded.t(),
+          quiz_item_id: pos_integer(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "quiz_item_alternatives" do
+    field :position, :integer, default: 0
+    field :description, :string
+    field :is_correct, :boolean, default: false
+
+    belongs_to :quiz_item, QuizItem
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(quiz_item_alternative, attrs) do
+    quiz_item_alternative
+    |> cast(attrs, [:position, :description, :is_correct, :quiz_item_id])
+    |> validate_required([:description, :quiz_item_id])
+    |> unique_constraint([:is_correct, :quiz_item_id],
+      name: :quiz_item_alternatives_is_correct_quiz_item_id_index,
+      message: gettext("There's already a correct alternative for this question")
+    )
+  end
+end

--- a/lib/lanttern/quizzes/quiz_item_student_entry.ex
+++ b/lib/lanttern/quizzes/quiz_item_student_entry.ex
@@ -1,0 +1,62 @@
+defmodule Lanttern.Quizzes.QuizItemStudentEntry do
+  @moduledoc """
+  The `QuizItemStudentEntry` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+  use Gettext, backend: Lanttern.Gettext
+
+  alias Lanttern.Quizzes.QuizItem
+  alias Lanttern.Quizzes.QuizItemAlternative
+  alias Lanttern.Schools.Student
+
+  @type t :: %__MODULE__{
+          id: pos_integer(),
+          answer: String.t() | nil,
+          reasoning: String.t() | nil,
+          score: float() | nil,
+          feedback: String.t() | nil,
+          quiz_item: QuizItem.t() | Ecto.Association.NotLoaded.t(),
+          quiz_item_id: pos_integer(),
+          student: Student.t() | Ecto.Association.NotLoaded.t(),
+          student_id: pos_integer(),
+          quiz_item_alternative: QuizItemAlternative.t() | Ecto.Association.NotLoaded.t() | nil,
+          quiz_item_alternative_id: pos_integer() | nil,
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "quiz_item_student_entries" do
+    field :answer, :string
+    field :reasoning, :string
+    field :score, :float
+    field :feedback, :string
+
+    belongs_to :quiz_item, QuizItem
+    belongs_to :student, Student
+    belongs_to :quiz_item_alternative, QuizItemAlternative
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(quiz_item_student_entry, attrs) do
+    quiz_item_student_entry
+    |> cast(attrs, [
+      :answer,
+      :reasoning,
+      :score,
+      :feedback,
+      :quiz_item_id,
+      :student_id,
+      :quiz_item_alternative_id
+    ])
+    |> validate_required([:quiz_item_id, :student_id])
+    |> check_constraint(:id,
+      name: :required_input,
+      message: gettext("Either answer or alternative must be provided (but not both)")
+    )
+    |> unique_constraint([:student_id, :quiz_item_id])
+  end
+end

--- a/priv/repo/migrations/20250606155248_create_quizzes.exs
+++ b/priv/repo/migrations/20250606155248_create_quizzes.exs
@@ -1,0 +1,16 @@
+defmodule Lanttern.Repo.Migrations.CreateQuizzes do
+  use Ecto.Migration
+
+  def change do
+    create table(:quizzes) do
+      add :position, :integer, default: 0, null: false
+      add :title, :text, null: false
+      add :description, :text, null: false
+      add :moment_id, references(:moments, on_delete: :nothing), null: false
+
+      timestamps()
+    end
+
+    create index(:quizzes, [:moment_id])
+  end
+end

--- a/priv/repo/migrations/20250609153638_create_quiz_items.exs
+++ b/priv/repo/migrations/20250609153638_create_quiz_items.exs
@@ -1,0 +1,22 @@
+defmodule Lanttern.Repo.Migrations.CreateQuizItems do
+  use Ecto.Migration
+
+  def change do
+    create table(:quiz_items) do
+      add :position, :integer, null: false, default: 0
+      add :description, :text, null: false
+      add :type, :text, null: false
+      add :quiz_id, references(:quizzes, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:quiz_items, [:quiz_id])
+
+    create constraint(
+             :quiz_items,
+             :valid_types,
+             check: "type IN ('multiple_choice', 'text')"
+           )
+  end
+end

--- a/priv/repo/migrations/20250609161100_create_quiz_item_alternatives.exs
+++ b/priv/repo/migrations/20250609161100_create_quiz_item_alternatives.exs
@@ -1,0 +1,20 @@
+defmodule Lanttern.Repo.Migrations.CreateQuizItemAlternatives do
+  use Ecto.Migration
+
+  def change do
+    create table(:quiz_item_alternatives) do
+      add :position, :integer, default: 0, null: false
+      add :description, :text, null: false
+      add :is_correct, :boolean, default: false, null: false
+      add :quiz_item_id, references(:quiz_items, on_delete: :nothing), null: false
+
+      timestamps()
+    end
+
+    create index(:quiz_item_alternatives, [:quiz_item_id])
+
+    create unique_index(:quiz_item_alternatives, [:is_correct, :quiz_item_id],
+             where: "is_correct IS TRUE"
+           )
+  end
+end

--- a/priv/repo/migrations/20250609165046_create_quiz_item_student_entries.exs
+++ b/priv/repo/migrations/20250609165046_create_quiz_item_student_entries.exs
@@ -1,0 +1,40 @@
+defmodule Lanttern.Repo.Migrations.CreateQuizItemStudentEntries do
+  use Ecto.Migration
+
+  def change do
+    # creating unique constraint to allow composite foreign key on quiz item alternative.
+    create unique_index(:quiz_item_alternatives, [:id, :quiz_item_id])
+
+    create table(:quiz_item_student_entries) do
+      add :answer, :text
+      add :reasoning, :text
+      add :score, :float
+      add :feedback, :text
+      add :quiz_item_id, references(:quiz_items, on_delete: :nothing), null: false
+      add :student_id, references(:students, on_delete: :nothing), null: false
+
+      add :quiz_item_alternative_id,
+          references(:quiz_item_alternatives,
+            with: [quiz_item_id: :quiz_item_id],
+            on_delete: :nothing
+          )
+
+      timestamps()
+    end
+
+    create index(:quiz_item_student_entries, [:quiz_item_id])
+    create index(:quiz_item_student_entries, [:quiz_item_alternative_id])
+    create unique_index(:quiz_item_student_entries, [:student_id, :quiz_item_id])
+
+    required_input_check = """
+    (answer IS NOT NULL AND quiz_item_alternative_id IS NULL)
+    OR (answer IS NULL AND quiz_item_alternative_id IS NOT NULL)
+    """
+
+    create constraint(
+             :quiz_item_student_entries,
+             :required_input,
+             check: required_input_check
+           )
+  end
+end

--- a/test/lanttern/quizzes_test.exs
+++ b/test/lanttern/quizzes_test.exs
@@ -140,4 +140,106 @@ defmodule Lanttern.QuizzesTest do
       assert %Ecto.Changeset{} = Quizzes.change_quiz_item(quiz_item)
     end
   end
+
+  describe "quiz_item_alternatives" do
+    alias Lanttern.Quizzes.QuizItemAlternative
+
+    @invalid_attrs %{position: nil, description: nil}
+
+    test "list_quiz_item_alternatives/0 returns all quiz_item_alternatives" do
+      quiz_item_alternative = insert(:quiz_item_alternative) |> Ecto.reset_fields([:quiz_item])
+      assert Quizzes.list_quiz_item_alternatives() == [quiz_item_alternative]
+    end
+
+    test "get_quiz_item_alternative!/1 returns the quiz_item_alternative with given id" do
+      quiz_item_alternative = insert(:quiz_item_alternative) |> Ecto.reset_fields([:quiz_item])
+      assert Quizzes.get_quiz_item_alternative!(quiz_item_alternative.id) == quiz_item_alternative
+    end
+
+    test "create_quiz_item_alternative/1 with valid data creates a quiz_item_alternative" do
+      quiz_item = insert(:quiz_item)
+
+      valid_attrs = %{
+        position: 42,
+        description: "some description",
+        is_correct: true,
+        quiz_item_id: quiz_item.id
+      }
+
+      assert {:ok, %QuizItemAlternative{} = quiz_item_alternative} =
+               Quizzes.create_quiz_item_alternative(valid_attrs)
+
+      assert quiz_item_alternative.position == 42
+      assert quiz_item_alternative.description == "some description"
+      assert quiz_item_alternative.is_correct
+      assert quiz_item_alternative.quiz_item_id == quiz_item.id
+    end
+
+    test "prevent more than one correct alternative per question" do
+      quiz_item = insert(:quiz_item)
+
+      valid_attrs_1 = %{description: "wrong", quiz_item_id: quiz_item.id}
+      valid_attrs_2 = %{description: "wrong", quiz_item_id: quiz_item.id}
+      valid_attrs_3 = %{description: "right", quiz_item_id: quiz_item.id, is_correct: true}
+      valid_attrs_4 = %{description: "right", quiz_item_id: quiz_item.id, is_correct: true}
+
+      assert {:ok, %QuizItemAlternative{}} =
+               Quizzes.create_quiz_item_alternative(valid_attrs_1)
+
+      assert {:ok, %QuizItemAlternative{}} =
+               Quizzes.create_quiz_item_alternative(valid_attrs_2)
+
+      assert {:ok, %QuizItemAlternative{}} =
+               Quizzes.create_quiz_item_alternative(valid_attrs_3)
+
+      assert {:error,
+              %Ecto.Changeset{
+                errors: [
+                  is_correct: {"There's already a correct alternative for this question", _}
+                ]
+              }} =
+               Quizzes.create_quiz_item_alternative(valid_attrs_4)
+    end
+
+    test "create_quiz_item_alternative/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Quizzes.create_quiz_item_alternative(@invalid_attrs)
+    end
+
+    test "update_quiz_item_alternative/2 with valid data updates the quiz_item_alternative" do
+      quiz_item_alternative = insert(:quiz_item_alternative)
+      update_attrs = %{position: 43, description: "some updated description", is_correct: false}
+
+      assert {:ok, %QuizItemAlternative{} = quiz_item_alternative} =
+               Quizzes.update_quiz_item_alternative(quiz_item_alternative, update_attrs)
+
+      assert quiz_item_alternative.position == 43
+      assert quiz_item_alternative.description == "some updated description"
+      assert quiz_item_alternative.is_correct == false
+    end
+
+    test "update_quiz_item_alternative/2 with invalid data returns error changeset" do
+      quiz_item_alternative = insert(:quiz_item_alternative) |> Ecto.reset_fields([:quiz_item])
+
+      assert {:error, %Ecto.Changeset{}} =
+               Quizzes.update_quiz_item_alternative(quiz_item_alternative, @invalid_attrs)
+
+      assert quiz_item_alternative == Quizzes.get_quiz_item_alternative!(quiz_item_alternative.id)
+    end
+
+    test "delete_quiz_item_alternative/1 deletes the quiz_item_alternative" do
+      quiz_item_alternative = insert(:quiz_item_alternative)
+
+      assert {:ok, %QuizItemAlternative{}} =
+               Quizzes.delete_quiz_item_alternative(quiz_item_alternative)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Quizzes.get_quiz_item_alternative!(quiz_item_alternative.id)
+      end
+    end
+
+    test "change_quiz_item_alternative/1 returns a quiz_item_alternative changeset" do
+      quiz_item_alternative = insert(:quiz_item_alternative)
+      assert %Ecto.Changeset{} = Quizzes.change_quiz_item_alternative(quiz_item_alternative)
+    end
+  end
 end

--- a/test/lanttern/quizzes_test.exs
+++ b/test/lanttern/quizzes_test.exs
@@ -1,0 +1,74 @@
+defmodule Lanttern.QuizzesTest do
+  use Lanttern.DataCase
+
+  alias Lanttern.Quizzes
+
+  describe "quizzes" do
+    alias Lanttern.Quizzes.Quiz
+
+    @invalid_attrs %{position: nil, description: nil, title: nil}
+
+    test "list_quizzes/0 returns all quizzes" do
+      quiz = insert(:quiz) |> Ecto.reset_fields([:moment])
+      assert Quizzes.list_quizzes() == [quiz]
+    end
+
+    test "get_quiz!/1 returns the quiz with given id" do
+      quiz = insert(:quiz) |> Ecto.reset_fields([:moment])
+      assert Quizzes.get_quiz!(quiz.id) == quiz
+    end
+
+    test "create_quiz/1 with valid data creates a quiz" do
+      moment = insert(:moment)
+
+      valid_attrs = %{
+        position: 42,
+        description: "some description",
+        title: "some title",
+        moment_id: moment.id
+      }
+
+      assert {:ok, %Quiz{} = quiz} = Quizzes.create_quiz(valid_attrs)
+      assert quiz.position == 42
+      assert quiz.description == "some description"
+      assert quiz.title == "some title"
+      assert quiz.moment_id == moment.id
+    end
+
+    test "create_quiz/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Quizzes.create_quiz(@invalid_attrs)
+    end
+
+    test "update_quiz/2 with valid data updates the quiz" do
+      quiz = insert(:quiz)
+
+      update_attrs = %{
+        position: 43,
+        description: "some updated description",
+        title: "some updated title"
+      }
+
+      assert {:ok, %Quiz{} = quiz} = Quizzes.update_quiz(quiz, update_attrs)
+      assert quiz.position == 43
+      assert quiz.description == "some updated description"
+      assert quiz.title == "some updated title"
+    end
+
+    test "update_quiz/2 with invalid data returns error changeset" do
+      quiz = insert(:quiz) |> Ecto.reset_fields([:moment])
+      assert {:error, %Ecto.Changeset{}} = Quizzes.update_quiz(quiz, @invalid_attrs)
+      assert quiz == Quizzes.get_quiz!(quiz.id)
+    end
+
+    test "delete_quiz/1 deletes the quiz" do
+      quiz = insert(:quiz)
+      assert {:ok, %Quiz{}} = Quizzes.delete_quiz(quiz)
+      assert_raise Ecto.NoResultsError, fn -> Quizzes.get_quiz!(quiz.id) end
+    end
+
+    test "change_quiz/1 returns a quiz changeset" do
+      quiz = insert(:quiz)
+      assert %Ecto.Changeset{} = Quizzes.change_quiz(quiz)
+    end
+  end
+end

--- a/test/lanttern/quizzes_test.exs
+++ b/test/lanttern/quizzes_test.exs
@@ -242,4 +242,95 @@ defmodule Lanttern.QuizzesTest do
       assert %Ecto.Changeset{} = Quizzes.change_quiz_item_alternative(quiz_item_alternative)
     end
   end
+
+  describe "quiz_item_student_entries" do
+    alias Lanttern.Quizzes.QuizItemStudentEntry
+
+    @invalid_attrs %{answer: nil, score: nil, feedback: nil}
+
+    test "list_quiz_item_student_entries/0 returns all quiz_item_student_entries" do
+      quiz_item_student_entry =
+        insert(:quiz_item_student_entry) |> Ecto.reset_fields([:quiz_item, :student])
+
+      assert Quizzes.list_quiz_item_student_entries() == [quiz_item_student_entry]
+    end
+
+    test "get_quiz_item_student_entry!/1 returns the quiz_item_student_entry with given id" do
+      quiz_item_student_entry =
+        insert(:quiz_item_student_entry) |> Ecto.reset_fields([:quiz_item, :student])
+
+      assert Quizzes.get_quiz_item_student_entry!(quiz_item_student_entry.id) ==
+               quiz_item_student_entry
+    end
+
+    test "create_quiz_item_student_entry/1 with valid data creates a quiz_item_student_entry" do
+      quiz_item = insert(:quiz_item)
+      student = insert(:student)
+
+      valid_attrs = %{
+        answer: "some answer",
+        score: 120.5,
+        feedback: "some feedback",
+        quiz_item_id: quiz_item.id,
+        student_id: student.id
+      }
+
+      assert {:ok, %QuizItemStudentEntry{} = quiz_item_student_entry} =
+               Quizzes.create_quiz_item_student_entry(valid_attrs)
+
+      assert quiz_item_student_entry.answer == "some answer"
+      assert quiz_item_student_entry.score == 120.5
+      assert quiz_item_student_entry.feedback == "some feedback"
+      assert quiz_item_student_entry.quiz_item_id == quiz_item.id
+      assert quiz_item_student_entry.student_id == student.id
+    end
+
+    test "create_quiz_item_student_entry/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Quizzes.create_quiz_item_student_entry(@invalid_attrs)
+    end
+
+    test "update_quiz_item_student_entry/2 with valid data updates the quiz_item_student_entry" do
+      quiz_item_student_entry = insert(:quiz_item_student_entry)
+
+      update_attrs = %{
+        answer: "some updated answer",
+        score: 456.7,
+        feedback: "some updated feedback"
+      }
+
+      assert {:ok, %QuizItemStudentEntry{} = quiz_item_student_entry} =
+               Quizzes.update_quiz_item_student_entry(quiz_item_student_entry, update_attrs)
+
+      assert quiz_item_student_entry.answer == "some updated answer"
+      assert quiz_item_student_entry.score == 456.7
+      assert quiz_item_student_entry.feedback == "some updated feedback"
+    end
+
+    test "update_quiz_item_student_entry/2 with invalid data returns error changeset" do
+      quiz_item_student_entry =
+        insert(:quiz_item_student_entry) |> Ecto.reset_fields([:quiz_item, :student])
+
+      assert {:error, %Ecto.Changeset{}} =
+               Quizzes.update_quiz_item_student_entry(quiz_item_student_entry, @invalid_attrs)
+
+      assert quiz_item_student_entry ==
+               Quizzes.get_quiz_item_student_entry!(quiz_item_student_entry.id)
+    end
+
+    test "delete_quiz_item_student_entry/1 deletes the quiz_item_student_entry" do
+      quiz_item_student_entry = insert(:quiz_item_student_entry)
+
+      assert {:ok, %QuizItemStudentEntry{}} =
+               Quizzes.delete_quiz_item_student_entry(quiz_item_student_entry)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Quizzes.get_quiz_item_student_entry!(quiz_item_student_entry.id)
+      end
+    end
+
+    test "change_quiz_item_student_entry/1 returns a quiz_item_student_entry changeset" do
+      quiz_item_student_entry = insert(:quiz_item_student_entry)
+      assert %Ecto.Changeset{} = Quizzes.change_quiz_item_student_entry(quiz_item_student_entry)
+    end
+  end
 end

--- a/test/lanttern/quizzes_test.exs
+++ b/test/lanttern/quizzes_test.exs
@@ -71,4 +71,73 @@ defmodule Lanttern.QuizzesTest do
       assert %Ecto.Changeset{} = Quizzes.change_quiz(quiz)
     end
   end
+
+  describe "quiz_items" do
+    alias Lanttern.Quizzes.QuizItem
+
+    @invalid_attrs %{position: nil, type: nil, description: nil}
+
+    test "list_quiz_items/0 returns all quiz_items" do
+      quiz_item = insert(:quiz_item) |> Ecto.reset_fields([:quiz])
+      assert Quizzes.list_quiz_items() == [quiz_item]
+    end
+
+    test "get_quiz_item!/1 returns the quiz_item with given id" do
+      quiz_item = insert(:quiz_item) |> Ecto.reset_fields([:quiz])
+      assert Quizzes.get_quiz_item!(quiz_item.id) == quiz_item
+    end
+
+    test "create_quiz_item/1 with valid data creates a quiz_item" do
+      quiz = insert(:quiz)
+
+      valid_attrs = %{
+        position: 42,
+        type: "multiple_choice",
+        description: "some description abc",
+        quiz_id: quiz.id
+      }
+
+      assert {:ok, %QuizItem{} = quiz_item} = Quizzes.create_quiz_item(valid_attrs)
+      assert quiz_item.position == 42
+      assert quiz_item.type == "multiple_choice"
+      assert quiz_item.description == "some description abc"
+      assert quiz_item.quiz_id == quiz.id
+    end
+
+    test "create_quiz_item/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Quizzes.create_quiz_item(@invalid_attrs)
+    end
+
+    test "update_quiz_item/2 with valid data updates the quiz_item" do
+      quiz_item = insert(:quiz_item)
+
+      update_attrs = %{
+        position: 43,
+        type: "multiple_choice",
+        description: "some updated description"
+      }
+
+      assert {:ok, %QuizItem{} = quiz_item} = Quizzes.update_quiz_item(quiz_item, update_attrs)
+      assert quiz_item.position == 43
+      assert quiz_item.type == "multiple_choice"
+      assert quiz_item.description == "some updated description"
+    end
+
+    test "update_quiz_item/2 with invalid data returns error changeset" do
+      quiz_item = insert(:quiz_item) |> Ecto.reset_fields([:quiz])
+      assert {:error, %Ecto.Changeset{}} = Quizzes.update_quiz_item(quiz_item, @invalid_attrs)
+      assert quiz_item == Quizzes.get_quiz_item!(quiz_item.id)
+    end
+
+    test "delete_quiz_item/1 deletes the quiz_item" do
+      quiz_item = insert(:quiz_item)
+      assert {:ok, %QuizItem{}} = Quizzes.delete_quiz_item(quiz_item)
+      assert_raise Ecto.NoResultsError, fn -> Quizzes.get_quiz_item!(quiz_item.id) end
+    end
+
+    test "change_quiz_item/1 returns a quiz_item changeset" do
+      quiz_item = insert(:quiz_item)
+      assert %Ecto.Changeset{} = Quizzes.change_quiz_item(quiz_item)
+    end
+  end
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -30,6 +30,7 @@ defmodule LantternWeb.ConnCase do
       import Phoenix.LiveViewTest
       import LantternWeb.ConnCase
       import Lanttern.Support.TestUtils
+      import Lanttern.Factory
     end
   end
 

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -24,6 +24,7 @@ defmodule Lanttern.DataCase do
       import Ecto.Changeset
       import Ecto.Query
       import Lanttern.DataCase
+      import Lanttern.Factory
     end
   end
 

--- a/test/support/factories/learning_context_factories.ex
+++ b/test/support/factories/learning_context_factories.ex
@@ -1,0 +1,28 @@
+defmodule Lanttern.LearningContextFactories do
+  @moduledoc """
+  This module defines factories for creating LearningContext schema structs for testing purposes.
+  """
+  defmacro __using__(_opts) do
+    quote do
+      def strand_factory do
+        %Lanttern.LearningContext.Strand{
+          name: "some strand name",
+          description: "some strand description"
+        }
+      end
+
+      @doc """
+      For proper use it's mandatory to include:
+
+          strand: %Lanttern.LearningContext.Strand{}
+      """
+      def moment_factory do
+        %Lanttern.LearningContext.Moment{
+          name: "some moment name",
+          description: "some moment description",
+          strand: build(:strand)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/quizzes_factories.ex
+++ b/test/support/factories/quizzes_factories.ex
@@ -27,6 +27,14 @@ defmodule Lanttern.QuizzesFactories do
           quiz_item: build(:quiz_item)
         }
       end
+
+      def quiz_item_student_entry_factory do
+        %Lanttern.Quizzes.QuizItemStudentEntry{
+          answer: "some quiz item student entry answer",
+          quiz_item: build(:quiz_item),
+          student: build(:student)
+        }
+      end
     end
   end
 end

--- a/test/support/factories/quizzes_factories.ex
+++ b/test/support/factories/quizzes_factories.ex
@@ -4,17 +4,20 @@ defmodule Lanttern.QuizzesFactories do
   """
   defmacro __using__(_opts) do
     quote do
-      @doc """
-      For proper use it's mandatory to include:
-
-          moment: %Lanttern.LearningContext.Moment{}
-      """
       def quiz_factory do
         %Lanttern.Quizzes.Quiz{
           position: 1,
           title: "some title",
           description: "some description",
           moment: build(:moment)
+        }
+      end
+
+      def quiz_item_factory do
+        %Lanttern.Quizzes.QuizItem{
+          description: "some quiz item description",
+          type: "text",
+          quiz: build(:quiz)
         }
       end
     end

--- a/test/support/factories/quizzes_factories.ex
+++ b/test/support/factories/quizzes_factories.ex
@@ -20,6 +20,13 @@ defmodule Lanttern.QuizzesFactories do
           quiz: build(:quiz)
         }
       end
+
+      def quiz_item_alternative_factory do
+        %Lanttern.Quizzes.QuizItemAlternative{
+          description: "some quiz item alternative description",
+          quiz_item: build(:quiz_item)
+        }
+      end
     end
   end
 end

--- a/test/support/factories/quizzes_factories.ex
+++ b/test/support/factories/quizzes_factories.ex
@@ -1,0 +1,22 @@
+defmodule Lanttern.QuizzesFactories do
+  @moduledoc """
+  This module defines factories for creating Quizzes schema structs for testing purposes.
+  """
+  defmacro __using__(_opts) do
+    quote do
+      @doc """
+      For proper use it's mandatory to include:
+
+          moment: %Lanttern.LearningContext.Moment{}
+      """
+      def quiz_factory do
+        %Lanttern.Quizzes.Quiz{
+          position: 1,
+          title: "some title",
+          description: "some description",
+          moment: build(:moment)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -19,4 +19,7 @@ defmodule Lanttern.Factory do
   use Lanttern.StudentRecordRelationshipFactory
   use Lanttern.StudentRecordStatusFactory
   use Lanttern.UserFactory
+
+  use Lanttern.LearningContextFactories
+  use Lanttern.QuizzesFactories
 end


### PR DESCRIPTION
this PR creates a new `Quizzes` context with their base schemas
- `Quiz`
- `QuizItem`
- `QuizItemAlternative`
- `QuizStudentEntry`

it's related to #345, which in turn is part of the greater #344 

it's basically code created by `mix phx.gen.context` + minor changes.

two changes that affects the project pattern/structure:

1. I've added `import Lanttern.Factory` to `LantternWeb.ConnCase`'s using block (as suggested in the official documentation https://hexdocs.pm/ex_machina/readme.html#usage-in-a-test) and to `Lanttern.DataCase` as well, so we don't need to explicit import factories in all test files
2. I've deleted the generated `Lanttern.QuizzesFixtures` module in favor of ex_machina factories. my suggestion here is to group factories by context — I think it's a good middle ground between having one file per factory/schema and putting all of the factories directly in `Lanttern.Factory` file