### PR TITLE
feat: Implement new message board functionality with sections and messages

### DIFF
--- a/lib/lanttern/message_board.ex
+++ b/lib/lanttern/message_board.ex
@@ -8,9 +8,11 @@ defmodule Lanttern.MessageBoard do
   alias Lanttern.Repo
   import Lanttern.RepoHelpers
 
+  alias Lanttern.Attachments.Attachment
   alias Lanttern.MessageBoard.Message
+  alias Lanttern.MessageBoard.MessageAttachment
+  alias Lanttern.MessageBoard.Section
   alias Lanttern.Schools.Class
-  alias Lanttern.Schools.Student
 
   @doc """
   Returns the list of messages.
@@ -33,8 +35,8 @@ defmodule Lanttern.MessageBoard do
       m in Message,
       group_by: m.id,
       order_by: [
-        desc: fragment("CASE WHEN ? THEN 1 ELSE 0 END", m.is_pinned),
-        desc: m.inserted_at
+        asc: m.updated_at,
+        asc: m.position
       ]
     )
     |> apply_list_messages_opts(opts)
@@ -70,14 +72,16 @@ defmodule Lanttern.MessageBoard do
   defp filter_archived(queryable, true) do
     from(
       m in queryable,
-      where: not is_nil(m.archived_at)
+      where: not is_nil(m.archived_at),
+      order_by: [asc: m.position, desc: m.updated_at]
     )
   end
 
   defp filter_archived(queryable, _) do
     from(
       m in queryable,
-      where: is_nil(m.archived_at)
+      where: is_nil(m.archived_at),
+      order_by: [asc: m.position, desc: m.updated_at]
     )
   end
 
@@ -92,8 +96,8 @@ defmodule Lanttern.MessageBoard do
       [%Message{}, ...]
 
   """
-  @spec list_student_messages(Student.t()) :: [Message.t()]
-  def list_student_messages(%Student{} = student) do
+  @spec list_student_messages(map()) :: [Message.t()]
+  def list_student_messages(student) do
     %{id: student_id, school_id: school_id} = student
 
     student_classes_ids =
@@ -116,7 +120,6 @@ defmodule Lanttern.MessageBoard do
           (m.send_to == "school" and m.school_id == ^school_id),
       group_by: m.id,
       order_by: [
-        desc: fragment("CASE WHEN ? THEN 1 ELSE 0 END", m.is_pinned),
         desc: m.inserted_at
       ]
     )
@@ -210,8 +213,29 @@ defmodule Lanttern.MessageBoard do
   @spec archive_message(Message.t()) ::
           {:ok, Message.t()} | {:error, Ecto.Changeset.t()}
   def archive_message(%Message{} = message) do
+    total_messages =
+      from(m in Message,
+        where: m.section_id == ^message.section_id,
+        select: count(m.id)
+      )
+      |> Repo.one()
+
+    max_archived_position =
+      from(m in Message,
+        where: m.section_id == ^message.section_id and not is_nil(m.archived_at),
+        select: max(m.position)
+      )
+      |> Repo.one()
+
+    new_position =
+      case max_archived_position do
+        nil -> total_messages
+        max_pos -> max_pos + 1
+      end
+
     message
     |> Message.archive_changeset()
+    |> Ecto.Changeset.put_change(:position, new_position)
     |> Repo.update()
   end
 
@@ -232,9 +256,26 @@ defmodule Lanttern.MessageBoard do
   @spec unarchive_message(Message.t()) ::
           {:ok, Message.t()} | {:error, Ecto.Changeset.t()}
   def unarchive_message(%Message{} = message) do
+    non_archived_count = count_non_archived_messages_in_section(message.section_id)
+
     message
     |> Message.unarchive_changeset()
+    |> Ecto.Changeset.put_change(:position, non_archived_count + 1)
     |> Repo.update()
+  end
+
+  @doc """
+  Counts non-archived messages in a section.
+  Returns 0 if section_id is nil.
+  """
+  def count_non_archived_messages_in_section(nil), do: 0
+
+  def count_non_archived_messages_in_section(section_id) do
+    from(m in Message,
+      where: m.section_id == ^section_id and is_nil(m.archived_at),
+      select: count(m.id)
+    )
+    |> Repo.one()
   end
 
   @doc """
@@ -265,4 +306,271 @@ defmodule Lanttern.MessageBoard do
   def change_message(%Message{} = message, attrs \\ %{}) do
     Message.changeset(message, attrs)
   end
+
+  def get_message_per_school(id, school_id) do
+    from(m in Message, where: m.id == ^id and m.school_id == ^school_id)
+    |> preload([:classes])
+    |> Repo.one()
+    |> case do
+      nil -> {:error, :not_found}
+      message -> {:ok, message}
+    end
+  end
+
+  @doc """
+  Returns the list of sections ordered by position for a specific school.
+  """
+  def list_sections(school_id) do
+    from(s in Section,
+      where: s.school_id == ^school_id,
+      order_by: s.position
+    )
+    |> Repo.all()
+  end
+
+  @doc """
+  Returns the list of sections ordered by position with messages preloaded and filtered.
+
+  ## Parameters
+
+  - `school_id` - the school id for filtering messages
+  - `classes_ids` - list of class ids for filtering messages
+  """
+  def list_sections(school_id, classes_ids) when is_list(classes_ids) do
+    messages_query =
+      from(
+        m in Message,
+        where: is_nil(m.archived_at),
+        order_by: m.position
+      )
+      |> apply_sections_filter_opts(classes_ids: classes_ids, school_id: school_id)
+      |> preload([:classes])
+
+    from(s in Section,
+      where: s.school_id == ^school_id,
+      order_by: s.position
+    )
+    |> preload(messages: ^messages_query)
+    |> Repo.all()
+  end
+
+  defp apply_sections_filter_opts(queryable, opts) do
+    case Keyword.get(opts, :school_id) do
+      nil ->
+        queryable
+
+      school_id ->
+        case Keyword.get(opts, :classes_ids) do
+          classes_ids when is_list(classes_ids) and classes_ids != [] ->
+            from(
+              m in queryable,
+              left_join: mc in assoc(m, :message_classes),
+              where:
+                (m.send_to == "school" and m.school_id == ^school_id) or
+                  mc.class_id in ^classes_ids
+            )
+
+          _ ->
+            from(m in queryable, where: m.school_id == ^school_id)
+        end
+    end
+  end
+
+  @doc """
+  Lists sections with messages filtered by student.
+
+  A message is related to the student if it's sent to the student's classes or school.
+  Returns sections with their associated messages filtered by student access.
+  """
+  def list_sections_for_students(student_id, school_id) do
+    student_classes_ids =
+      from(
+        cl in Class,
+        join: cs in "classes_students",
+        on: cl.id == cs.class_id,
+        where: cs.student_id == ^student_id,
+        select: cl.id
+      )
+      |> Repo.all()
+
+    messages_query =
+      from(
+        m in Message,
+        left_join: mc in assoc(m, :message_classes),
+        where: is_nil(m.archived_at),
+        order_by: m.position
+      )
+      |> apply_sections_filter_opts(classes_ids: student_classes_ids, school_id: school_id)
+
+    from(s in Section,
+      where: s.school_id == ^school_id,
+      order_by: s.position
+    )
+    |> preload(messages: ^messages_query)
+    |> Repo.all()
+  end
+
+  @doc """
+  Gets a single section.
+
+  Raises `Ecto.NoResultsError` if the Section does not exist.
+  """
+  def get_section!(id), do: Repo.get!(Section, id)
+
+  @doc """
+  Gets a single section with messages preloaded and ordered.
+
+  Messages are ordered by position (ascending) and then by updated_at (descending).
+  Raises `Ecto.NoResultsError` if the Section does not exist.
+  """
+  def get_section_with_ordered_messages!(id) do
+    Section
+    |> Repo.get!(id)
+    |> Repo.preload(
+      messages:
+        from(m in Message,
+          order_by: [
+            asc: m.position,
+            desc: m.updated_at,
+            asc: m.archived_at
+          ]
+        )
+    )
+  end
+
+  @doc """
+  Creates a section.
+  """
+  def create_section(attrs) do
+    %Section{}
+    |> Section.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a section.
+  """
+  def update_section(%Section{} = section, attrs) do
+    section
+    |> Section.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a section.
+  """
+  def delete_section(%Section{} = section) do
+    Repo.delete(section)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking section changes.
+  """
+  def change_section(%Section{} = section, attrs \\ %{}) do
+    Section.changeset(section, attrs)
+  end
+
+  def update_messages_position(messages) do
+    messages
+    |> Enum.filter(fn m -> is_nil(m.archived_at) end)
+    |> Enum.with_index()
+    |> Enum.reduce(Ecto.Multi.new(), fn {message, i}, multi ->
+      query = from(m in Message, where: m.id == ^message.id)
+
+      Ecto.Multi.update_all(multi, "update-#{message.id}", query, set: [position: i])
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, _data} -> :ok
+      _ -> {:error, "Something went wrong"}
+    end
+  end
+
+  def update_section_position(sections) do
+    sections
+    |> Enum.with_index()
+    |> Enum.reduce(Ecto.Multi.new(), fn {section, i}, multi ->
+      query = from(m in Section, where: m.id == ^section.id)
+
+      Ecto.Multi.update_all(multi, "update-#{section.id}", query, set: [position: i])
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:ok, _data} -> :ok
+      _ -> {:error, "Something went wrong"}
+    end
+  end
+
+  # @doc """
+  # Returns the list of message_attachments.
+
+  # ## Examples
+
+  #     iex> list_message_attachments()
+  #     [%MessageAttachment{}, ...]
+
+  # """
+  # def list_message_attachments do
+  #   Repo.all(MessageAttachment)
+  # end
+
+  # @doc """
+  # Gets a single message_attachment.
+
+  # Raises `Ecto.NoResultsError` if the Message attachment does not exist.
+
+  # ## Examples
+
+  #     iex> get_message_attachment!(123)
+  #     %MessageAttachment{}
+
+  #     iex> get_message_attachment!(456)
+  #     ** (Ecto.NoResultsError)
+
+  # """
+  # def get_message_attachment!(id), do: Repo.get!(MessageAttachment, id)
+
+  @doc """
+  Creates a message_attachment.
+  """
+  @spec create_message_attachment(pos_integer(), pos_integer(), map()) ::
+          {:ok, Attachment.t()} | {:error, Ecto.Changeset.t()}
+  def create_message_attachment(profile_id, message_id, attrs) do
+    insert_query =
+      %Attachment{}
+      |> Attachment.changeset(Map.put(attrs, "owner_id", profile_id))
+
+    Ecto.Multi.new()
+    |> Ecto.Multi.insert(:insert_attachment, insert_query)
+    |> Ecto.Multi.run(:set_position, fn _repo, %{insert_attachment: attachment} ->
+      from(
+        ma in MessageAttachment,
+        where: ma.message_id == ^message_id
+      )
+      |> set_position_in_attrs(%{
+        message_id: message_id,
+        attachment_id: attachment.id,
+        owner_id: profile_id
+      })
+      |> then(&{:ok, &1})
+    end)
+    |> Ecto.Multi.insert(:link_message, fn %{set_position: attrs} ->
+      MessageAttachment.changeset(%MessageAttachment{}, attrs)
+    end)
+    |> Repo.transaction()
+    |> case do
+      {:error, _multi, changeset, _changes} -> {:error, changeset}
+      {:ok, %{insert_attachment: attachment}} -> {:ok, attachment}
+    end
+  end
+
+  @doc """
+  Update message attachments positions based on ids list order.
+
+  Expects a list of attachment ids in the new order.
+  """
+  @spec update_message_attachments_positions(attachments_ids :: [pos_integer()]) ::
+          :ok | {:error, String.t()}
+  def update_message_attachments_positions(attachments_ids),
+    do: update_positions(MessageAttachment, attachments_ids, id_field: :attachment_id)
 end

--- a/lib/lanttern/message_board/message.ex
+++ b/lib/lanttern/message_board/message.ex
@@ -8,31 +8,42 @@ defmodule Lanttern.MessageBoard.Message do
   use Gettext, backend: Lanttern.Gettext
 
   alias Lanttern.MessageBoard.MessageClass
