### PR TITLE
339 ilp adjustments

### DIFF
--- a/lib/lanttern/ilp.ex
+++ b/lib/lanttern/ilp.ex
@@ -922,10 +922,17 @@ defmodule Lanttern.ILP do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_ilp_comment(attrs \\ %{}) do
+  def create_ilp_comment(attrs, log_profile_id) do
     %ILPComment{}
     |> ILPComment.changeset(attrs)
     |> Repo.insert()
+    |> tap(fn
+      {:ok, %ILPComment{} = ilp_comment} ->
+        ILPLog.async_create_ilp_comment_log(ilp_comment, :CREATE, log_profile_id)
+
+      _ ->
+        :nothing
+    end)
   end
 
   @doc """
@@ -933,33 +940,39 @@ defmodule Lanttern.ILP do
 
   ## Examples
 
-      iex> update_ilp_comment(ilp_comment, %{field: new_value})
+      iex> update_ilp_comment(ilp_comment, %{field: new_value}, log_profile_id)
       {:ok, %ILPComment{}}
 
-      iex> update_ilp_comment(ilp_comment, %{field: bad_value})
+      iex> update_ilp_comment(ilp_comment, %{field: bad_value}, log_profile_id)
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_ilp_comment(%ILPComment{} = ilp_comment, attrs) do
+  def update_ilp_comment(%ILPComment{} = ilp_comment, attrs, log_profile_id) do
     ilp_comment
     |> ILPComment.changeset(attrs)
     |> Repo.update()
+    |> tap(fn
+      {:ok, %ILPComment{} = ilp_comment} ->
+        ILPLog.async_create_ilp_comment_log(ilp_comment, :UPDATE, log_profile_id)
+
+      _ ->
+        :nothing
+    end)
   end
 
   @doc """
   Deletes a ilp_comment.
-
-  ## Examples
-
-      iex> delete_ilp_comment(ilp_comment)
-      {:ok, %ILPComment{}}
-
-      iex> delete_ilp_comment(ilp_comment)
-      {:error, %Ecto.Changeset{}}
-
   """
-  def delete_ilp_comment(%ILPComment{} = ilp_comment) do
-    Repo.delete(ilp_comment)
+  def delete_ilp_comment(%ILPComment{} = ilp_comment, log_profile_id) do
+    ilp_comment
+    |> Repo.delete()
+    |> tap(fn
+      {:ok, %ILPComment{} = ilp_comment} ->
+        ILPLog.async_create_ilp_comment_log(ilp_comment, :DELETE, log_profile_id)
+
+      _ ->
+        :nothing
+    end)
   end
 
   @doc """

--- a/lib/lanttern/ilp_log/ilp_comment_log.ex
+++ b/lib/lanttern/ilp_log/ilp_comment_log.ex
@@ -1,0 +1,42 @@
+defmodule Lanttern.ILPLog.ILPCommentLog do
+  @moduledoc """
+  The `ILPCommentLog` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @schema_prefix "log"
+  schema "ilp_comments" do
+    field :ilp_comment_id, :id
+    field :owner_id, :id
+    field :student_ilp_id, :id
+    field :operation, Ecto.Enum, values: [:CREATE, :UPDATE, :DELETE]
+
+    field :position, :integer
+    field :content, :string
+
+    timestamps(updated_at: false)
+  end
+
+  @doc false
+  def changeset(ilp_comment_log, attrs) do
+    ilp_comment_log
+    |> cast(attrs, [
+      :ilp_comment_id,
+      :owner_id,
+      :student_ilp_id,
+      :operation,
+      :position,
+      :content
+    ])
+    |> validate_required([
+      :ilp_comment_id,
+      :owner_id,
+      :student_ilp_id,
+      :operation,
+      :position,
+      :content
+    ])
+  end
+end

--- a/lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex
@@ -1,6 +1,17 @@
 defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
   @moduledoc """
