### PR TITLE
Add versioned Claude Code skills for commit, review, and PR workflows

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,93 @@
+---
+description: Craft a Conventional Commit message and create the commit
+disable-model-invocation: true
+---
+
+## Context
+
+- Staged files: !`git diff --cached --name-only`
+- Staged diff: !`git diff --cached`
+- Unstaged changes: !`git status --short`
+- Recent commits (for style reference): !`git log --oneline -10`
+- Current branch: !`git branch --show-current`
+
+## Your task
+
+You are an expert Git commit message architect. Analyze the staged changes above and create a commit following the guidelines below. If no files are staged, inform the user and stop.
+
+### Conventional Commit format
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+### Types
+
+- `feat`: new feature
+- `fix`: bug fix
+- `docs`: documentation only
+- `style`: formatting, whitespace (no logic change)
+- `refactor`: neither fixes a bug nor adds a feature
+- `perf`: performance improvement
+- `test`: adding or correcting tests
+- `build`: build system or dependency changes
+- `ci`: CI configuration changes
+- `chore`: other changes that don't modify src or test files
+
+### Subject line rules
+
+- Under 72 characters
+- Imperative mood ("add" not "added" or "adds")
+- No capital letter after the colon
+- No period at the end
+- Describe WHAT changed conceptually, not WHERE in the code
+
+### Scope
+
+- Use the module, component, or area affected (e.g., "auth", "contexts", "live")
+- Omit if change spans multiple unrelated areas
+
+### Body (optional)
+
+- Explain WHY the change was made
+- Describe non-obvious implications
+- Wrap at 72 characters
+
+### Footer (optional)
+
+- Breaking changes: `BREAKING CHANGE: description`
+- Issue references: `Closes #123` or `Refs #456`
+
+### Authorship
+
+Always append these two lines at the end of the commit message (after a blank line if there's no other footer):
+
+```
+Generated with Claude Code
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+### Key principles
+
+1. **Conceptual over literal**: describe behavior/functionality, not file names or line numbers
+2. **Information density**: succinct but informative — every word adds value
+3. **Future-focused**: write for the developer reading this in 6 months
+4. **Project context**: this is a Phoenix/Elixir educational assessment app — use domain language (assessment, learning management, LiveView, contexts, schemas)
+5. **Multi-file changes**: describe the unified goal, not each file's changes
+
+### Workflow
+
+1. If no staged files → inform the user and stop
+2. Analyze the diff conceptually
+3. Determine type and scope
+4. Check for breaking changes
+5. Craft the subject line (verify: ≤72 chars, imperative, no period)
+6. Decide if body/footer adds value
+7. Stage any unstaged files that belong to this commit if appropriate
+8. Create the commit
+
+Do not explain the commit message to the user — just stage and commit. Show only the git output confirming the commit was created.

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,129 @@
+---
+description: Run precommit checks, write a PR description, get approval, and open the PR on GitHub. Usage: /open-pr [base-branch] (e.g. /open-pr main)
+---
+
+## Your task
+
+The user may have specified a base branch in their invocation (e.g. `/open-pr main` or `/open-pr develop`).
+
+- If a base branch was provided, use it.
+- If no base branch was provided, ask the user: "Which branch should this PR target? (e.g. main, develop)"
+
+Do not proceed until you have the base branch confirmed.
+
+Once you have the base branch, also confirm the current branch by running:
+
+```
+git branch --show-current
+```
+
+---
+
+### Step 1 — Gather diff context
+
+Using the confirmed base branch, run:
+
+```
+git log <base-branch>..HEAD --oneline
+git diff <base-branch>..HEAD --name-only
+git diff <base-branch>..HEAD
+```
+
+---
+
+### Step 2 — Run precommit checks
+
+Run `mix precommit` to verify the code compiles cleanly, passes Credo strict analysis, and all tests pass.
+
+```
+mix precommit
+```
+
+If `mix precommit` fails, **stop immediately** and report the failures to the user. Do not proceed to writing the PR description until all issues are resolved.
+
+---
+
+### Step 3 — Write the PR description
+
+Using the diff context gathered in Step 1, extract:
+
+- The main purpose of the changes
+- Which parts of the system are affected
+- Whether this is a feature, fix, refactor, or other type of change
+- Any issue numbers referenced in commit messages or branch name (e.g. branch `452-link-staff-member-to-classes` → issue #452)
+
+Craft a comprehensive PR description following these principles:
+
+- Focus on WHAT was implemented and WHY, not HOW
+- Write in present tense and active voice
+- Be specific about functionality (e.g. "Adds support for linking staff members to classes" not "Updates staff members")
+- Consider the educational domain (student/teacher/admin experience, assessment, learning management)
+
+Use this structure:
+
+```
+### Summary
+
+A brief 1-2 sentence overview of what this PR accomplishes.
+
+### Related Issues
+
+- Closes #[issue-number]
+
+### What This PR Does
+
+A clear explanation of the functionality added, changed, or fixed:
+
+- New features or capabilities introduced
+- Problems solved or bugs fixed
+- Improvements to existing functionality
+- User-facing changes
+
+### Impact and Scope
+
+- Which parts of the system are affected
+- Which features or modules are touched
+- Any breaking changes or migration requirements
+
+### Testing Considerations
+
+(Include if relevant)
+
+- Key scenarios covered by tests
+- Edge cases considered
+
+### Additional Notes
+
+(Include if relevant)
+
+- Deployment considerations
+- Follow-up tasks
+
+---
+
+Generated with [Claude Code](https://claude.ai/code)
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
+```
+
+---
+
+### Step 4 — Ask for approval
+
+Present the full PR description to the user and ask:
+
+> Does this PR description look good? Reply **yes** to open the PR, or provide feedback to revise it.
+
+Do not proceed until the user approves. If they provide feedback, revise the description and ask again.
+
+---
+
+### Step 5 — Create the PR
+
+Once approved, run:
+
+```
+gh pr create --base <base-branch> --title "<summary line>" --body "<approved description>"
+```
+
+Use the Summary line as the PR title. After the PR is created, display the PR URL to the user.

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,0 +1,71 @@
+---
+description: Review a GitHub PR by number against Lanttern's code quality standards. Usage: /pr-review #123
+---
+
+## Your task
+
+You are an expert code reviewer specializing in Phoenix/Elixir applications, with deep knowledge of the Lanttern educational assessment platform's codebase, patterns, and quality standards.
+
+The user has invoked `/pr-review` with a PR number (e.g. `#123` or just `123`). Extract that number from their input, then follow the setup steps below before reviewing.
+
+**Display the review in the terminal only — do NOT post comments, create GitHub issues, or push/write to any remote repository.**
+
+### Step 1 — Gather PR metadata
+
+Run the following via Bash (replace `<PR>` with the number from user input):
+
+```
+gh pr view <PR> --json number,title,url,state,headRefName,baseRefName,body,closingIssuesReferences,reviews,comments,reviewThreads
+```
+
+This gives you:
+- `headRefName` — the PR branch
+- `baseRefName` — the target branch (may not be `main`)
+- `body` — PR description
+- `closingIssuesReferences` — GitHub issues this PR closes (use these as issue context, same as `--issues` in `/review`)
+- `reviews` / `comments` / `reviewThreads` — full history for PR History Awareness
+
+If `closingIssuesReferences` contains issues, fetch each one for full context:
+
+```
+gh issue view <number> --json number,title,body
+```
+
+### Step 2 — Sync branches locally
+
+Fetch both branches so diffs and history are accurate:
+
+```
+git fetch origin <headRefName> <baseRefName>
+```
+
+### Step 3 — Build diff context
+
+Using the fetched refs, run these via Bash:
+
+```
+git diff origin/<baseRefName>...origin/<headRefName>
+git diff origin/<baseRefName>...origin/<headRefName> --name-only
+git diff origin/<baseRefName>...origin/<headRefName> --stat -- 'lib/**'
+git log origin/<baseRefName>..origin/<headRefName> --oneline
+```
+
+### Step 4 — PR History Awareness
+
+Using the data from Step 1, before reviewing:
+
+- **Previous change requests**: If reviewers previously requested changes, verify those have been addressed. Flag any that remain unresolved.
+- **Prior comments**: Take prior inline review comments into account — do not repeat feedback that was already acknowledged and resolved.
+- **Review state**: Note if the PR was previously approved, dismissed, or had change requests, and consider this in your overall assessment.
+- **Unresolved threads**: Highlight any review threads that appear unresolved based on the PR data.
+
+### Step 5 — Apply the review checklist
+
+Read the shared checklist file at `.claude/skills/review-checklist.md` and apply it in full.
+
+**Framing guidance for this skill**: The overall assessment in the Overview section should be framed as one of:
+- "Approved"
+- "Approved with minor suggestions"
+- "Needs changes before merge"
+
+**IMPORTANT**: Output the review to the terminal only. You may use `gh` in **read-only** mode to fetch PR data (reviews, comments, threads, issues). Do NOT use `gh` to post comments, request changes, approve, or otherwise write to the remote repository. Do not use `git push` or any other write operation against the remote.

--- a/.claude/skills/review-checklist.md
+++ b/.claude/skills/review-checklist.md
@@ -1,0 +1,78 @@
+## Review Checklist
+
+Systematically analyze the following areas:
+
+#### 1. Code Quality and Standards
+- Verify `mix precommit` was run (proper formatting, no Credo issues)
+- Check for proper use of `__MODULE__` instead of self-aliasing
+- Ensure schemas avoid query functions (queries belong in context files)
+- Verify context functions follow `list_items(opts)` pattern with keyword list options
+- Check that `render/1` is at the top of LiveView files
+- Look for proper use of `stream` for potentially large datasets
+
+#### 2. Type Specifications
+- Verify schema `t()` specs include `| Ecto.Association.NotLoaded.t()` for preloaded structures
+- Check `| nil` is included for nullable fields but excluded for required fields
+
+#### 3. Testing Approach
+- Ensure tests focus on behavior (what) not implementation (how)
+- Verify use of `phoenix_test` for front-end testing (`visit/2`, `click_link/2`, etc.)
+- Check that tests cover main user workflows rather than excessive unit tests
+- Confirm pattern matching is used for assertions instead of `length/1` and `hd/1`
+- Verify ExMachina factories are used instead of fixture functions
+- Check factories properly `build` and only `insert` when needed
+
+#### 4. Design Patterns
+- Verify HTTP requests use `:req` (Req) library, not `:httpoison`, `:tesla`, or `:httpc`
+- Check that test functions are in test files, not context modules
+- Ensure new context CRUD functions include `current_user` parameter for access control
+
+#### 5. Security
+- Look for potential security vulnerabilities
+- Consider if `mix sobelow` analysis would be beneficial
+- Verify proper access control implementation
+
+#### 6. Performance
+- Check for N+1 query problems
+- Verify efficient use of Ecto queries and preloading
+- Look for opportunities to use streaming for large datasets
+
+#### 7. Project-Specific Context
+- Ensure alignment with Lanttern's educational assessment domain
+- Verify changes fit within the Phoenix web framework patterns
+- Check consistency with existing codebase patterns
+
+## Output Format
+
+Structure your review as follows:
+
+#### Overview
+- Brief summary of what the change accomplishes
+- Overall assessment (see framing guidance in the calling skill)
+- If GitHub issues were provided, state whether they are addressed
+
+#### Critical Issues
+- List any blocking issues that must be fixed before merge
+- Include specific file locations and line references when relevant
+
+#### Suggestions for Improvement
+- Non-blocking improvements that would enhance code quality
+- Best practice recommendations
+- Performance optimizations
+
+#### Positive Observations
+- Highlight good patterns and implementations
+- Acknowledge particularly well-done aspects
+
+#### Questions
+- Any clarifications needed about implementation decisions
+- Areas where the intent is unclear
+
+## Review Principles
+
+1. **Be Specific**: Reference exact files and line numbers
+2. **Be Constructive**: Explain why something should change and suggest alternatives
+3. **Be Thorough**: Analyze the actual implementation, don't just skim
+4. **Be Balanced**: Acknowledge good work alongside suggestions
+5. **Focus on Impact**: Prioritize issues by their effect on functionality, maintainability, and security
+6. **Teach**: When suggesting changes, explain the reasoning and project context

--- a/.claude/skills/review/SKILL.md
+++ b/.claude/skills/review/SKILL.md
@@ -1,0 +1,62 @@
+---
+description: Review the current branch locally against Lanttern's code quality standards before opening a PR. Usage: /review [base-branch] [--issues #12,#34]
+---
+
+## Your task
+
+You are an expert code reviewer specializing in Phoenix/Elixir applications, with deep knowledge of the Lanttern educational assessment platform's codebase, patterns, and quality standards.
+
+The user has invoked `/review`. This is a **pre-PR local review** — the goal is to catch issues before the PR is opened. Parse the user's input for:
+
+- **Base branch** (optional): the branch to diff against. Defaults to `main` if not provided.
+- **GitHub issues** (optional): one or more issue numbers passed via `--issues` (e.g. `--issues #12,#34` or `--issues 12 34`). These represent the issues this change intends to resolve.
+
+**Display the review in the terminal only — do NOT post comments, create GitHub issues, or push/write to any remote repository.**
+
+### Step 1 — Identify branches
+
+Run:
+
+```
+git branch --show-current
+```
+
+This gives you `headBranch`. The base branch is either what the user provided or `main`.
+
+### Step 2 — Fetch base branch
+
+Ensure the base branch is up to date:
+
+```
+git fetch origin <baseBranch>
+```
+
+### Step 3 — Build diff context
+
+```
+git diff origin/<baseBranch>...<headBranch>
+git diff origin/<baseBranch>...<headBranch> --name-only
+git diff origin/<baseBranch>...<headBranch> --stat -- 'lib/**'
+git log origin/<baseBranch>..<headBranch> --oneline
+```
+
+### Step 4 — GitHub issues context (if provided)
+
+If the user supplied issue numbers, fetch each issue's title and body for context:
+
+```
+gh issue view <number> --json number,title,body
+```
+
+Use this to understand the intent behind the change and verify the implementation addresses the described problem or feature.
+
+### Step 5 — Apply the review checklist
+
+Read the shared checklist file at `.claude/skills/review-checklist.md` and apply it in full.
+
+**Framing guidance for this skill**: The overall assessment in the Overview section should be framed as one of:
+- "Ready to open as a PR"
+- "Needs minor changes before opening"
+- "Needs significant changes before opening"
+
+**IMPORTANT**: Output the review to the terminal only. Do not use `gh` or `git` in write mode. Do not push, comment, or create anything on the remote.

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ npm-debug.log
 # LLMs
 CLAUDE.md
 .windsurfrules
-.claude
+.claude/settings.local.json
 
 # Elixir LS
 .elixir_ls

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,10 @@
 Lanttern is a web application written using the Phoenix web framework for educational assessment and learning management.
 
+## Legacy tables
+
+Some database tables are retained for historical/data purposes but are no longer backed by application code.
+See [`docs/legacy.md`](docs/legacy.md) for the full list and context.
+
 ## Project guidelines
 
 - We do use `mix credo` (with `--strict` flag), `mix sobelow`, and tests for code quality, security analysis, and ensuring that everything is working as expected. That being said, use those only when strictly necessary to save some tokens, but always remember the developer to run those tasks
@@ -7,7 +12,6 @@ Lanttern is a web application written using the Phoenix web framework for educat
 - Use Tidewave MCP for development tooling
 - do not alias the module in itself. prefer using `__MODULE__`
 - do not create test functions in contexts — create them in the test file itself
-- use the developer subagents for code review and commit message writing, if available
 
 ## Design patterns
 
@@ -49,12 +53,6 @@ end
 - Use `non_neg_integer()` for position fields
 - Always include `| Ecto.Association.NotLoaded.t()` for preloaded structures
 - Always include `| nil` for nullable fields
-
-## PR size check
-
-We should aim for PRs with a maximum of 500 loc (additions and deletions) considering only the `lib` folder.
-
-It's important to periodically update the `main` branch, and check for size with `git diff --stat main lib`.
 
 ## Temporary guidelines
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,21 @@ Lanttern.Identity.cleanup_expired_login_codes()
 
 Use the versioned `AGENTS.md` as reference for setting your own LLM agent instruction (e.g. copy and paste the content into a `CLAUDE.md` file for working with Claude Code).
 
+### Claude skills usage
+
+```
+/commit                          # creates commit message (based on staged) and commits
+
+/open-pr main                    # run precommit checks and creates the PR
+
+/review                          # diff current branch vs main
+/review develop                  # diff vs develop
+/review --issues #12,#34         # with issue context
+/review develop --issues 12      # both
+
+/pr-review 123                   # GitHub PR (issues auto-detected from PR)
+```
+
 ## Restoring a PostgreSQL Backup
 
 ### Requirements


### PR DESCRIPTION
### Summary

Adds versioned Claude Code skills (`/commit`, `/open-pr`, `/review`, `/pr-review`) to the repository, enabling standardized AI-assisted developer workflows for commits, PR creation, and code review.

### What This PR Does

- Introduces four Claude skills covering the full PR lifecycle: commit message generation, pre-PR local review, PR creation with precommit gating, and GitHub PR review
- Adds a shared `review-checklist.md` used by both `/review` and `/pr-review` to enforce Lanttern's code quality standards (Credo, test patterns, type specs, security)
- Updates `.gitignore` to track the `.claude/` directory (versioning skills with the repo) while keeping `settings.local.json` private
- Syncs `AGENTS.md` with current project guidelines, adding the legacy tables section and removing outdated references to developer subagents
- Documents skill usage in `README.md` under the LLM agents section

### Impact and Scope

- No application code or database changes — tooling and documentation only
- Skills are stored under `.claude/skills/` and are available to any developer using Claude Code on this repo

### Additional Notes

- Remember to run `mix credo --strict`, `mix sobelow`, and the test suite as part of normal development — the `/open-pr` skill enforces this via `mix precommit`

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>