+  alias Lanttern.MessageBoard.Section
+  alias Lanttern.Schools.Class
   alias Lanttern.Schools.School
 
   @type t :: %__MODULE__{
           id: pos_integer(),
           name: String.t(),
           description: String.t(),
+          subtitle: String.t() | nil,
+          color: String.t() | nil,
+          cover: String.t() | nil,
           send_to: String.t(),
           archived_at: DateTime.t() | nil,
-          is_pinned: boolean(),
           school_id: pos_integer() | nil,
+          section_id: pos_integer() | nil,
           school: School.t() | nil,
+          classes_ids: [pos_integer()] | nil,
+          classes: [Class.t()] | nil,
           inserted_at: DateTime.t() | nil,
           updated_at: DateTime.t() | nil
         }
 
-  schema "board_messages" do
+  schema "messages" do
     field :name, :string
     field :description, :string
     field :send_to, :string
     field :archived_at, :utc_datetime
-    field :is_pinned, :boolean, default: false
+    field :subtitle, :string
+    field :color, :string
+    field :cover, :string
+    field :position, :integer, default: 0
 
     field :classes_ids, {:array, :id}, virtual: true
 
     belongs_to :school, School
+    belongs_to :section, Section
 
     has_many :message_classes, MessageClass, on_replace: :delete
     has_many :classes, through: [:message_classes, :class]
@@ -44,8 +55,18 @@ defmodule Lanttern.MessageBoard.Message do
   def changeset(message, attrs) do
     changeset =
       message