-   to-do
+  Renders an overlay with a `StudentILPComment` form
+
+  ### Attrs
+      attr :ilp_comment, ILPComment, required: true
+      attr :id, :string, required: true
+      attr :form_action, :string, required: true
+      attr :student_ilp, StudentILP, required: true
+      attr :title, :string, required: true
+      attr :current_profile, Profile, required: true
+      attr :on_cancel, :any, required: true, doc: "`<.slide_over>` `on_cancel` attr"
+      attr :notify_parent, :boolean
+      attr :notify_component, Phoenix.LiveComponent.CID
   """
 
   use LantternWeb, :live_component
@@ -141,7 +152,7 @@ defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
     do: save_ilp_comment(socket, socket.assigns.form_action, comment_params)
 
   def handle_event("delete", _, socket) do
-    case ILP.delete_ilp_comment(socket.assigns.ilp_comment) do
+    case ILP.delete_ilp_comment(socket.assigns.ilp_comment, socket.assigns.current_profile.id) do
       {:ok, ilp_comment} ->
         notify(__MODULE__, {:deleted, ilp_comment}, socket.assigns)
 
@@ -159,7 +170,7 @@ defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
       |> Map.put("student_ilp_id", socket.assigns.student_ilp.id)
       |> Map.put("owner_id", socket.assigns.current_profile.id)
 
-    case ILP.create_ilp_comment(params) do
+    case ILP.create_ilp_comment(params, log_profile_id: socket.assigns.current_profile.id) do
       {:ok, comment} ->
         notify(__MODULE__, {:created, comment}, socket.assigns)
         {:noreply, socket}
@@ -170,7 +181,9 @@ defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
   end
 
   defp save_ilp_comment(socket, :edit, params) do
-    case ILP.update_ilp_comment(socket.assigns.ilp_comment, params) do
+    profile_id = socket.assigns.current_profile.id
+
+    case ILP.update_ilp_comment(socket.assigns.ilp_comment, params, profile_id) do
       {:ok, comment} ->
         notify(__MODULE__, {:updated, comment}, socket.assigns)
 

--- a/lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex
@@ -17,9 +17,12 @@ defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
   use LantternWeb, :live_component
 
   alias Lanttern.ILP
-
   alias Lanttern.ILP.ILPComment
-  alias LantternWeb.Attachments.AttachmentAreaComponent
+  alias Lanttern.ILP.ILPCommentAttachment
+  alias Lanttern.SupabaseHelpers
+
+  import Lanttern.Utils, only: [swap: 3]
+  import LantternWeb.AttachmentsComponents
 
   @impl true
   def mount(socket) do
@@ -29,11 +32,37 @@ defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
       |> assign(:on_edit_patch, nil)
       |> assign(:create_patch, nil)
       |> assign(:class, nil)
-      |> assign(:is_ilp_manager, false)
       |> assign(:initialized, false)
+      |> assign(:is_adding_external, false)
+      |> assign(:is_editing, false)
+      |> assign(:allow_editing, true)
+      |> stream_configure(
+        :attachments,
+        dom_id: fn {attachment, _i} -> "attachment-#{attachment.id}" end
+      )
+      |> allow_upload(:attachment_file,
+        accept: :any,
+        max_file_size: 5_000_000,
+        max_entries: 1
+      )
+      |> assign(:upload_error, nil)
+      |> assign(:attachments_length, 0)
+      |> assign(:attachments_ids, nil)
 
     {:ok, socket}
   end
+
+  defp stream_attachments(%{assigns: %{ilp_comment: %{id: id}}} = socket) when not is_nil(id) do
+    attachments = ILP.list_ilp_comment_attachments(id)
+    attachments_ids = Enum.map(attachments, & &1.id)
+
+    socket
+    |> stream(:attachments, Enum.with_index(attachments), reset: true)
+    |> assign(:attachments_length, length(attachments))
+    |> assign(:attachments_ids, attachments_ids)
+  end
+
+  defp stream_attachments(socket), do: socket
 
   @impl true
   def render(assigns) do
@@ -63,18 +92,170 @@ defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
             <%= gettext("Oops, something went wrong! Please check the errors above.") %>
           </.error_block>
         </.form>
-        <.live_component
-          :if={@form_action == :edit}
-          ilp_comment_id={@ilp_comment.id}
-          module={AttachmentAreaComponent}
-          id="ilp-comment"
-          title={gettext("Attachments")}
-          allow_editing={true}
-          notify_parent
-          class="mt-10"
-          current_profile={@current_profile}
-          ilp_comment={@ilp_comment}
-        />
+        <div id="ilp-comment-attachments">
+          <div class={[@class, if(@form_action == :new && @attachments_length == 0, do: "hidden")]}>
+            <div :if={@title} class={["flex items-center gap-2"]}>
+              <.icon name="hero-paper-clip" class="w-6 h-6" />
+              <h5 class="font-display font-bold text-sm"><%= gettext("Attachments") %></h5>
+            </div>
+            <.attachments_list
+              :if={@attachments_length > 0}
+              id={"#{@id}-attachments-list"}
+              class={if @is_editing, do: "hidden"}
+              attachments={@streams.attachments}
+              allow_editing={@allow_editing}
+              attachments_length={@attachments_length}
+              on_move_up={
+                fn i ->
+                  JS.push("reorder_attachments", value: %{from: i, to: i - 1}, target: @myself)
+                end
+              }
+              on_move_down={
+                fn i ->
+                  JS.push("reorder_attachments", value: %{from: i, to: i + 1}, target: @myself)
+                end
+              }
+              on_edit={
+                fn id ->
+                  JS.push("edit", value: %{"id" => id}, target: @myself)
+                end
+              }
+              on_remove={
+                fn id ->
+                  JS.push("delete_attachment", value: %{"id" => id}, target: @myself)
+                end
+              }
+            />
+            <div
+              :if={@is_adding_external || @is_editing}
+              class="p-4 border border-dashed border-ltrn-subtle rounded-sm mt-4 bg-white shadow-lg"
+            >
+              <.form
+                for={@form_attachment}
+                id="external-attachment-form"
+                phx-target={@myself}
+                phx-change="validate_attachment"
+                phx-submit="save_attachment"
+              >
+                <.input
+                  field={@form_attachment[:name]}
+                  type="text"
+                  label={gettext("Attachment name")}
+                  class="mb-6"
+                  phx-debounce="1500"
+                />
+                <.input
+                  field={@form_attachment[:link]}
+                  type="text"
+                  label={gettext("Link")}
+                  class="mb-6"
+                  phx-debounce="1500"
+                />
+                <div class="flex justify-end gap-2">
+                  <.button
+                    type="button"
+                    theme="ghost"
+                    phx-click="cancel_attachment"
+                    phx-target={@myself}
+                  >
+                    <%= gettext("Cancel") %>
+                  </.button>
+                  <.button
+                    type="submit"
+                    phx-disable-with={gettext("Saving...")}
+                    id="save-external-attachment"
+                  >
+                    <%= gettext("Save") %>
+                  </.button>
+                </div>
+              </.form>
+            </div>
+            <div
+              :for={entry <- @uploads.attachment_file.entries}
+              class="p-4 border border-dashed border-ltrn-subtle rounded-sm mt-4 shadow-lg bg-white"
+            >
+              <p class="flex items-center gap-2 text-sm text-ltrn-subtle">
+                <.icon name="hero-paper-clip-mini" />
+                <%= gettext("File upload") %>
+              </p>
+              <p class="mt-2 font-bold">
+                <%= entry.client_name %>
+              </p>
+              <.error_block :if={@invalid_upload_msg} class="mt-4">
+                <%= @invalid_upload_msg %>
+              </.error_block>
+              <div class="flex justify-end gap-4 mt-10">
+                <.button
+                  type="button"
+                  theme="ghost"
+                  phx-click={JS.push("cancel_upload", value: %{"ref" => entry.ref}, target: @myself)}
+                >
+                  <%= gettext("Cancel") %>
+                </.button>
+                <.button
+                  type="submit"
+                  form={"#{@id}-attachments-upload-form"}
+                  disabled={!entry.valid?}
+                >
+                  <%= gettext("Upload") %>
+                </.button>
+              </div>
+            </div>
+            <div
+              :if={@allow_editing && !@is_adding_external && !@is_editing}
+              class={[
+                "grid grid-cols-2 gap-2 mt-4",
+                if(@uploads.attachment_file.entries != [], do: "hidden")
+              ]}
+            >
+              <div
+                class="p-4 border border-dashed border-ltrn-subtle rounded-sm text-center text-ltrn-subtle bg-white shadow-lg"
+                phx-drop-target={@uploads.attachment_file.ref}
+              >
+                <form
+                  id={"#{@id}-attachments-upload-form"}
+                  phx-submit="upload"
+                  phx-change="validate_upload"
+                  phx-target={@myself}
+                >
+                  <.icon name="hero-document-plus" class="h-8 w-8 mx-auto mb-6" />
+                  <div>
+                    <label
+                      for={@uploads.attachment_file.ref}
+                      class="cursor-pointer text-ltrn-primary hover:text-ltrn-dark focus-within:outline-hidden focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-ltrn-dark"
+                    >
+                      <span><%= gettext("Upload a file") %></span>
+                      <.live_file_input upload={@uploads.attachment_file} class="sr-only" />
+                    </label>
+                    <span><%= gettext("or drag and drop here") %></span>
+                  </div>
+                </form>
+              </div>
+              <div class="p-4 border border-dashed border-ltrn-subtle rounded-sm text-center bg-white shadow-lg">
+                <.icon name="hero-link" class="h-8 w-8 mx-auto mb-6 text-ltrn-subtle" />
+                <div>
+                  <button
+                    type="button"
+                    class="inline text-ltrn-primary hover:text-ltrn-dark focus-within:outline-hidden focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-ltrn-dark"
+                    phx-click="add_external"
+                    phx-target={@myself}
+                    id="external-link-button"
+                  >
+                    <%= gettext("Or add a link to an external file") %>
+                    <span class="text-ltrn-subtle"><%= gettext("(e.g. Google Docs)") %></span>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <.error_block
+              :if={@upload_error}
+              class="mt-4"
+              on_dismiss={JS.push("clear_upload_error", target: @myself)}
+            >
+              <%= @upload_error %>
+            </.error_block>
+          </div>
+        </div>
         <:actions_left :if={@ilp_comment.id}>
           <.action
             type="button"
@@ -125,6 +306,7 @@ defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
   defp initialize(%{assigns: %{initialized: false}} = socket) do
     socket
     |> assign_form()
+    |> stream_attachments()
     |> assign(:initialized, true)
   end
 
@@ -148,8 +330,44 @@ defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
     {:noreply, assign(socket, :form, to_form(changeset))}
   end
 
-  def handle_event("save", %{"ilp_comment" => comment_params}, socket),
-    do: save_ilp_comment(socket, socket.assigns.form_action, comment_params)
+  def handle_event("cancel_attachment", _params, socket) do
+    socket =
+      socket
+      |> assign(:is_adding_external, false)
+      |> assign(:is_editing, false)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("validate_attachment", %{"ilp_comment_attachment" => params}, socket) do
+    changeset =
+      %ILPCommentAttachment{}
+      |> ILPCommentAttachment.changeset(params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :form_attachment, to_form(changeset))}
+  end
+
+  def handle_event("add_external", _, socket) do
+    changeset = ILP.change_ilp_comment_attachment(%ILPCommentAttachment{})
+
+    socket =
+      socket
+      |> assign(:is_adding_external, true)
+      |> assign(:form_attachment, to_form(changeset))
+
+    {:noreply, socket}
+  end
+
+  def handle_event("reorder_attachments", %{"from" => i, "to" => j}, socket) do
+    socket.assigns.attachments_ids
+    |> swap(i, j)
+    |> ILP.update_ilp_comment_attachment_positions()
+    |> case do
+      :ok -> {:noreply, stream_attachments(socket)}
+      {:error, msg} -> {:noreply, put_flash(socket, :error, msg)}
+    end
+  end
 
   def handle_event("delete", _, socket) do
     case ILP.delete_ilp_comment(socket.assigns.ilp_comment, socket.assigns.current_profile.id) do
@@ -160,6 +378,100 @@ defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
 
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  def handle_event("delete_attachment", params, socket) do
+    attachment = ILP.get_ilp_comment_attachment!(params["id"])
+
+    case ILP.delete_ilp_comment_attachment(attachment) do
+      {:ok, _attachment} ->
+        {:noreply, stream_attachments(socket)}
+
+      {:error, _changeset} ->
+        socket = assign(socket, :error_msg, gettext("Error deleting attachment"))
+
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("edit", params, socket) do
+    attachment = ILP.get_ilp_comment_attachment!(params["id"])
+    changeset = ILP.change_ilp_comment_attachment(attachment, %{})
+
+    socket =
+      socket
+      |> assign(:is_editing, true)
+      |> assign(:attachment, attachment)
+      |> assign(:form_attachment, to_form(changeset))
+
+    {:noreply, socket}
+  end
+
+  def handle_event("save_attachment", %{"ilp_comment_attachment" => params}, socket) do
+    case socket.assigns do
+      %{is_adding_external: true} ->
+        params = Map.put(params, "is_external", true)
+
+        save_attachment(socket, :new, params)
+
+      %{is_editing: true} ->
+        save_attachment(socket, :edit, params)
+    end
+  end
+
+  def handle_event("save", %{"ilp_comment" => comment_params}, socket),
+    do: save_ilp_comment(socket, socket.assigns.form_action, comment_params)
+
+  def handle_event("validate_upload", _, socket) do
+    upload_conf = socket.assigns.uploads.attachment_file
+
+    invalid_upload_msg =
+      case upload_conf.entries do
+        [entry] -> upload_errors(upload_conf, entry)
+        _ -> []
+      end
+      |> Enum.map(&upload_error_to_string(upload_conf, &1))
+      |> case do
+        [] -> nil
+        error_messages -> Enum.join(error_messages, " ")
+      end
+
+    socket =
+      socket
+      |> assign(:invalid_upload_msg, invalid_upload_msg)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("cancel_upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :attachment_file, ref)}
+  end
+
+  def handle_event("clear_upload_error", _, socket) do
+    {:noreply, assign(socket, :upload_error, nil)}
+  end
+
+  def handle_event("upload", _params, socket) do
+    socket
+    |> consume_uploaded_entries(:attachment_file, fn %{path: file_path}, entry ->
+      map = %{content_type: entry.client_type}
+
+      case SupabaseHelpers.upload_object("attachments", entry.client_name, file_path, map) do
+        {:ok, object} ->
+          base_url = SupabaseHelpers.config()[:base_url]
+          attachment_url = "#{base_url}/storage/v1/object/public/#{URI.encode(object["Key"])}"
+
+          {:ok, {:ok, {attachment_url, entry.client_name}}}
+
+        {:error, message} ->
+          {:ok, {:error, message}}
+      end
+    end)
+    |> hd()
+    |> case do
+      {:ok, {link, name}} -> save_attachment(socket, :new, %{"name" => name, "link" => link})
+      {:error, message} -> {:noreply, assign(socket, :upload_error, message)}
     end
   end
 
@@ -186,6 +498,41 @@ defmodule LantternWeb.ILP.ILPCommentFormOverlayComponent do
     case ILP.update_ilp_comment(socket.assigns.ilp_comment, params, profile_id) do
       {:ok, comment} ->
         notify(__MODULE__, {:updated, comment}, socket.assigns)
+
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp save_attachment(socket, :new, params) do
+    params = Map.put(params, "ilp_comment_id", socket.assigns.ilp_comment.id)
+
+    case ILP.create_ilp_comment_attachment(params) do
+      {:ok, _attachment} ->
+        socket =
+          socket
+          |> assign(:is_adding_external, false)
+          |> stream_attachments()
+
+        {:noreply, socket}
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  defp save_attachment(socket, :edit, params) do
+    params = Map.put(params, "ilp_comment_id", socket.assigns.ilp_comment.id)
+
+    case ILP.update_ilp_comment_attachment(socket.assigns.attachment, params) do
+      {:ok, _attachment} ->
+        socket =
+          socket
+          |> assign(:is_adding_external, false)
+          |> assign(:is_editing, false)
+          |> stream_attachments()
 
         {:noreply, socket}
 

--- a/lib/lanttern_web/live/shared/ilp/student_ilp_component.ex
+++ b/lib/lanttern_web/live/shared/ilp/student_ilp_component.ex
@@ -219,7 +219,11 @@ defmodule LantternWeb.ILP.StudentILPComponent do
   end
 
   defp assign_ilp_comments(%{assigns: %{student_ilp: %StudentILP{id: id}}} = socket) do
-    assign(socket, :ilp_comments, ILP.list_ilp_comments_by_student_ilp(id))
+    if connected?(socket) do
+      assign(socket, :ilp_comments, ILP.list_ilp_comments_by_student_ilp(id))
+    else
+      socket
+    end
   end
 
   defp assign_ilp_comments(socket), do: socket

--- a/priv/repo/migrations/20250614223141_create_ilp_comment_logs.exs
+++ b/priv/repo/migrations/20250614223141_create_ilp_comment_logs.exs
@@ -1,0 +1,25 @@
+defmodule Lanttern.Repo.Migrations.CreateIlpCommentLogs do
+  use Ecto.Migration
+
+  def change do
+    execute("CREATE TYPE operation_type AS ENUM ('CREATE', 'UPDATE', 'DELETE')")
+
+    create table(:ilp_comments, prefix: "log") do
+      add :ilp_comment_id, :bigint, null: false
+      add :owner_id, :bigint, null: false
+      add :operation, :operation_type, null: false
+
+      add :student_ilp_id, :bigint, null: false
+
+      add :position, :integer, null: false
+      add :content, :text, null: false
+
+      timestamps(updated_at: false)
+    end
+  end
+
+  def down do
+    drop table(:ilp_comments, prefix: "log")
+    execute "DROP TYPE IF EXISTS operation_type"
+  end
+end

--- a/test/lanttern/ilp_test.exs
+++ b/test/lanttern/ilp_test.exs
@@ -975,7 +975,8 @@ defmodule Lanttern.ILPTest do
       attrs = %{owner_id: ctx.profile.id, student_ilp_id: ctx.student_ilp.id}
       valid_attrs = params_for(:ilp_comment, attrs)
 
-      assert {:ok, %ILPComment{} = ilp_comment} = ILP.create_ilp_comment(valid_attrs)
+      assert {:ok, %ILPComment{} = ilp_comment} =
+               ILP.create_ilp_comment(valid_attrs, ctx.profile.id)
 
       assert ilp_comment.position == valid_attrs.position
       assert ilp_comment.content == valid_attrs.content
@@ -983,16 +984,16 @@ defmodule Lanttern.ILPTest do
       assert ilp_comment.student_ilp_id == ctx.student_ilp.id
     end
 
-    test "create_ilp_comment/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = ILP.create_ilp_comment(@invalid_attrs)
+    test "create_ilp_comment/2 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = ILP.create_ilp_comment(@invalid_attrs, nil)
     end
 
-    test "update_ilp_comment/2 with valid data updates the ilp_comment", ctx do
+    test "update_ilp_comment/3 with valid data updates the ilp_comment", ctx do
       ilp_comment = insert(:ilp_comment, %{owner: ctx.profile, student_ilp: ctx.student_ilp})
       update_attrs = %{position: 43, content: "some"}
 
       assert {:ok, %ILPComment{} = ilp_comment} =
-               ILP.update_ilp_comment(ilp_comment, update_attrs)
+               ILP.update_ilp_comment(ilp_comment, update_attrs, nil)
 
       assert ilp_comment.position == update_attrs.position
       assert ilp_comment.content == update_attrs.content
@@ -1002,13 +1003,16 @@ defmodule Lanttern.ILPTest do
 
     test "update_ilp_comment/2 with invalid data returns error changeset" do
       ilp_comment = insert(:ilp_comment)
-      assert {:error, %Ecto.Changeset{}} = ILP.update_ilp_comment(ilp_comment, @invalid_attrs)
+
+      assert {:error, %Ecto.Changeset{}} =
+               ILP.update_ilp_comment(ilp_comment, @invalid_attrs, nil)
+
       assert ilp_comment == ILP.get_ilp_comment(ilp_comment.id)
     end
 
     test "delete_ilp_comment/1 deletes the ilp_comment" do
       ilp_comment = insert(:ilp_comment)
-      assert {:ok, %ILPComment{}} = ILP.delete_ilp_comment(ilp_comment)
+      assert {:ok, %ILPComment{}} = ILP.delete_ilp_comment(ilp_comment, nil)
       assert ILP.get_ilp_comment(ilp_comment.id) == nil
     end
 


### PR DESCRIPTION
Definitive separation from `AttachmentAreaComponent`
Targeting facilitate tests following principles like separation of concerns.
This implementation is a branch of [#352 add-support-to-ilp-comments-logging](https://github.com/camino-school/lanttern/tree/352-add-support-to-ilp-comments-logging) with an open [PR](https://github.com/camino-school/lanttern/pull/357) 
an change regarding `assign_ilp_comments/1` where added since `initialize/1` still run two times in Live components with `initialized: true`.