### PR TITLE
display profile pictures in ILP comments list

### DIFF
--- a/lib/lanttern/identity.ex
+++ b/lib/lanttern/identity.ex
@@ -755,4 +755,15 @@ defmodule Lanttern.Identity do
       "guardian" -> profile.guardian_of_student.name
     end
   end
+
+  @doc """
+  Returns the picture URL of the profile
+  """
+  def get_profile_picture_url(profile) do
+    case profile.type do
+      "student" -> profile.student.profile_picture_url
+      "staff" -> profile.staff_member.profile_picture_url
+      "guardian" -> profile.guardian_of_student.profile_picture_url
+    end
+  end
 end

--- a/lib/lanttern/schools/student.ex
+++ b/lib/lanttern/schools/student.ex
@@ -42,9 +42,9 @@ defmodule Lanttern.Schools.Student do
 
   schema "students" do
     field :name, :string
+    field :profile_picture_url, :string
     field :deactivated_at, :utc_datetime
 
-    field :profile_picture_url, :string, virtual: true
     field :classes_ids, {:array, :id}, virtual: true
     field :has_diff_rubric, :boolean, virtual: true, default: false
     field :tags_ids, {:array, :id}, virtual: true
@@ -80,7 +80,14 @@ defmodule Lanttern.Schools.Student do
   @doc false
   def changeset(student, attrs) do
     student
-    |> cast(attrs, [:name, :deactivated_at, :school_id, :classes_ids, :tags_ids])
+    |> cast(attrs, [
+      :name,
+      :profile_picture_url,
+      :deactivated_at,
+      :school_id,
+      :classes_ids,
+      :tags_ids
+    ])
     |> validate_required([:name, :school_id])
     |> put_classes(attrs)
     |> cast_tags()

--- a/lib/lanttern_web/components/ilp_components.ex
+++ b/lib/lanttern_web/components/ilp_components.ex
@@ -104,8 +104,8 @@ defmodule LantternWeb.ILPComponents do
         id={"ilp-comment-#{ilp_comment.id}"}
       >
         <.profile_picture
-          picture_url={ilp_comment.owner.profile_picture_url}
-          profile_name={ilp_comment.owner.name}
+          picture_url={Identity.get_profile_picture_url(ilp_comment.owner)}
+          profile_name={Identity.get_profile_name(ilp_comment.owner)}
         />
         <.card_base class="flex-1 sm:max-w-3/4 p-2">
           <div class="flex items-center justify-between gap-4">

--- a/priv/repo/migrations/20250626194557_add_profile_picture_url_to_students.exs
+++ b/priv/repo/migrations/20250626194557_add_profile_picture_url_to_students.exs
@@ -13,12 +13,12 @@ defmodule Lanttern.Repo.Migrations.AddProfilePictureUrlToStudents do
             set profile_picture_url = last_sci.profile_picture_url
             from (
               select
-                distinct on (sci.student_id, sc.end_at, sc.start_at)
+                distinct on (sci.student_id)
                 sci.*
               from students_cycle_info sci
               join school_cycles sc on sc.id = sci.cycle_id
               where sci.profile_picture_url is not null
-              order by sc.end_at desc, sc.start_at asc
+              order by sci.student_id, sc.end_at desc, sc.start_at asc
             ) as last_sci
             where last_sci.student_id = s.id
             """,

--- a/priv/repo/migrations/20250626194557_add_profile_picture_url_to_students.exs
+++ b/priv/repo/migrations/20250626194557_add_profile_picture_url_to_students.exs
@@ -1,0 +1,27 @@
+defmodule Lanttern.Repo.Migrations.AddProfilePictureUrlToStudents do
+  use Ecto.Migration
+
+  def change do
+    alter table(:students) do
+      add :profile_picture_url, :text
+    end
+
+    # set the last student cycle info profile picture URL
+    # as the initial student profile_picture_url value
+    execute """
+            update students s
+            set profile_picture_url = last_sci.profile_picture_url
+            from (
+              select
+                distinct on (sci.student_id, sc.end_at, sc.start_at)
+                sci.*
+              from students_cycle_info sci
+              join school_cycles sc on sc.id = sci.cycle_id
+              where sci.profile_picture_url is not null
+              order by sc.end_at desc, sc.start_at asc
+            ) as last_sci
+            where last_sci.student_id = s.id
+            """,
+            ""
+  end
+end


### PR DESCRIPTION
- added `profile_picture_url` to `Student` schema. this already existed as a virtual field, and the value came from the student cycle info. we still want to have the "profile picture evolution" from cycle info, but we're adding a database column for this default student profile picture in order to facilitate student profile picture rendering. a new issue #364 was created to refine the implementation
- added `Identity.get_profile_picture_url/1`

resolves #363