-      |> cast(attrs, [:name, :description, :school_id, :send_to, :is_pinned])
-      |> validate_required([:name, :description, :school_id, :send_to])
+      |> cast(attrs, [
+        :name,
+        :description,
+        :school_id,
+        :send_to,
+        :section_id,
+        :subtitle,
+        :color,
+        :cover,
+        :position
+      ])
+      |> validate_required([:name, :description, :school_id, :send_to, :section_id])
       |> check_constraint(
         :send_to,
         name: :valid_send_to,

--- a/lib/lanttern/message_board/message_attachment.ex
+++ b/lib/lanttern/message_board/message_attachment.ex
@@ -1,0 +1,29 @@
+defmodule Lanttern.MessageBoard.MessageAttachment do
+  @moduledoc """
+  The `MessageAttachment` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Lanttern.Attachments.Attachment
+  alias Lanttern.Identity.Profile
+  alias Lanttern.MessageBoard.Message
+
+  schema "message_attachments" do
+    field :position, :integer, default: 0
+
+    belongs_to :owner, Profile
+    belongs_to :message, Message
+    belongs_to :attachment, Attachment
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(message_attachment, attrs) do
+    message_attachment
+    |> cast(attrs, [:position, :owner_id, :message_id, :attachment_id])
+    |> validate_required([:owner_id, :message_id, :attachment_id])
+  end
+end

--- a/lib/lanttern/message_board/message_class.ex
+++ b/lib/lanttern/message_board/message_class.ex
@@ -11,7 +11,7 @@ defmodule Lanttern.MessageBoard.MessageClass do
   alias Lanttern.Schools.School
 
   @primary_key false
-  schema "board_messages_classes" do
+  schema "messages_classes" do
     belongs_to :message, Message, primary_key: true
     belongs_to :class, Class, primary_key: true
     belongs_to :school, School

--- a/lib/lanttern/message_board/section.ex
+++ b/lib/lanttern/message_board/section.ex
@@ -1,0 +1,28 @@
+defmodule Lanttern.MessageBoard.Section do
+  @moduledoc """
+  The `Sections` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "sections" do
+    field :name, :string
+    field :position, :integer, default: 0
+
+    belongs_to :school, Lanttern.Schools.School
+    has_many :messages, Lanttern.MessageBoard.Message
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(section, attrs) do
+    section
+    |> cast(attrs, [:name, :position, :school_id])
+    |> validate_required([:name, :position, :school_id])
+    |> unique_constraint([:name, :school_id],
+      message: "section name must be unique within a school"
+    )
+  end
+end

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -1012,6 +1012,7 @@ defmodule LantternWeb.CoreComponents do
   attr :id, :string, default: nil
   attr :class, :any, default: nil
   attr :bg_class, :any, default: nil, doc: "view `<.card_base>` docs"
+  attr :html_attrs, :global, doc: "additional HTML attributes like style, data-*, phx-*, etc."
 
   slot :inner_block, required: true
 
@@ -1019,8 +1020,9 @@ defmodule LantternWeb.CoreComponents do
     ~H"""
     <.card_base
       id={@id}
-      class={["flex items-center gap-4 py-4 pl-2 pr-4", @class]}
+      class={["flex items-center py-4 pl-2 pr-4", @class]}
       bg_class={@bg_class}
+      {@html_attrs}
     >
       <.drag_handle class="sortable-handle" />
       <div class="flex-1 min-w-0">

--- a/lib/lanttern_web/components/message_board_components.ex
+++ b/lib/lanttern_web/components/message_board_components.ex
@@ -55,14 +55,6 @@ defmodule LantternWeb.MessageBoardComponents do
         <.action :if={@edit_patch} type="link" patch={@edit_patch} icon_name="hero-pencil-mini">
           {gettext("Edit")}
         </.action>
-        <div
-          :if={@message.is_pinned && is_nil(@message.archived_at)}
-          class="flex items-center justify-center w-6 h-6 rounded-full bg-ltrn-mesh-cyan"
-          title={gettext("Pinned message")}
-        >
-          <%!-- there's no pin in Hero Icons. I imported one from https://tabler.io/icons --%>
-          <.icon name="hero-pin-mini" class="text-ltrn-primary" />
-        </div>
       </div>
       <div class="flex flex-row-reverse sm:flex-row items-center gap-2 mt-2 text-xs">
         <.icon name="hero-calendar-mini" class="w-5 h-5 text-ltrn-subtle" />

--- a/lib/lanttern_web/live/pages/message_board/components.ex
+++ b/lib/lanttern_web/live/pages/message_board/components.ex
@@ -1,0 +1,280 @@
+defmodule LantternWeb.MessageBoard.Components do
+  @moduledoc """
+  Shared function components related to `MessageBoard` context
+  """
+
+  use Phoenix.Component
+
+  use Gettext, backend: Lanttern.Gettext
+  import LantternWeb.CoreComponents
+
+  alias Lanttern.MessageBoard.Message
+
+  @doc """
+  Renders message board cards.
+  """
+  attr :message, Message,
+    required: true,
+    doc: "expects `classes` preload when `show_sent_to` is true"
+
+  attr :edit_patch, :string, default: nil
+  attr :on_unarchive, JS, default: nil
+  attr :on_delete, JS, default: nil
+  attr :show_sent_to, :boolean, default: false
+  attr :class, :any, default: nil
+  attr :id, :any, default: nil
+  attr :tz, :string, default: nil
+
+  @deprecated "Use message_card_admin/1 instead"
+  def message_board_card(assigns) do
+    ~H"""
+    <.card_base
+      id={@id}
+      class={["p-6 pl-4 border border-l-12 border-ltrn-lightest shadow-xl z-20", @class]}
+      style={"border-color: var(--color-ltrn-lightest); border-left-color: #{@message.color};"}
+    >
+      <div class="flex items-start justify-between gap-4">
+        <h5 class="flex-1 font-display font-black text-xl" inner-html={} title={@message.name}>
+          {Phoenix.HTML.raw(Earmark.as_html!(@message.name, inner_html: true))}
+        </h5>
+        <.action
+          :if={@on_unarchive}
+          type="button"
+          phx-click={@on_unarchive}
+          icon_name="hero-arrow-up-tray-mini"
+          data-confirm={gettext("Are you sure, this will unarchive the message?")}
+        >
+          {gettext("Unarchive")}
+        </.action>
+        <.action
+          :if={@on_delete}
+          type="button"
+          phx-click={@on_delete}
+          icon_name="hero-x-mark-mini"
+          theme="alert"
+          data-confirm={gettext("Are you sure? This action cannot be undone.")}
+        >
+          {gettext("Delete")}
+        </.action>
+        <.action :if={@edit_patch} type="link" patch={@edit_patch} icon_name="hero-pencil-mini">
+          {gettext("Edit")}
+        </.action>
+      </div>
+
+      <div
+        :if={@show_sent_to}
+        class="flex flex-row-reverse sm:flex-row items-center gap-2 mt-2 text-xs"
+      >
+        <%= if @message.send_to == "classes" do %>
+          <.icon name="hero-users-mini" class="w-5 h-5 text-ltrn-subtle" />
+          <.badge :for={class <- @message.classes}>{class.name}</.badge>
+        <% else %>
+          <.icon name="hero-user-group-mini" class="w-5 h-5 text-ltrn-subtle" />
+          <.badge>{gettext("Sent to all school")}</.badge>
+        <% end %>
+      </div>
+
+      <.markdown text={@message.content} class="mt-10" />
+    </.card_base>
+    """
+  end
+
+  @doc """
+  Renders message board cards for admin/student variants.
+  """
+  attr :message, Message, required: true
+  attr :on_delete, JS, default: nil
+  attr :edit_patch, :string, default: nil
+  attr :on_unarchive, JS, default: nil
+  attr :id, :any, default: nil
+
+  attr :mode, :string,
+    required: true,
+    doc: "expects `mode` defined when show in admin and student/guardian view."
+
+  def message_card_admin(assigns) do
+    ~H"""
+    <div
+      id={"message-#{@message.id}"}
+      class="aspect-square relative bg-white/90 backdrop-blur-sm rounded-md border border-l-12 border-ltrn-lightest shadow-xl z-20"
+      style={"
+       border-color: var(--color-ltrn-lightest);
+       border-left-color: #{@message.color};
+       border-left-opacity: 1;
+       border-opacity: 0.5;
+      "}
+    >
+      <%= if @message.cover && @message.cover != "" && !@message.archived_at do %>
+        <div class="w-full h-9/16 overflow-hidden rounded-tr-md">
+          <img
+            src={@message.cover || "/placeholder.svg"}
+            alt={@message.name}
+            class="w-full h-full aspect-video object-cover"
+          />
+        </div>
+      <% end %>
+
+      <div class="p-6 pl-4">
+        <div class="flex items-start gap-4">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-2">
+              <h3
+                class={
+                  "font-display font-black text-xl" <>
+                    if(@message.cover && @message.cover != "" && !@message.archived_at, do: " truncate", else: "")
+                }
+                title={@message.name}
+              >
+                {@message.name}
+              </h3>
+            </div>
+          </div>
+        </div>
+
+        <%= if @mode == "admin" do %>
+          <div class="absolute bottom-6 right-6 flex items-center gap-2">
+            <.action
+              :if={@on_unarchive}
+              type="button"
+              phx-click={@on_unarchive}
+              icon_name="hero-arrow-up-tray-mini"
+              theme="dark"
+              size="sm"
+              data-confirm={gettext("Are you sure?")}
+              title={gettext("Unarchive")}
+            >
+            </.action>
+
+            <.action
+              :if={@on_delete && @message.archived_at}
+              type="button"
+              phx-click={@on_delete}
+              icon_name="hero-x-mark-mini"
+              theme="subtle"
+              size="sm"
+              data-confirm={gettext("Are you sure? This action cannot be undone.")}
+              title={gettext("Delete")}
+            >
+            </.action>
+
+            <.action
+              :if={@edit_patch && !@message.archived_at}
+              id={"message-#{@message.id}-edit"}
+              class="inline-flex hover:text-gray-600"
+              type="link"
+              patch={@edit_patch}
+              theme="subtle"
+              icon_name="hero-pencil-mini"
+            >
+            </.action>
+
+            <.action
+              :if={@edit_patch && @message.archived_at}
+              id={"message-#{@message.id}-view"}
+              class="inline-flex hover:text-gray-600"
+              type="link"
+              patch={@edit_patch}
+              theme="subtle"
+              icon_name="hero-eye-mini"
+              title={gettext("Preview")}
+            >
+            </.action>
+          </div>
+        <% else %>
+          <p
+            class={"text-gray-600 text-sm mb-4 " <> (if @message.cover && @message.cover != "", do: "line-clamp-2 truncate", else: "") }
+            title={@message.subtitle}
+          >
+            {@message.subtitle}
+          </p>
+
+          <div class="absolute bottom-3 right-4">
+            <button class="w-full flex items-center justify-between gap-[14px] transition-colors hover:text-blue-600 group">
+              <span
+                class="font-display font-bold text-base"
+                phx-click="card_lookout"
+                phx-value-id={@message.id}
+              >
+                {gettext("Find out more")}&nbsp
+              </span>
+              <.icon
+                name="hero-arrow-right"
+                class="w-6 h-6 mapping-3 transition-transform group-hover:translate-x-1"
+              />
+            </button>
+          </div>
+        <% end %>
+      </div>
+    </div>
+    """
+  end
+
+  @doc """
+  Renders message cards for guardian/student variants.
+  """
+  attr :message, Message, required: true
+  attr :class, :any, default: nil
+  attr :id, :any, default: nil
+  slot :inner_block
+
+  def message_card(assigns) do
+    ~H"""
+    <div
+      class={[
+        "overflow-auto-x aspect-square w-full bg-white/90 backdrop-blur-sm rounded-sm border border-l-12 border-ltrn-lightest shadow-xl z-20",
+        @class
+      ]}
+      style={"border-color: var(--color-ltrn-lightest); border-left-color: #{@message.color};"}
+    >
+      <%= if @message.cover && @message.cover != "" do %>
+        <div class="w-full h-9/16 overflow-hidden rounded-tr-md">
+          <img
+            src={@message.cover || "/placeholder.svg"}
+            alt={@message.name}
+          />
+        </div>
+      <% end %>
+
+      <div class="p-6 pl-4">
+        <div class="flex items-start">
+          <div class="flex-1 min-w-0">
+            <div class="flex items-center gap-2 mb-2">
+              <h3
+                class={"font-display font-black text-xl" <> (if @message.cover && @message.cover != "", do: " line-clamp-2", else: "")}
+                title={@message.name}
+              >
+                {@message.name}
+              </h3>
+            </div>
+
+            <p
+              :if={!@message.cover || @message.cover == ""}
+              class="text-gray-600 text-sm mb-4"
+              title={@message.subtitle}
+            >
+              {@message.subtitle}
+            </p>
+          </div>
+        </div>
+
+        <div class="absolute bottom-3 right-4">
+          <button
+            class="w-full flex items-center justify-between gap-[14px] transition-colors group"
+            phx-click="card_lookout"
+            phx-value-id={@message.id}
+            id={"#{assigns.id}-lookout"}
+          >
+            <span class="font-display font-bold text-sm hover:text-ltrn-subtle">
+              {gettext("See more")}
+            </span>
+            <.icon
+              name="hero-arrow-right"
+              class="w-6 h-6 mapping-3 transition-transform group-hover:translate-x-1"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+end

--- a/lib/lanttern_web/live/pages/message_board/index_live.ex
+++ b/lib/lanttern_web/live/pages/message_board/index_live.ex
@@ -1,0 +1,613 @@
+defmodule LantternWeb.MessageBoard.IndexLive do
+  use LantternWeb, :live_view
+
+  import LantternWeb.CoreComponents
+  import LantternWeb.MessageBoard.Components
+  import LantternWeb.FiltersHelpers, only: [assign_classes_filter: 2]
+
+  alias Lanttern.MessageBoard
+  alias Lanttern.MessageBoard.Message
+  alias Lanttern.MessageBoard.Section
+  alias Lanttern.Schools.Cycle
+
+  # shared
+  alias LantternWeb.Attachments.AttachmentAreaComponent
+  alias LantternWeb.MessageBoard.MessageFormOverlayComponent
+
+  def mount(_params, _session, socket) do
+    if connected?(socket), do: send(self(), :initialized)
+
+    communication_manager? =
+      "communication_management" in socket.assigns.current_user.current_profile.permissions
+
+    socket =
+      socket
+      |> assign(:initialized, false)
+      |> assign(:show_reorder, false)
+      |> assign(:classes, [])
+      |> assign(:selected_classes, [])
+      |> assign(:selected_classes_ids, [])
+      |> assign(:message, nil)
+      |> assign(:messages, [])
+      |> assign(:section, nil)
+      |> assign(:section_id, nil)
+      |> assign(:sections, [])
+      |> assign(:communication_manager?, communication_manager?)
+      |> assign(:section_overlay_title, nil)
+      |> assign(:form_action, nil)
+      |> assign(:page_title, gettext("Message board"))
+
+    {:ok, socket}
+  end
+
+  def handle_params(params, _url, socket) do
+    socket =
+      socket
+      |> assign(:params, params)
+      |> assign_message()
+      |> assign_section()
+      |> assign_reorder()
+
+    {:noreply, socket}
+  end
+
+  def handle_event("delete_message", %{"message_id" => id}, socket) do
+    message = MessageBoard.get_message!(id)
+
+    case MessageBoard.delete_message(message) do
+      {:ok, _message} ->
+        socket
+        |> put_flash(:info, gettext("Message deleted successfully"))
+        |> assign_sections()
+        |> then(&{:noreply, &1})
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to delete message"))}
+    end
+  end
+
+  def handle_event("unarchive", %{"message_id" => id}, socket) do
+    message = MessageBoard.get_message!(id)
+
+    case MessageBoard.unarchive_message(message) do
+      {:ok, _} ->
+        socket =
+          socket
+          |> put_flash(:info, gettext("Message restored"))
+          |> assign_sections()
+
+        {:noreply, socket}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to unarchive message"))}
+    end
+  end
+
+  def handle_event("unarchive_message", %{"id" => id}, socket) do
+    message = MessageBoard.get_message!(id)
+
+    case MessageBoard.unarchive_message(message) do
+      {:ok, unarchived_message} ->
+        # Get current active messages in the section to determine position
+        if socket.assigns.section && socket.assigns.section.messages do
+          non_archived_messages =
+            Enum.filter(socket.assigns.section.messages, fn m ->
+              is_nil(m.archived_at) and m.id != unarchived_message.id
+            end)
+
+          # Add the unarchived message at the end
+          new_messages_order = non_archived_messages ++ [unarchived_message]
+
+          # Update positions
+          MessageBoard.update_messages_position(new_messages_order)
+        end
+
+        socket =
+          socket
+          |> put_flash(:info, gettext("Message restored"))
+          |> assign_sections()
+          |> push_patch(to: ~p"/school/message_board")
+
+        {:noreply, socket}
+
+      {:error, _} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to unarchive message"))}
+    end
+  end
+
+  def handle_event("validate_section", %{"section" => section_params}, socket) do
+    changeset =
+      socket.assigns.section
+      |> MessageBoard.change_section(section_params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, :form, to_form(changeset))}
+  end
+
+  def handle_event("save_section", params, %{assigns: %{form_action: :edit}} = socket) do
+    section_params = Map.get(params, "section")
+
+    socket.assigns.section
+    |> MessageBoard.update_section(section_params)
+    |> case do
+      {:ok, _section} ->
+        socket
+        |> put_flash(:info, "Section updated successfully")
+        |> push_patch(to: ~p"/school/message_board")
+        |> assign_sections()
+        |> assign(:form_action, nil)
+        |> then(&{:noreply, &1})
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  def handle_event("save_section", params, %{assigns: %{form_action: :create}} = socket) do
+    section_params =
+      params
+      |> Map.get("section")
+      |> Map.put("school_id", socket.assigns.current_user.current_profile.school_id)
+
+    section_params
+    |> MessageBoard.create_section()
+    |> case do
+      {:ok, _section} ->
+        socket
+        |> put_flash(:info, "Section created successfully")
+        |> push_patch(to: ~p"/school/message_board")
+        |> assign_sections()
+        |> assign(:form_action, nil)
+        |> then(&{:noreply, &1})
+
+      {:error, %Ecto.Changeset{} = changeset} ->
+        {:noreply, assign(socket, :form, to_form(changeset))}
+    end
+  end
+
+  def handle_event("delete_section", _params, %{assigns: %{section: section}} = socket) do
+    case MessageBoard.delete_section(section) do
+      {:ok, _section} ->
+        socket
+        |> put_flash(:info, gettext("Section deleted successfully"))
+        |> push_patch(to: ~p"/school/message_board")
+        |> assign_sections()
+        |> assign(:form_action, nil)
+        |> then(&{:noreply, &1})
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, gettext("Failed to delete section"))}
+    end
+  end
+
+  def handle_event("sortable_update", %{"oldIndex" => old, "newIndex" => new}, socket) do
+    non_archived = Enum.filter(socket.assigns.section.messages, fn m -> is_nil(m.archived_at) end)
+    {changed_id, rest} = List.pop_at(non_archived, old)
+    new_messages = List.insert_at(rest, new, changed_id)
+    MessageBoard.update_messages_position(new_messages)
+
+    {:noreply, assign_sections(socket)}
+  end
+
+  def handle_info({MessageFormOverlayComponent, {action, _message}}, socket)
+      when action in [:created, :updated] do
+    flash_message =
+      case action do
+        :created -> {:info, gettext("Message created successfully")}
+        :updated -> {:info, gettext("Message updated successfully")}
+      end
+
+    socket
+    |> put_flash(elem(flash_message, 0), elem(flash_message, 1))
+    |> push_patch(to: ~p"/school/message_board")
+    |> assign_sections()
+    |> then(&{:noreply, &1})
+  end
+
+  def handle_info({MessageFormOverlayComponent, {:archived, _message}}, socket) do
+    socket =
+      socket
+      |> put_flash(:info, gettext("Message archived"))
+      |> push_patch(to: ~p"/school/message_board")
+      |> assign_sections()
+
+    {:noreply, socket}
+  end
+
+  def handle_info({MessageFormOverlayComponent, {:unarchived, _message}}, socket) do
+    socket =
+      socket
+      |> put_flash(:info, gettext("Message restored"))
+      |> push_patch(to: ~p"/school/message_board")
+      |> assign_sections()
+
+    {:noreply, socket}
+  end
+
+  def handle_info({AttachmentAreaComponent, {_action, _attachment}}, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_info({LantternWeb.MessageBoard.ReorderComponent, :reordered}, socket) do
+    {:noreply, assign_sections(socket)}
+  end
+
+  def handle_info(:initialized, socket) do
+    socket =
+      socket
+      |> apply_assign_classes_filter()
+      |> assign_sections()
+      |> assign(:initialized, true)
+
+    {:noreply, socket}
+  end
+
+  defp apply_assign_classes_filter(socket) do
+    assign_classes_filter_opts =
+      case socket.assigns.current_user.current_profile do
+        %{current_school_cycle: %Cycle{} = cycle} -> [cycles_ids: [cycle.id]]
+        _ -> []
+      end
+
+    assign_classes_filter(socket, assign_classes_filter_opts)
+  end
+
+  defp assign_sections(socket) do
+    school_id = socket.assigns.current_user.current_profile.school_id
+    sections = MessageBoard.list_sections(school_id, socket.assigns.selected_classes_ids)
+
+    assign(socket, :sections, sections)
+  end
+
+  defp assign_section(%{assigns: %{params: %{"new_section" => "true"}}} = socket) do
+    section = %Section{}
+    changeset = MessageBoard.change_section(section)
+
+    socket
+    |> assign(:section, section)
+    |> assign(:section_overlay_title, gettext("New section"))
+    |> assign(:form_action, :create)
+    |> assign(:form, to_form(changeset))
+  end
+
+  defp assign_section(%{assigns: %{params: %{"edit_section" => id}}} = socket) do
+    section = MessageBoard.get_section_with_ordered_messages!(id)
+    changeset = MessageBoard.change_section(section)
+
+    socket
+    |> assign(:section, section)
+    |> assign(:section_overlay_title, gettext("Edit section"))
+    |> assign(:form_action, :edit)
+    |> assign(:form, to_form(changeset))
+  end
+
+  defp assign_section(%{assigns: %{params: %{"section_id" => section_id}}} = socket) do
+    section = MessageBoard.get_section!(section_id)
+
+    assign(socket, :section_id, section.id)
+  end
+
+  defp assign_section(socket), do: assign(socket, :section, nil)
+
+  defp assign_message(%{assigns: %{communication_manager?: false}} = socket),
+    do: assign(socket, :message, nil)
+
+  defp assign_message(%{assigns: %{params: %{"new" => "true", "section_id" => id}}} = socket) do
+    message = %Message{
+      school_id: socket.assigns.current_user.current_profile.school_id,
+      classes: [],
+      send_to: "school",
+      section_id: id
+    }
+
+    socket
+    |> assign(:message, message)
+    |> assign(:message_overlay_title, gettext("New message"))
+  end
+
+  defp assign_message(%{assigns: %{params: %{"edit" => message_id}}} = socket) do
+    school_id = socket.assigns.current_user.current_profile.school_id
+
+    with true <- socket.assigns.communication_manager?,
+         {:ok, message} <- MessageBoard.get_message_per_school(message_id, school_id) do
+      socket
+      |> assign(:message, message)
+      |> assign(:message_overlay_title, gettext("Edit message"))
+    else
+      _ -> assign(socket, :message, nil)
+    end
+  end
+
+  defp assign_message(socket), do: assign(socket, :message, nil)
+
+  defp assign_reorder(%{assigns: %{params: %{"reorder" => "true"}}} = socket) do
+    assign(socket, :show_reorder, true)
+  end
+
+  defp assign_reorder(socket), do: assign(socket, :show_reorder, false)
+
+  def render(assigns) do
+    ~H"""
+    <Layouts.app_logged_in flash={@flash} current_user={@current_user} current_path={@current_path}>
+      <.header_nav current_user={@current_user}>
+        <:title>{gettext("Message board admin")}</:title>
+        <div class="flex items-center justify-between gap-4 p-4">
+          <div class="flex items-center gap-4">
+            <.action
+              type="button"
+              phx-click={JS.exec("data-show", to: "#message-board-classes-filters-overlay")}
+              icon_name="hero-chevron-down-mini"
+            >
+              {format_action_items_text(@selected_classes, gettext("All years"))}
+            </.action>
+            <.action
+              type="link"
+              patch={~p"/school/message_board/archive"}
+              icon_name="hero-archive-box-solid"
+            >
+              {gettext("View archived messages")}
+            </.action>
+          </div>
+          <div class="flex items-center gap-4">
+            <.action
+              type="link"
+              patch={~p"/school/message_board?reorder=true"}
+              icon_name="hero-arrows-up-down-mini"
+            >
+              {gettext("Reorder sections")}
+            </.action>
+            <.action
+              type="link"
+              patch={~p"/school/message_board?new_section=true"}
+              icon_name="hero-plus-circle-mini"
+            >
+              {gettext("Create section")}
+            </.action>
+          </div>
+        </div>
+      </.header_nav>
+
+      <.responsive_container class="p-4">
+        <p class="flex items-center gap-2 mb-6">
+          <.icon name="hero-information-circle-mini" class="text-ltrn-subtle" />
+          {gettext(
+            "Manage message board sections and messages. Messages are displayed in students and guardians home page."
+          )}
+        </p>
+
+        <%= if @sections == [] do %>
+          <.card_base class="p-10 mt-4">
+            <.empty_state>
+              {gettext("No sections created yet")}
+            </.empty_state>
+          </.card_base>
+        <% else %>
+          <div class="space-y-8">
+            <%= for section <- @sections do %>
+              <div class="bg-white rounded-lg shadow-lg">
+                <div class="flex items-center justify-between p-4 border-gray-200 -mb-4">
+                  <div class="flex items-center space-x-3">
+                    <h2 class="text-lg font-bold">{section.name}</h2>
+                  </div>
+                  <div class="flex items-center space-x-2">
+                    <.action
+                      type="link"
+                      patch={~p"/school/message_board?edit_section=#{section.id}"}
+                      theme="subtle"
+                      icon_name="hero-cog-6-tooth-mini"
+                      id={"section-#{section.id}-settings"}
+                      title={gettext("Configure section")}
+                    >
+                    </.action>
+                  </div>
+                </div>
+                <div class="p-4">
+                  <div
+                    class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 xl:grid-cols-4 gap-4"
+                    id={"section-#{section.id}-messages"}
+                  >
+                    <%= for message <- section.messages do %>
+                      <.message_card_admin
+                        message={message}
+                        mode="admin"
+                        edit_patch={~p"/school/message_board?edit=#{message.id}"}
+                        on_delete={JS.push("delete_message", value: %{message_id: message.id})}
+                      />
+                    <% end %>
+
+                    <.link
+                      :if={@communication_manager?}
+                      patch={~p"/school/message_board?new=true&section_id=#{section.id}"}
+                      class="aspect-square w-full bg-white border-1 border-dashed border-gray-300 rounded-lg p-6 flex flex-col items-center justify-center text-gray-400 hover:text-gray-600 hover:border-gray-400 transition-colors group shadow-lg"
+                    >
+                      <.icon
+                        name="hero-plus"
+                        class="w-12 h-12 aspect-square mb-4 group-hover:scale-110 transition-transform"
+                      />
+                      <span class="text-sm font-medium">Add new message</span>
+                    </.link>
+                  </div>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+      </.responsive_container>
+
+      <.live_component
+        :if={@message}
+        module={MessageFormOverlayComponent}
+        id="message-form-overlay"
+        message={@message}
+        section_id={@section_id}
+        title={@message_overlay_title}
+        current_profile={@current_user.current_profile}
+        on_cancel={JS.patch(~p"/school/message_board")}
+        notify_parent
+      />
+
+      <div :if={@section} phx-remove={JS.exec("phx-remove", to: "#section-form-overlay")}>
+        <.slide_over
+          id="section-form-overlay"
+          show={true}
+          on_cancel={JS.patch(~p"/school/message_board")}
+        >
+          <:title>{@section_overlay_title}</:title>
+          <.form
+            id="message-form"
+            for={@form}
+            phx-change="validate_section"
+            phx-submit="save_section"
+          >
+            <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
+              {gettext("Oops, something went wrong! Please check the errors below.")}
+            </.error_block>
+            <.input
+              field={@form[:name]}
+              type="text"
+              label={gettext("Section name")}
+              class="mb-6 -mt-6"
+              phx-debounce="1500"
+            />
+          </.form>
+          <div
+            :if={@form_action == :edit}
+            phx-hook="Sortable"
+            id="sortable-section-cards"
+            data-sortable-handle=".sortable-handle"
+            phx-update="ignore"
+          >
+            <.dragable_card
+              :for={
+                message <-
+                  if is_list(@section.messages),
+                    do: Enum.filter(@section.messages, fn m -> is_nil(m.archived_at) end),
+                    else: []
+              }
+              id={"sortable-#{message.id}"}
+              class="mb-4 border-l-12 gap-2"
+              style={"border-left-color: #{message.color};"}
+            >
+              <h3 class="font-display font-black text-lg" title={message.name}>
+                {message.name}
+              </h3>
+            </.dragable_card>
+          </div>
+
+          <%!-- Render archived messages after the sortable non-archived list --%>
+          <div
+            :if={
+              @form_action == :edit &&
+                length(Enum.filter(@section.messages || [], fn m -> !is_nil(m.archived_at) end)) > 0
+            }
+            class="mt-6"
+          >
+            <label class="block text-sm font-medium leading-6 text-zinc-800">
+              {gettext("Archived messages")}
+            </label>
+            <div class="space-y-2 mt-2">
+              <.card_base
+                :for={
+                  message <- Enum.filter(@section.messages || [], fn m -> !is_nil(m.archived_at) end)
+                }
+                class="p-4 opacity-60 bg-ltrn-lightest border-l-12"
+                style={"border-left-color: #{message.color};"}
+              >
+                <div class="flex items-center justify-between">
+                  <h3 class="font-display font-black text-lg" title={message.name}>
+                    {message.name}
+                  </h3>
+                  <div class="flex items-center gap-2">
+                    <.action
+                      type="button"
+                      phx-click="unarchive_message"
+                      phx-value-id={message.id}
+                      icon_name="hero-arrow-up-tray-mini"
+                      theme="dark"
+                      size="md"
+                      title={gettext("Unarchive")}
+                    >
+                    </.action>
+                  </div>
+                </div>
+              </.card_base>
+            </div>
+          </div>
+          <:actions_left :if={@section.id}>
+            <.action
+              type="button"
+              theme="subtle"
+              size="md"
+              phx-click="delete_section"
+              data-confirm={gettext("Are you sure? All messages in this section will be deleted.")}
+            >
+              {gettext("Delete")}
+            </.action>
+          </:actions_left>
+          <:actions>
+            <.action
+              type="button"
+              theme="subtle"
+              size="md"
+              phx-click={JS.exec("data-cancel", to: "#section-form-overlay")}
+            >
+              {gettext("Cancel")}
+            </.action>
+            <.action
+              type="submit"
+              theme="primary"
+              size="md"
+              icon_name="hero-check"
+              form="message-form"
+            >
+              {gettext("Save")}
+            </.action>
+          </:actions>
+        </.slide_over>
+      </div>
+
+      <.slide_over
+        :if={@show_reorder}
+        id="reorder-sections-overlay"
+        show={true}
+        on_cancel={JS.patch(~p"/school/message_board")}
+      >
+        <:title>{gettext("Reorder sections")}</:title>
+        <.live_component
+          module={LantternWeb.MessageBoard.ReorderComponent}
+          id="reorder-sections-component"
+          current_user={@current_user}
+        />
+        <:actions>
+          <.action
+            type="button"
+            theme="subtle"
+            size="md"
+            phx-click={JS.exec("data-cancel", to: "#reorder-sections-overlay")}
+          >
+            {gettext("Cancel")}
+          </.action>
+          <.action
+            type="button"
+            theme="primary"
+            size="md"
+            phx-click={JS.patch(~p"/school/message_board")}
+          >
+            {gettext("Done")}
+          </.action>
+        </:actions>
+      </.slide_over>
+
+      <.live_component
+        module={LantternWeb.Filters.ClassesFilterOverlayComponent}
+        id="message-board-classes-filters-overlay"
+        current_user={@current_user}
+        title={gettext("Filter messages by class")}
+        navigate={~p"/school/message_board"}
+        classes={@classes}
+        selected_classes_ids={@selected_classes_ids}
+      />
+    </Layouts.app_logged_in>
+    """
+  end
+end

--- a/lib/lanttern_web/live/pages/message_board/message_board_grid_component.ex
+++ b/lib/lanttern_web/live/pages/message_board/message_board_grid_component.ex
@@ -1,0 +1,163 @@
+defmodule LantternWeb.MessageBoard.MessageBoardGridComponent do
+  @moduledoc """
+  LiveComponent for rendering a grid of message board cards.
+
+  Displays messages in a responsive grid layout and handles card interactions.
+  """
+  use LantternWeb, :live_component
+
+  import LantternWeb.MessageBoard.Components
+
+  @impl true
+  def handle_event("card_lookout", %{"id" => id}, socket) do
+    send(self(), {:card_lookout, id})
+    {:noreply, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="space-y-8">
+      <div :if={@show_title}>
+        <h2 class="flex items-center gap-2 font-display font-black text-2xl">
+          {gettext("Message board")}
+        </h2>
+      </div>
+
+      <%= for section <- @sections do %>
+        <div class="space-y-4 px-0">
+          <!-- Mobile-only full-bleed carousel -->
+          <div class="md:hidden -mx-6">
+            <div>
+              <h3 class="text-lg font-bold mb-1 pl-6">
+                {section.name}
+              </h3>
+            </div>
+
+            <div
+              id={"section-#{section.id}-messages-wrapper-mobile"}
+              class="relative"
+              style="overflow: visible;"
+            >
+              <div
+                id={"section-#{section.id}-messages-mobile"}
+                class="hide-scrollbar snap-x snap-mandatory overflow-x-auto flex gap-4 pl-0"
+              >
+                <!-- spacer to offset first card by 16px on mobile -->
+                <div class="flex-shrink-0" style="width:10px;" aria-hidden="true"></div>
+                <%= for message <- section.messages do %>
+                  <div
+                    id={"section-#{section.id}-message-#{message.id}-mobile"}
+                    class="snap-center flex-shrink-0 w-[80vw] max-w-[320px] scroll-smooth"
+                    style="overflow: visible;"
+                  >
+                    <div class="mt-1 mb-9">
+                      <!-- mobile bottom gutter so shadow is visible -->
+                      <.message_card
+                        id={"sect-#{section.id}-msg-#{message.id}-card"}
+                        message={message}
+                        class="mx-0"
+                      >
+                        <div :if={@show_see_more} class="absolute bottom-3 right-4">
+                          <button
+                            class="w-full flex items-center justify-between gap-[14px] transition-colors hover:text-ltrn-subtle group"
+                            phx-click="card_lookout"
+                            phx-value-id={message.id}
+                          >
+                            <span class="font-display font-bold text-sm">
+                              {gettext("See more")}
+                            </span>
+                            <.icon
+                              name="hero-arrow-right"
+                              class="w-6 h-6 mapping-3 transition-transform group-hover:translate-x-1"
+                            />
+                          </button>
+                        </div>
+                      </.message_card>
+                    </div>
+                  </div>
+                <% end %>
+                <!-- trailing spacer to balance the initial offset -->
+                <div class="flex-shrink-0" style="width:10px;" aria-hidden="true"></div>
+              </div>
+
+              <div class="mt-0 flex items-center justify-center space-x-2 indicators">
+                <%= for message <- section.messages do %>
+                  <a
+                    href={"#section-#{section.id}-message-#{message.id}-mobile"}
+                    class="block w-2 h-2 rounded-full bg-white focus:outline-none indicator-dot"
+                    style="border: 1px solid #94A3B8;"
+                    aria-label={gettext("Go to message %{id}", id: message.id)}
+                  >
+                  </a>
+                <% end %>
+              </div>
+
+              <style>
+                <%= for message <- section.messages do %>
+                  #section-<%= section.id %>-messages-wrapper-mobile:has(#section-<%= section.id %>-message-<%= message.id %>-mobile:target) .indicators a[href="#section-<%= section.id %>-message-<%= message.id %>-mobile"] {
+                      background: <%= message.color || "#94A3B8" %>;
+                      border-color: <%= message.color || "#94A3B8" %>;
+                    }
+                <% end %>
+              </style>
+            </div>
+          </div>
+          
+    <!-- Desktop/tablet: use existing grid within responsive container -->
+          <div class="hidden md:block">
+            <div>
+              <h3 class="text-lg font-bold mb-1 px-6 md:px-0">
+                {section.name}
+              </h3>
+            </div>
+
+            <div
+              id={"section-#{section.id}-messages-wrapper"}
+              class="relative"
+              style="overflow: visible;"
+            >
+              <div
+                id={"section-#{section.id}-messages"}
+                class="hide-scrollbar ml-0 snap-none md:overflow-visible md:grid md:grid-cols-2 lg:grid-cols-3 md:gap-4 gap-4 md:px-0"
+              >
+                <%= for message <- section.messages do %>
+                  <div
+                    id={"section-#{section.id}-message-#{message.id}"}
+                    class="md:static md:w-auto md:max-w-none"
+                    style="overflow: visible;"
+                  >
+                    <div class="mt-0 mb-1">
+                      <.message_card
+                        id={"sect-#{section.id}-msg-#{message.id}-responsive-card"}
+                        message={message}
+                        class="mx-0"
+                      >
+                        <div :if={@show_see_more} class="absolute bottom-3 right-4">
+                          <button
+                            class="w-full flex items-center justify-between gap-[14px] transition-colors hover:text-ltrn-subtle group"
+                            phx-click="card_lookout"
+                            phx-value-id={message.id}
+                          >
+                            <span class="font-display font-bold text-sm">
+                              {gettext("See more")}
+                            </span>
+                            <.icon
+                              name="hero-arrow-right"
+                              class="w-6 h-6 mapping-3 transition-transform group-hover:translate-x-1"
+                            />
+                          </button>
+                        </div>
+                      </.message_card>
+                    </div>
+                  </div>
+                <% end %>
+              </div>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/lanttern_web/live/pages/message_board/reorder_component.ex
+++ b/lib/lanttern_web/live/pages/message_board/reorder_component.ex
@@ -1,0 +1,81 @@
+defmodule LantternWeb.MessageBoard.ReorderComponent do
+  @moduledoc """
+    Reorder Componet for Message Board.
+  """
+  use LantternWeb, :live_component
+
+  alias Lanttern.MessageBoard
+
+  def mount(socket) do
+    {:ok, assign(socket, :initialized, false)}
+  end
+
+  def update(assigns, socket) do
+    socket =
+      socket
+      |> assign(assigns)
+      |> initialize()
+
+    {:ok, socket}
+  end
+
+  def handle_event("sortable_update", %{"oldIndex" => old, "newIndex" => new}, socket) do
+    {changed_id, rest} = List.pop_at(socket.assigns.sections, old)
+    new_sections = List.insert_at(rest, new, changed_id)
+    MessageBoard.update_section_position(new_sections)
+    send(self(), {__MODULE__, :reordered})
+
+    {:noreply, assign_sections(socket)}
+  end
+
+  def handle_info(_msg, socket), do: {:noreply, socket}
+
+  defp assign_sections(socket) do
+    school_id = socket.assigns.current_user.current_profile.school_id
+    sections = MessageBoard.list_sections(school_id)
+
+    assign(socket, :sections, sections)
+  end
+
+  defp initialize(%{assigns: %{initialized: false}} = socket) do
+    socket
+    |> assign_sections()
+    |> assign(:initialized, true)
+  end
+
+  defp initialize(socket), do: socket
+
+  def render(assigns) do
+    ~H"""
+    <div class="px-6">
+      <%= if @sections == [] do %>
+        <.card_base class="p-10 mt-4">
+          <.empty_state>
+            {gettext("No sections created yet")}
+          </.empty_state>
+        </.card_base>
+      <% else %>
+        <div class="-mb-6"></div>
+        <div
+          class="space-y-8"
+          phx-hook="Sortable"
+          phx-target={@myself}
+          id="sortable-section-cards"
+          data-sortable-handle=".sortable-handle"
+          phx-update="ignore"
+        >
+          <.dragable_card
+            :for={section <- @sections}
+            id={"sortable-#{section.id}"}
+            class="w-full bg-white rounded-lg shadow-lg my-4 border-l-12 gap-2"
+          >
+            <h3 class="font-display font-black text-lg truncate" title={section.name}>
+              {section.name}
+            </h3>
+          </.dragable_card>
+        </div>
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/lib/lanttern_web/live/shared/menu_component.ex
+++ b/lib/lanttern_web/live/shared/menu_component.ex
@@ -460,6 +460,12 @@ defmodule LantternWeb.MenuComponent do
         path: ~p"/grades_reports",
         text: gettext("Grades reports")
       },
+      %{
+        profile: "staff",
+        active: :message_board,
+        path: ~p"/school/message_board",
+        text: gettext("Message Board")
+      },
       # student
       %{
         profile: "student",

--- a/lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/message_board/message_form_overlay_component.ex
@@ -4,23 +4,125 @@ defmodule LantternWeb.MessageBoard.MessageFormOverlayComponent do
 
   ### Attrs
 
-      attr :message, Message, required: true
-      attr :title, :string, required: true
-      attr :current_profile, Profile, required: true
-      attr :on_cancel, :any, required: true, doc: "`<.slide_over>` `on_cancel` attr"
-      attr :notify_parent, :boolean
-      attr :notify_component, Phoenix.LiveComponent.CID
-
+    attr :message, Message, required: true
+    attr :title, :string, required: true
+    attr :current_profile, Profile, required: true
+    attr :section_id, :integer
+    attr :on_cancel, :any, required: true, doc: "`<.slide_over>` `on_cancel` attr"
+    attr :notify_parent, :boolean
+    attr :notify_component, Phoenix.LiveComponent.CID
   """
 
   use LantternWeb, :live_component
 
   alias Lanttern.MessageBoard
   alias Lanttern.MessageBoard.Message
+  alias Lanttern.SupabaseHelpers
+
+  attr :field, Phoenix.HTML.FormField
+  attr :label, :string
+  attr :help_text, :string
+  attr :class, :string, default: nil
+
+  def input_with_help_text(assigns) do
+    ~H"""
+    <div class={@class}>
+      <.label>
+        {@label}
+        <span class="font-normal">({@help_text})</span>
+      </.label>
+      <.input field={@field} type="text" class="mt-2" phx-debounce="1500" />
+    </div>
+    """
+  end
 
   # shared
 
   alias LantternWeb.Schools.ClassesFieldComponent
+  import LantternWeb.FormComponents
+
+  # Custom image field component for message form with aspect ratio recommendation
+  attr :current_image_url, :string, required: true
+  attr :is_removing, :boolean, required: true
+  attr :upload, :any, required: true, doc: "use it to pass `@uploads.something`"
+  attr :on_cancel_replace, Phoenix.LiveView.JS, required: true
+  attr :on_cancel_upload, Phoenix.LiveView.JS, required: true
+  attr :on_replace, Phoenix.LiveView.JS, required: true
+  attr :class, :any, default: nil
+
+  defp message_image_field(assigns) do
+    ~H"""
+    <div
+      :if={!@current_image_url || @is_removing}
+      class={[
+        "p-4 border border-dashed border-ltrn-subtle rounded-md text-center text-ltrn-subtle bg-white shadow-lg",
+        if(@upload.entries != [], do: "hidden"),
+        @class
+      ]}
+      phx-drop-target={@upload.ref}
+    >
+      <div>
+        <.icon name="hero-photo" class="h-10 w-10 mx-auto mb-6" />
+        <div>
+          <label
+            for={@upload.ref}
+            class="cursor-pointer text-ltrn-primary hover:text-ltrn-dark focus-within:outline-hidden focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-ltrn-dark"
+          >
+            <span>{gettext("Upload a cover image file")}</span>
+            <.live_file_input upload={@upload} class="sr-only" />
+          </label>
+          <span>{gettext("or drag and drop here")}</span>
+          <div class="mt-2">
+            <span class="text-xs">
+              {gettext("Recommended aspect ratio of 16:9 (landscape orientation)")}
+            </span>
+          </div>
+          <button :if={@is_removing} type="button" phx-click={@on_cancel_replace} class="mt-4">
+            {gettext("Cancel cover removal")}
+          </button>
+        </div>
+      </div>
+    </div>
+    <div :if={@current_image_url && !@is_removing} class={["relative", @class]}>
+      <div class="flex items-center justify-center w-full h-60 bg-ltrn-subtle overflow-hidden">
+        <img src={@current_image_url} alt="Cover image" class="w-full" />
+      </div>
+      <.icon_button
+        type="button"
+        name="hero-x-mark"
+        theme="white"
+        rounded
+        phx-click={@on_replace}
+        sr_text={gettext("Replace image")}
+        class="absolute top-2 right-2"
+      />
+    </div>
+    <div :for={entry <- @upload.entries} class={["relative", @class]}>
+      <div
+        :if={entry.valid?}
+        class="flex items-center justify-center w-full h-60 bg-ltrn-subtle overflow-hidden"
+      >
+        <.live_img_preview entry={entry} class="w-full" />
+      </div>
+      <.error_block :if={!entry.valid?} class="p-6 border border-red-500 rounded-sm">
+        <p>{gettext("File \"%{file}\" is invalid.", file: entry.client_name)}</p>
+        <%= for err <- upload_errors(@upload, entry) do %>
+          {LantternWeb.FormComponents.upload_error_to_string(@upload, err)}
+        <% end %>
+      </.error_block>
+      <.icon_button
+        type="button"
+        name="hero-x-mark"
+        theme="white"
+        rounded
+        phx-click={@on_cancel_upload}
+        phx-value-ref={entry.ref}
+        sr_text={gettext("cancel")}
+        class="absolute top-2 right-2"
+      />
+    </div>
+    """
+  end
 
   @impl true
   def render(assigns) do
@@ -38,32 +140,74 @@ defmodule LantternWeb.MessageBoard.MessageFormOverlayComponent do
           <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
             {gettext("Oops, something went wrong! Please check the errors below.")}
           </.error_block>
-          <.input
-            field={@form[:name]}
-            type="text"
-            label={gettext("Message title")}
+          <.message_image_field
+            current_image_url={@message.cover}
+            is_removing={@is_removing_cover}
+            upload={@uploads.cover}
+            on_cancel_replace={JS.push("cancel-replace-cover", target: @myself)}
+            on_cancel_upload={JS.push("cancel-upload", target: @myself)}
+            on_replace={JS.push("replace-cover", target: @myself)}
             class="mb-6"
-            phx-debounce="1500"
           />
+          <div class="mb-6 flex items-center gap-4">
+            <.label for={@form[:color].id}>{gettext("Card color")}</.label>
+            <div class="p-1 border-2 border-white rounded-md shadow-lg bg-white -mt-2">
+              <.input
+                field={@form[:color]}
+                type="color"
+                class="w-[52px]"
+                phx-debounce="1500"
+              />
+            </div>
+          </div>
+          <div class="mb-6">
+            <.input
+              field={@form[:name]}
+              type="text"
+              label={gettext("Message title")}
+              maxlength="30"
+              phx-debounce="1500"
+            />
+            <div class="flex justify-end mt-1">
+              <span class="text-xs text-ltrn-subtle">
+                {String.length(@form[:name].value || "")} / 30
+              </span>
+            </div>
+          </div>
+
+          <div class="mb-6">
+            <.input
+              field={@form[:subtitle]}
+              type="text"
+              maxlength="160"
+              phx-debounce="1500"
+            >
+              <:custom_label>
+                <span class="font-bold">{gettext("Message subtitle")}</span>
+                <span class="font-normal"> ({gettext("what appears in the card preview")})</span>
+              </:custom_label>
+            </.input>
+            <div class="flex justify-between items-center mt-1">
+              <span
+                :if={!is_nil(@message.cover) or @uploads.cover.entries != []}
+                class="text-xs text-red-500"
+              >
+                {gettext(
+                  "When using a cover image, subtitles will not be displayed in the message card."
+                )}
+              </span>
+              <span class="text-xs text-ltrn-subtle">
+                {String.length(@form[:subtitle].value || "")} / 160
+              </span>
+            </div>
+          </div>
           <.input
             field={@form[:description]}
             type="markdown"
-            label={gettext("Description")}
+            label={gettext("Contents")}
             class="mb-6"
             phx-debounce="1500"
           />
-          <div class="p-4 rounded-xs mb-6 bg-ltrn-mesh-cyan">
-            <.input
-              field={@form[:is_pinned]}
-              type="toggle"
-              theme="primary"
-              label={gettext("Pin message")}
-            />
-            <p class="mt-4">
-              {gettext("Pinned messages are displayed at the top of the message board.")}
-            </p>
-          </div>
-          <%!-- allow send to selection only when creating message --%>
           <%= if @message.id do %>
             <div :if={@message.send_to == "school"} class="flex items-center gap-2 mb-6">
               <.icon name="hero-user-group" class="w-6 h-6" />
@@ -89,6 +233,7 @@ defmodule LantternWeb.MessageBoard.MessageFormOverlayComponent do
               </.error>
             </fieldset>
           <% end %>
+
           <.live_component
             module={ClassesFieldComponent}
             id="message-form-classes-picker"
@@ -104,6 +249,7 @@ defmodule LantternWeb.MessageBoard.MessageFormOverlayComponent do
               if(@form[:send_to].value != "classes", do: "hidden")
             ]}
           />
