### PR TITLE
isolated dev environments per contributor

### DIFF
--- a/.github/workflows/fly_deploy_dev.yml
+++ b/.github/workflows/fly_deploy_dev.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Deploy to contributor's Fly.io app
         run: |
           # Try contributor-specific GitHub username first, then fallback to shared
-          flyctl deploy --remote-only ${{ secrets[format('FLY_DEPLOY_OPTS_{0}', steps.contributor.outputs.github_user)] || secrets.FLY_DEPLOY_OPTS }}
+          flyctl deploy --config fly.dev.toml --remote-only ${{ secrets[format('FLY_DEPLOY_OPTS_{0}', steps.contributor.outputs.github_user)] || secrets.FLY_DEPLOY_OPTS }}
         env:
           # Try contributor-specific GitHub username first, then fallback to shared
           FLY_API_TOKEN: ${{ secrets[format('FLY_API_TOKEN_{0}', steps.contributor.outputs.github_user)] || secrets.FLY_API_TOKEN }}

--- a/.github/workflows/fly_deploy_manual.yml
+++ b/.github/workflows/fly_deploy_manual.yml
@@ -15,6 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only -a ${{ secrets.FLY_APP_NAME }}
+      - run: flyctl deploy --config fly.prod.toml --remote-only ${{ secrets.FLY_DEPLOY_OPTS }}
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -1,0 +1,37 @@
+# fly.toml app configuration file generated for lanttern-dev on 2023-10-16T16:35:58-03:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+# use `-a` flag on `fly deploy` to override app name when needed
+app = "lanttern-dev"
+primary_region = "iad"
+kill_signal = "SIGTERM"
+swap_size_mb = 512
+
+[build]
+
+[deploy]
+release_command = "/app/bin/migrate"
+
+[env]
+# use fly secrets to override PHX_HOST
+PHX_HOST = "lanttern-dev.fly.dev"
+PORT = "8080"
+
+[http_service]
+internal_port = 8080
+force_https = true
+auto_stop_machines = "stop"
+auto_start_machines = true
+min_machines_running = 0
+processes = ["app"]
+
+[http_service.concurrency]
+type = "connections"
+hard_limit = 1000
+soft_limit = 1000
+
+[[vm]]
+size = "shared-cpu-1x"
+memory = "256mb"

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -3,8 +3,8 @@
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-# use `-a` flag to override the app name
-app = "lanttern-dev"
+# use `-a` flag on `fly deploy` to override app name when needed
+app = "lanttern"
 primary_region = "gru"
 kill_signal = "SIGTERM"
 swap_size_mb = 512
@@ -16,13 +16,13 @@ release_command = "/app/bin/migrate"
 
 [env]
 # use fly secrets to override PHX_HOST
-PHX_HOST = "lanttern-dev.fly.dev"
+PHX_HOST = "lanttern.org"
 PORT = "8080"
 
 [http_service]
 internal_port = 8080
 force_https = true
-auto_stop_machines = true
+auto_stop_machines = "stop"
 auto_start_machines = true
 min_machines_running = 1
 processes = ["app"]


### PR DESCRIPTION
some adjustments related to #369 were already made directly in the main branch, but this PR includes separated `fly.toml` config files for dev (`fly.dev.toml`) and prod (`fly.prod.toml`).

the main reason for this change is that we want to spend as little as possible in dev env, so the config for dev should allow no machines running, while in prod we always want at least 1 machine running.