+
           <div
             :if={@form[:classes_ids].errors != [] && @form.source.action in [:insert, :update]}
             class="mb-6"
@@ -112,13 +258,29 @@ defmodule LantternWeb.MessageBoard.MessageFormOverlayComponent do
               {msg}
             </.error>
           </div>
-          <.error_block :if={@form.source.action in [:insert, :update]} class="mb-6">
-            {gettext("Oops, something went wrong! Please check the errors above.")}
-          </.error_block>
         </.form>
         <:actions_left :if={@message.id}>
           <.action
-            :if={@message.archived_at}
+            :if={is_nil(@message.archived_at)}
+            type="button"
+            theme="subtle"
+            size="md"
+            phx-click="archive"
+            phx-target={@myself}
+          >
+            {gettext("Archive")}
+          </.action>
+          <.action
+            :if={!is_nil(@message.archived_at)}
+            type="button"
+            theme="subtle"
+            size="md"
+            phx-click="unarchive"
+            phx-target={@myself}
+          >
+            {gettext("Unarchive")}
+          </.action>
+          <.action
             type="button"
             theme="subtle"
             size="md"
@@ -127,27 +289,6 @@ defmodule LantternWeb.MessageBoard.MessageFormOverlayComponent do
             data-confirm={gettext("Are you sure?")}
           >
             {gettext("Delete")}
-          </.action>
-          <.action
-            :if={is_nil(@message.archived_at)}
-            type="button"
-            theme="subtle"
-            size="md"
-            phx-click="archive"
-            phx-target={@myself}
-            data-confirm={gettext("Are you sure? You can unarchive the message later.")}
-          >
-            {gettext("Archive")}
-          </.action>
-          <.action
-            :if={@message.archived_at}
-            type="button"
-            theme="subtle"
-            size="md"
-            phx-click="unarchive"
-            phx-target={@myself}
-          >
-            {gettext("Unarchive")}
           </.action>
         </:actions_left>
         <:actions>
@@ -170,15 +311,22 @@ defmodule LantternWeb.MessageBoard.MessageFormOverlayComponent do
 
   @impl true
   def mount(socket) do
-    socket = assign(socket, :initialized, false)
+    socket =
+      socket
+      |> assign(:initialized, false)
+      |> assign(:is_removing_cover, false)
+      |> assign(:section_id, nil)
+      |> allow_upload(:cover,
+        accept: ~w(.jpg .jpeg .png .webp),
+        max_file_size: 5_000_000,
+        max_entries: 1
+      )
+
     {:ok, socket}
   end
 
   @impl true
-  def update(
-        %{action: {ClassesFieldComponent, {:changed, selected_classes_ids}}},
-        socket
-      ) do
+  def update(%{action: {ClassesFieldComponent, {:changed, selected_classes_ids}}}, socket) do
     socket =
       socket
       |> assign(:selected_classes_ids, selected_classes_ids)
@@ -224,14 +372,49 @@ defmodule LantternWeb.MessageBoard.MessageFormOverlayComponent do
   # event handlers
 
   @impl true
-  def handle_event("validate", %{"message" => message_params}, socket),
-    do: {:noreply, assign_validated_form(socket, message_params)}
+  def handle_event("validate", %{"message" => message_params}, socket) do
+    {:noreply, assign_validated_form(socket, message_params)}
+  end
 
   def handle_event("save", %{"message" => message_params}, socket) do
-    message_params =
-      inject_extra_params(socket, message_params)
+    params = inject_extra_params(socket.assigns, message_params)
 
-    save_message(socket, socket.assigns.message.id, message_params)
+    if socket.assigns.is_removing_cover == true do
+      SupabaseHelpers.remove_object("covers", socket.assigns.message.cover)
+    end
+
+    cover_image_url =
+      consume_uploaded_entries(socket, :cover, fn %{path: file_path}, entry ->
+        {:ok, object} =
+          SupabaseHelpers.upload_object(
+            "covers",
+            entry.client_name,
+            file_path,
+            %{content_type: entry.client_type}
+          )
+
+        image_url =
+          "#{SupabaseHelpers.config().base_url}/storage/v1/object/public/#{URI.encode(object.key)}"
+
+        {:ok, image_url}
+      end)
+      |> case do
+        [] -> nil
+        [image_url] -> image_url
+      end
+
+    cover_image_url =
+      cond do
+        cover_image_url -> cover_image_url
+        socket.assigns.is_removing_cover -> nil
+        true -> socket.assigns.message.cover
+      end
+
+    params =
+      params
+      |> Map.put("cover", cover_image_url)
+
+    save_message(socket, socket.assigns.message.id, params)
   end
 
   def handle_event("delete", _, socket) do
@@ -270,26 +453,21 @@ defmodule LantternWeb.MessageBoard.MessageFormOverlayComponent do
     end
   end
 
-  defp assign_validated_form(socket, params) do
-    params = inject_extra_params(socket, params)
-
-    changeset =
-      socket.assigns.message
-      |> MessageBoard.change_message(params)
-      |> Map.put(:action, :validate)
-
-    assign(socket, :form, to_form(changeset))
+  def handle_event("cancel-upload", %{"ref" => ref}, socket) do
+    {:noreply, cancel_upload(socket, :cover, ref)}
   end
 
-  # inject params handled in backend
-  defp inject_extra_params(socket, params) do
-    params
-    |> Map.put("school_id", socket.assigns.message.school_id)
-    |> Map.put("classes_ids", socket.assigns.selected_classes_ids)
+  def handle_event("replace-cover", _, socket) do
+    {:noreply, assign(socket, :is_removing_cover, true)}
+  end
+
+  def handle_event("cancel-replace-cover", _, socket) do
+    {:noreply, assign(socket, :is_removing_cover, false)}
   end
 
   defp save_message(socket, nil, message_params) do
-    MessageBoard.create_message(message_params)
+    message_params
+    |> MessageBoard.create_message()
     |> case do
       {:ok, message} ->
         notify(__MODULE__, {:created, message}, socket.assigns)
@@ -313,5 +491,23 @@ defmodule LantternWeb.MessageBoard.MessageFormOverlayComponent do
       {:error, %Ecto.Changeset{} = changeset} ->
         {:noreply, assign(socket, :form, to_form(changeset))}
     end
+  end
+
+  defp assign_validated_form(socket, params) do
+    params = inject_extra_params(socket.assigns, params)
+
+    changeset =
+      socket.assigns.message
+      |> MessageBoard.change_message(params)
+      |> Map.put(:action, :validate)
+
+    assign(socket, :form, to_form(changeset))
+  end
+
+  defp inject_extra_params(assigns, params) do
+    params
+    |> Map.put("school_id", assigns.message.school_id)
+    |> Map.put("classes_ids", assigns.selected_classes_ids)
+    |> Map.put("section_id", assigns.message.section_id || assigns.section_id)
   end
 end

--- a/lib/lanttern_web/router.ex
+++ b/lib/lanttern_web/router.ex
@@ -63,7 +63,7 @@ defmodule LantternWeb.Router do
       live "/school/classes", SchoolLive, :manage_classes
       live "/school/staff", SchoolLive, :manage_staff
       live "/school/cycles", SchoolLive, :manage_cycles
-      live "/school/message_board", SchoolLive, :message_board
+      live "/school/message_board", MessageBoard.IndexLive
       live "/school/moment_cards_templates", SchoolLive, :manage_moment_cards_templates
 
       live "/school/students/deactivated", DeactivatedStudentsLive, :index

--- a/priv/repo/migrations/20250806121001_create_sections.exs
+++ b/priv/repo/migrations/20250806121001_create_sections.exs
@@ -1,0 +1,15 @@
+defmodule Lanttern.Repo.Migrations.CreateSections do
+  use Ecto.Migration
+
+  def change do
+    create table(:sections) do
+      add :name, :string
+      add :position, :integer, default: 0, null: false
+      add :school_id, references(:schools, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create unique_index(:sections, [:name, :school_id])
+  end
+end

--- a/priv/repo/migrations/20250806121012_create_messages.exs
+++ b/priv/repo/migrations/20250806121012_create_messages.exs
@@ -1,0 +1,37 @@
+defmodule Lanttern.Repo.Migrations.CreateMessages do
+  use Ecto.Migration
+
+  def change do
+    create table(:messages) do
+      add :name, :text, null: false
+      add :description, :text, null: false
+      add :send_to, :string, null: false
+      add :archived_at, :utc_datetime
+      add :school_id, references(:schools, on_delete: :nothing), null: false
+      add :subtitle, :string
+      add :color, :string
+      add :cover, :string
+      add :position, :integer, default: 0, null: false
+
+      add :section_id, references(:sections, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create unique_index(:messages, [:school_id, :id])
+
+    create constraint(:messages, :valid_send_to, check: "send_to IN ('school', 'classes')")
+
+    create table(:messages_classes) do
+      add :message_id,
+          references(:messages, with: [school_id: :school_id], on_delete: :delete_all),
+          primary_key: true
+
+      # in the future we will handle how to cascade class and school deletion to messages
+      add :class_id, references(:classes, with: [school_id: :school_id], on_delete: :nothing),
+        primary_key: true
+
+      add :school_id, references(:schools, on_delete: :nothing), null: false
+    end
+  end
+end

--- a/test/lanttern/message_board_test.exs
+++ b/test/lanttern/message_board_test.exs
@@ -1,183 +1,176 @@
 defmodule Lanttern.MessageBoardTest do
   use Lanttern.DataCase
 
+  alias Lanttern.MessageBoard
   alias Lanttern.Repo
 
-  alias Lanttern.MessageBoard
+  import Lanttern.Factory
 
-  describe "board_messages" do
+  describe "messages" do
     alias Lanttern.MessageBoard.Message
-
-    import Lanttern.MessageBoardFixtures
-
-    alias Lanttern.SchoolsFixtures
 
     @invalid_attrs %{name: nil, description: nil, send_to: nil}
 
-    test "list_messages/1 returns all board_messages (pinned first. archived not included)" do
-      message = message_fixture()
-      {:ok, _archived} = message_fixture() |> MessageBoard.archive_message()
-
-      # wait 1 second to test ordering by inserted_at
-      Process.sleep(1000)
-      pinned = message_fixture(%{is_pinned: true})
-
-      assert MessageBoard.list_messages() == [pinned, message]
-    end
-
     test "list_messages/1 with archived opt returns all archived board messages" do
-      _message = message_fixture()
-      {:ok, archived} = message_fixture() |> MessageBoard.archive_message()
+      _message = insert(:message)
+      {:ok, archived} = insert(:message) |> MessageBoard.archive_message()
 
-      assert MessageBoard.list_messages(archived: true) == [archived]
+      assert [expected] = MessageBoard.list_messages(archived: true)
+      assert expected.id == archived.id
     end
 
-    test "list_messages/1 with school_id opt returns all board_messages filtered by given school" do
-      school = SchoolsFixtures.school_fixture()
-      message = message_fixture(%{school_id: school.id})
+    test "list_messages/1 with school_id opt returns all messages filtered by given school" do
+      school = insert(:school)
+      section = insert(:section, %{school: school})
+
+      message = insert(:message, %{school: school, section: section, send_to: "school"})
 
       # other fixtures for filtering assertion
-      message_fixture()
+      insert(:message)
 
-      assert MessageBoard.list_messages(school_id: school.id) == [message]
+      [expected_message] = MessageBoard.list_messages(school_id: school.id)
+
+      assert expected_message.id == message.id
     end
 
-    test "list_messages/1 with classes_ids opt returns all board_messages filtered by given classes" do
-      class = SchoolsFixtures.class_fixture()
+    test "list_messages/1 with classes_ids opt returns all messages filtered by given classes" do
+      school = insert(:school)
+      cycle = insert(:cycle, %{school: school})
+      class = insert(:class, %{school: school, cycle: cycle, name: "Class 1"})
+      section = insert(:section, %{school: school})
 
-      message =
-        message_fixture(%{
-          send_to: "classes",
-          school_id: class.school_id,
-          classes_ids: [class.id]
-        })
+      message = insert(:message, %{school: school, send_to: "classes"})
+
+      insert(:message_class, %{message: message, class: class, school: school})
 
       # wait 1 second to test ordering by inserted_at
       Process.sleep(1000)
 
       # school messages should be included in the list
       school_message =
-        message_fixture(%{
-          send_to: "school",
-          school_id: class.school_id
+        insert(:message, %{
+          name: "School message",
+          section: section,
+          school: school,
+          send_to: "school"
         })
 
-      # other fixtures for filtering assertion
-      another_class = SchoolsFixtures.class_fixture(%{school_id: class.school_id})
+      Process.sleep(1000)
 
-      message_fixture(%{
-        send_to: "classes",
-        school_id: class.school_id,
-        classes_ids: [another_class.id]
-      })
+      # other messages for filtering assertion
+      another_class = insert(:class, %{school: school, cycle: cycle})
+      attrs = %{name: "another message", section: section, school: school, send_to: "classes"}
+      another_message = insert(:message, attrs)
+      insert(:message_class, %{message: another_message, class: another_class, school: school})
 
-      message_fixture()
-
-      assert [expected_school_message, expected_message] =
-               MessageBoard.list_messages(school_id: class.school_id, classes_ids: [class.id])
+      assert [expected_message, expected_school_message, expected_another_message] =
+               MessageBoard.list_messages(school_id: school.id)
 
       assert expected_message.id == message.id
       assert expected_school_message.id == school_message.id
+      assert expected_another_message.id == another_message.id
+
+      assert [expected_message, expected_school] =
+               MessageBoard.list_messages(school_id: school.id, classes_ids: [class.id])
+
+      assert expected_school.id == school_message.id
+      assert expected_message.id == message.id
+
+      assert [expected_school, expected_another] =
+               MessageBoard.list_messages(school_id: school.id, classes_ids: [another_class.id])
+
+      assert expected_school.id == school_message.id
+      assert expected_another.id == another_message.id
     end
 
     test "list_student_messages/1 returns all messages relevant to the student" do
-      school = SchoolsFixtures.school_fixture()
-      class = SchoolsFixtures.class_fixture(%{school_id: school.id})
-      student = SchoolsFixtures.student_fixture(%{school_id: school.id, classes_ids: [class.id]})
+      school = insert(:school)
+      cycle = insert(:cycle, %{school: school})
+      class = insert(:class, %{school: school, cycle: cycle})
+      student = insert(:student, %{school: school})
+
+      # Create the association between student and class
+      Repo.insert_all("classes_students", [%{class_id: class.id, student_id: student.id}])
 
       school_message =
-        message_fixture(%{
+        insert(:message, %{
           send_to: "school",
-          school_id: class.school_id
+          school: school
         })
 
       # wait 1 second to test ordering by inserted_at
       Process.sleep(1000)
 
       class_message =
-        message_fixture(%{
+        insert(:message, %{
           send_to: "classes",
-          school_id: class.school_id,
+          school: school,
           classes_ids: [class.id]
         })
 
-      # expect pinned messages first
-      pinned_message =
-        message_fixture(%{
+      insert(:message_class, %{message: class_message, class: class, school: school})
+      # other fixtures for filtering assertion
+      another_class = insert(:class, %{name: "another class", cycle: cycle, school: school})
+
+      another_message =
+        insert(:message, %{
           send_to: "classes",
-          school_id: class.school_id,
-          classes_ids: [class.id],
-          is_pinned: true
+          school: school,
+          classes_ids: [another_class.id]
         })
 
-      # other fixtures for filtering assertion
-      another_class = SchoolsFixtures.class_fixture(%{school_id: class.school_id})
+      insert(:message_class, %{message: another_message, class: another_class, school: school})
 
-      message_fixture(%{
+      insert(:message, %{
         send_to: "classes",
-        school_id: class.school_id,
-        classes_ids: [another_class.id]
-      })
-
-      message_fixture(%{
-        send_to: "classes",
-        school_id: class.school_id,
+        school: school,
         classes_ids: [class.id]
       })
       |> MessageBoard.archive_message()
 
-      message_fixture()
+      insert(:message)
 
-      assert [expected_pinned_message, expected_class_message, expected_school_message] =
+      assert [expected_class_message, expected_school_message] =
                MessageBoard.list_student_messages(student)
 
-      assert expected_pinned_message.id == pinned_message.id
       assert expected_class_message.id == class_message.id
       assert expected_school_message.id == school_message.id
     end
 
     test "get_message!/1 returns the message with given id" do
-      message = message_fixture()
-      assert MessageBoard.get_message!(message.id) == message
+      message = insert(:message)
+      assert expected_message = MessageBoard.get_message!(message.id)
+      assert expected_message.id == message.id
     end
 
     test "create_message/1 with valid data creates a school message" do
-      school = Lanttern.SchoolsFixtures.school_fixture()
-
-      valid_attrs = %{
-        name: "some name",
-        description: "some description",
-        send_to: "school",
-        school_id: school.id
-      }
+      school = insert(:school)
+      valid_attrs = params_with_assocs(:message, %{school: school})
 
       assert {:ok, %Message{} = message} = MessageBoard.create_message(valid_attrs)
-      assert message.name == "some name"
-      assert message.description == "some description"
+      assert message.name == valid_attrs.name
+      assert message.description == valid_attrs.description
       assert message.send_to == "school"
       assert message.school_id == school.id
     end
 
     test "create_message/1 with valid data creates a class message" do
-      school = Lanttern.SchoolsFixtures.school_fixture()
-      class = Lanttern.SchoolsFixtures.class_fixture(%{school_id: school.id})
+      school = insert(:school)
+      cycle = insert(:cycle, %{school: school})
+      class = insert(:class, %{school: school, cycle: cycle})
+      attrs = %{classes_ids: [class.id], school: school, send_to: "classes"}
 
-      valid_attrs = %{
-        name: "some name",
-        description: "some description",
-        send_to: "classes",
-        school_id: school.id,
-        classes_ids: [class.id]
-      }
+      valid_attrs = params_with_assocs(:message, attrs)
 
       assert {:ok, %Message{} = message} = MessageBoard.create_message(valid_attrs)
-      assert message.name == "some name"
-      assert message.description == "some description"
+      assert message.name == valid_attrs.name
+      assert message.description == valid_attrs.description
       assert message.send_to == "classes"
       assert message.school_id == school.id
 
       message = message |> Repo.preload(:classes)
-      assert message.classes == [class]
+      assert [message_classes] = message.message_classes
+      assert message_classes.class_id == class.id
     end
 
     test "create_message/1 with invalid data returns error changeset" do
@@ -185,7 +178,7 @@ defmodule Lanttern.MessageBoardTest do
     end
 
     test "update_message/2 with valid data updates the message" do
-      message = message_fixture() |> Repo.preload(:message_classes)
+      message = insert(:message) |> Repo.preload(:message_classes)
 
       update_attrs = %{
         name: "some updated name",
@@ -198,34 +191,100 @@ defmodule Lanttern.MessageBoardTest do
     end
 
     test "update_message/2 with invalid data returns error changeset" do
-      message = message_fixture() |> Repo.preload(:message_classes)
+      message = insert(:message) |> Repo.preload(:message_classes)
       assert {:error, %Ecto.Changeset{}} = MessageBoard.update_message(message, @invalid_attrs)
-      assert message == MessageBoard.get_message!(message.id) |> Repo.preload(:message_classes)
+
+      assert expected_message =
+               MessageBoard.get_message!(message.id) |> Repo.preload(:message_classes)
+
+      assert message.id == expected_message.id
     end
 
     test "archive_message/1 sets archived_at for given message" do
-      message = message_fixture()
+      message = insert(:message)
 
       assert {:ok, %Message{archived_at: %DateTime{}}} =
                MessageBoard.archive_message(message)
     end
 
     test "unarchive_message/1 sets archived_at to nil for given message" do
-      message = message_fixture(%{archived_at: DateTime.utc_now()})
+      message = insert(:message, %{archived_at: DateTime.utc_now()})
 
       assert {:ok, %Message{archived_at: nil}} =
                MessageBoard.unarchive_message(message)
     end
 
     test "delete_message/1 deletes the message" do
-      message = message_fixture()
+      message = insert(:message)
       assert {:ok, %Message{}} = MessageBoard.delete_message(message)
       assert_raise Ecto.NoResultsError, fn -> MessageBoard.get_message!(message.id) end
     end
 
     test "change_message/1 returns a message changeset" do
-      message = message_fixture() |> Repo.preload(:message_classes)
+      message = insert(:message) |> Repo.preload(:message_classes)
       assert %Ecto.Changeset{} = MessageBoard.change_message(message)
+    end
+  end
+
+  describe "sections" do
+    alias Lanttern.MessageBoard.Section
+
+    @invalid_attrs %{name: nil, position: nil, school_id: nil}
+
+    test "get_section!/1 returns the section with given id" do
+      section = insert(:section)
+      fetched_section = MessageBoard.get_section!(section.id)
+
+      assert fetched_section.id == section.id
+      assert fetched_section.name == section.name
+      assert fetched_section.position == section.position
+      assert fetched_section.school_id == section.school_id
+    end
+
+    test "create_section/1 with valid data creates a section" do
+      valid_attrs = params_for(:section)
+
+      assert {:ok, %Section{} = section} = MessageBoard.create_section(valid_attrs)
+      assert section.name == valid_attrs.name
+      assert section.position == valid_attrs.position
+      assert section.school_id == valid_attrs.school_id
+    end
+
+    test "create_section/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = MessageBoard.create_section(@invalid_attrs)
+    end
+
+    test "update_section/2 with valid data updates the section" do
+      section = insert(:section)
+      update_attrs = params_for(:section)
+
+      assert {:ok, %Section{} = section} = MessageBoard.update_section(section, update_attrs)
+      assert section.name == update_attrs.name
+      assert section.position == update_attrs.position
+      assert section.school_id == update_attrs.school_id
+    end
+
+    test "update_section/2 with invalid data returns error changeset" do
+      section = insert(:section)
+      original_section = MessageBoard.get_section!(section.id)
+
+      assert {:error, %Ecto.Changeset{}} = MessageBoard.update_section(section, @invalid_attrs)
+
+      updated_section = MessageBoard.get_section!(section.id)
+      assert updated_section.name == original_section.name
+      assert updated_section.position == original_section.position
+      assert updated_section.school_id == original_section.school_id
+    end
+
+    test "delete_section/1 deletes the section" do
+      section = insert(:section)
+      assert {:ok, %Section{}} = MessageBoard.delete_section(section)
+      assert_raise Ecto.NoResultsError, fn -> MessageBoard.get_section!(section.id) end
+    end
+
+    test "change_section/1 returns a section changeset" do
+      section = insert(:section)
+      assert %Ecto.Changeset{} = MessageBoard.change_section(section)
     end
   end
 end

--- a/test/lanttern_web/live/pages/guardian/guardian_home_live_test.exs
+++ b/test/lanttern_web/live/pages/guardian/guardian_home_live_test.exs
@@ -2,9 +2,10 @@ defmodule LantternWeb.GuardianHomeLiveTest do
   use LantternWeb.ConnCase
 
   alias Lanttern.IdentityFixtures
-  alias Lanttern.MessageBoardFixtures
+  alias Lanttern.Schools
   alias Lanttern.StudentsCycleInfo
-  alias Lanttern.StudentsCycleInfoFixtures
+
+  import Lanttern.Factory
 
   @live_view_path "/guardian"
 
@@ -20,10 +21,11 @@ defmodule LantternWeb.GuardianHomeLiveTest do
     end
 
     test "display message board", %{conn: conn, user: user} do
-      school_id = user.current_profile.school_id
+      school = Schools.get_school!(user.current_profile.school_id)
 
-      MessageBoardFixtures.message_fixture(%{
-        school_id: school_id,
+      insert(:message, %{
+        send_to: "school",
+        school: school,
         name: "some message name",
         description: "some message description"
       })
@@ -31,17 +33,17 @@ defmodule LantternWeb.GuardianHomeLiveTest do
       {:ok, view, _html} = live(conn, @live_view_path)
 
       assert view |> has_element?("h5", "some message name")
-      assert view |> has_element?("p", "some message description")
     end
 
     test "display student cycle info", %{conn: conn, user: user, student: student} do
-      school_id = user.current_profile.school_id
+      school = Schools.get_school!(user.current_profile.school_id)
+      cycle = Schools.get_cycle!(user.current_profile.current_school_cycle.id)
 
       student_cycle_info =
-        StudentsCycleInfoFixtures.student_cycle_info_fixture(%{
-          school_id: school_id,
-          student_id: student.id,
-          cycle_id: user.current_profile.current_school_cycle.id,
+        insert(:student_cycle_info, %{
+          school: school,
+          student: student,
+          cycle: cycle,
           shared_info: "some shared_info"
         })
 

--- a/test/lanttern_web/live/pages/school/message_board/archive/archived_messages_live_test.exs
+++ b/test/lanttern_web/live/pages/school/message_board/archive/archived_messages_live_test.exs
@@ -1,8 +1,10 @@
 defmodule LantternWeb.ArchivedMessagesLiveTest do
   use LantternWeb.ConnCase
 
+  import Lanttern.Factory
+
   alias Lanttern.MessageBoard
-  alias Lanttern.MessageBoardFixtures
+  alias Lanttern.Schools
 
   @live_view_path "/school/message_board/archive"
 
@@ -10,18 +12,34 @@ defmodule LantternWeb.ArchivedMessagesLiveTest do
 
   describe "Archived message board" do
     test "list archived messages", %{conn: conn, user: user} do
-      school_id = user.current_profile.school_id
+      # school_id = user.current_profile.school_id
+      school = Schools.get_school!(user.current_profile.school_id)
+      section = insert(:section, %{school: school})
 
       message =
-        MessageBoardFixtures.message_fixture(%{
-          school_id: school_id,
+        insert(:message, %{
+          school: school,
+          section: section,
           name: "not archived message abc",
           description: "not archived message desc abc"
         })
 
+      # message =
+      #   MessageBoardFixtures.message_fixture(%{
+      #     school_id: school_id,
+      #     name: "not archived message abc",
+      #     description: "not archived message desc abc"
+      #   })
+
+      # MessageBoardFixtures.message_fixture(%{
+      #   school_id: school_id,
+      #   name: "archived message abc",
+      #   description: "archived message desc abc"
+      # })
       {:ok, archived} =
-        MessageBoardFixtures.message_fixture(%{
-          school_id: school_id,
+        insert(:message, %{
+          school: school,
+          section: section,
           name: "archived message abc",
           description: "archived message desc abc"
         })
@@ -39,10 +57,18 @@ defmodule LantternWeb.ArchivedMessagesLiveTest do
     test "display unarchive and delete buttons to communication manager", context do
       %{conn: conn, user: user} = set_user_permissions(["communication_management"], context)
 
-      school_id = user.current_profile.school_id
+      school = Schools.get_school!(user.current_profile.school_id)
+      section = insert(:section, %{school: school})
+
+      # school_id = user.current_profile.school_id
 
       {:ok, _message} =
-        MessageBoardFixtures.message_fixture(%{school_id: school_id})
+        insert(:message, %{
+          school: school,
+          section: section
+        })
+        # |> MessageBoard.archive_message()
+        # MessageBoardFixtures.message_fixture(%{school_id: school_id})
         |> MessageBoard.archive_message()
 
       {:ok, view, _html} = live(conn, @live_view_path)
@@ -55,10 +81,18 @@ defmodule LantternWeb.ArchivedMessagesLiveTest do
       conn: conn,
       user: user
     } do
-      school_id = user.current_profile.school_id
+      school = Schools.get_school!(user.current_profile.school_id)
+      section = insert(:section, %{school: school})
+
+      # school_id = user.current_profile.school_id
 
       {:ok, _message} =
-        MessageBoardFixtures.message_fixture(%{school_id: school_id})
+        insert(:message, %{
+          school: school,
+          section: section
+        })
+        # |> MessageBoard.archive_message()
+        # MessageBoardFixtures.message_fixture(%{school_id: school_id})
         |> MessageBoard.archive_message()
 
       {:ok, view, _html} = live(conn, @live_view_path)

--- a/test/lanttern_web/live/pages/student/student_home_live_test.exs
+++ b/test/lanttern_web/live/pages/student/student_home_live_test.exs
@@ -1,10 +1,11 @@
 defmodule LantternWeb.StudentHomeLiveTest do
   use LantternWeb.ConnCase
 
+  import Lanttern.Factory
+
   alias Lanttern.IdentityFixtures
-  alias Lanttern.MessageBoardFixtures
+  alias Lanttern.Schools
   alias Lanttern.StudentsCycleInfo
-  alias Lanttern.StudentsCycleInfoFixtures
 
   @live_view_path "/student"
 
@@ -20,10 +21,12 @@ defmodule LantternWeb.StudentHomeLiveTest do
     end
 
     test "display message board", %{conn: conn, user: user} do
-      school_id = user.current_profile.school_id
+      school = Schools.get_school!(user.current_profile.school_id)
+      section = insert(:section, %{school: school})
 
-      MessageBoardFixtures.message_fixture(%{
-        school_id: school_id,
+      insert(:message, %{
+        school: school,
+        section: section,
         name: "some message name",
         description: "some message description"
       })
@@ -35,13 +38,14 @@ defmodule LantternWeb.StudentHomeLiveTest do
     end
 
     test "display student cycle info", %{conn: conn, user: user, student: student} do
-      school_id = user.current_profile.school_id
+      school = Schools.get_school!(user.current_profile.school_id)
+      cycle = Schools.get_cycle!(user.current_profile.current_school_cycle.id)
 
       student_cycle_info =
-        StudentsCycleInfoFixtures.student_cycle_info_fixture(%{
-          school_id: school_id,
-          student_id: student.id,
-          cycle_id: user.current_profile.current_school_cycle.id,
+        insert(:student_cycle_info, %{
+          school: school,
+          student: student,
+          cycle: cycle,
           shared_info: "some shared_info"
         })
 

--- a/test/support/factories/class_factory.ex
+++ b/test/support/factories/class_factory.ex
@@ -1,0 +1,14 @@
+defmodule Lanttern.ClassFactory do
+  @moduledoc false
+  defmacro __using__(_opts) do
+    quote do
+      def class_factory do
+        %Lanttern.Schools.Class{
+          name: "Class name",
+          school: build(:school),
+          cycle: build(:cycle)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/message_class.ex
+++ b/test/support/factories/message_class.ex
@@ -1,0 +1,17 @@
+defmodule Lanttern.MessageClassFactory do
+  @moduledoc """
+  Factory for the MessageClass schema.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      def message_class_factory do
+        %Lanttern.MessageBoard.MessageClass{
+          message: nil,
+          class: nil,
+          school: nil
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/message_factory.ex
+++ b/test/support/factories/message_factory.ex
@@ -1,0 +1,19 @@
+defmodule Lanttern.MessageFactory do
+  @moduledoc """
+  Factory for the Message schema.
+  """
+
+  defmacro __using__(_opts) do
+    quote do
+      def message_factory do
+        %Lanttern.MessageBoard.Message{
+          description: "some description",
+          section: build(:section),
+          name: sequence(:name, &"name_#{&1}"),
+          send_to: "school",
+          school: build(:school)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/section_factory.ex
+++ b/test/support/factories/section_factory.ex
@@ -1,0 +1,19 @@
+defmodule Lanttern.SectionFactory do
+  @moduledoc """
+  Factory for the Section schema.
+  This factory is used to create instances of the Section schema for testing purposes.
+  It provides a default set of attributes for the Section schema, which can be overridden
+  when creating a new instance.
+  """
+  defmacro __using__(_opts) do
+    quote do
+      def section_factory do
+        %Lanttern.MessageBoard.Section{
+          name: sequence(:section_name, &"Section #{&1}"),
+          position: 0,
+          school: insert(:school)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factories/student_cycle_info.ex
+++ b/test/support/factories/student_cycle_info.ex
@@ -1,0 +1,19 @@
+defmodule Lanttern.StudentCycleInfoFactory do
+  @moduledoc """
+  Factory for the Section schema.
+  This factory is used to create instances of the StudentCycleInfo schema for testing purposes.
+  It provides a default set of attributes for the StudentCycleInfo schema, which can be overridden
+  when creating a new instance.
+  """
+  defmacro __using__(_opts) do
+    quote do
+      def student_cycle_info_factory do
+        %Lanttern.StudentsCycleInfo.StudentCycleInfo{
+          student: build(:student),
+          cycle: build(:cycle),
+          school: build(:school)
+        }
+      end
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -4,16 +4,21 @@ defmodule Lanttern.Factory do
   use ExMachina.Ecto, repo: Lanttern.Repo
 
   use Lanttern.AttachmentFactory
+  use Lanttern.ClassFactory
   use Lanttern.CycleFactory
   use Lanttern.ILPCommentAttachmentFactory
   use Lanttern.ILPCommentFactory
   use Lanttern.ILPTemplateFactory
   use Lanttern.MessageBoardFactory
+  use Lanttern.MessageFactory
+  use Lanttern.MessageClassFactory
   use Lanttern.NoteFactory
   use Lanttern.ProfileFactory
   use Lanttern.SchoolFactory
+  use Lanttern.SectionFactory
   use Lanttern.StaffMemberFactory
   use Lanttern.StrandNoteRelationshipFactory
+  use Lanttern.StudentCycleInfoFactory
   use Lanttern.StudentFactory
   use Lanttern.StudentILPFactory
   use Lanttern.StudentRecordFactory


### PR DESCRIPTION

- Add MessageBoard.IndexLive for managing message board sections and messages.
- Create MessageBoard.MessageBoardGridComponent for rendering messages in a grid layout in admin view.
- Introduce MessageBoard.ReorderComponent for reordering sections.
- Create database migrations for sections and messages with appropriate relationships.
- Implement factories for sections, messages, and related entities for testing.