### PR TITLE
Separate student/year association from student/class via StudentCycleInfo

### DIFF
--- a/lib/lanttern/reporting.ex
+++ b/lib/lanttern/reporting.ex
@@ -671,40 +671,36 @@ defmodule Lanttern.Reporting do
       year: %Year{} = year
     } = report_card
 
+    cycle_id_for_classes = cycle.parent_cycle_id || cycle.id
+
     where_cycle_filter =
       if cycle.parent_cycle_id,
-        do: dynamic([_s, _c, _y, cy], cy.id == ^cycle.parent_cycle_id),
+        do: dynamic([_s, sci], sci.cycle_id == ^cycle.parent_cycle_id),
         else: true
+
+    classes_query =
+      from(c in Lanttern.Schools.Class,
+        join: y in assoc(c, :years),
+        where: y.id == ^year.id,
+        where: c.cycle_id == ^cycle_id_for_classes
+      )
 
     from(
       s in Student,
-      join: c in assoc(s, :classes),
-      join: y in assoc(c, :years),
-      join: cy in assoc(c, :cycle),
+      join: sci in assoc(s, :cycles_info),
+      on: sci.year_id == ^year.id,
       left_join: sr in StudentReportCard,
       on: sr.student_id == s.id and sr.report_card_id == ^report_card_id,
       where: is_nil(sr),
-      where: y.id == ^year.id,
       where: ^where_cycle_filter,
       where: is_nil(s.deactivated_at),
-      order_by: [asc: c.name, asc: s.name],
-      preload: [classes: c]
+      order_by: [asc: s.name],
+      preload: [classes: ^classes_query],
+      select_merge: %{profile_picture_url: sci.profile_picture_url},
+      distinct: s.id
     )
-    |> maybe_load_profile_picture_url(cycle)
     |> Repo.all()
   end
-
-  defp maybe_load_profile_picture_url(queryable, %{parent_cycle_id: cycle_id})
-       when not is_nil(cycle_id) do
-    from(
-      s in queryable,
-      left_join: sci in assoc(s, :cycles_info),
-      on: sci.cycle_id == ^cycle_id,
-      select_merge: %{profile_picture_url: sci.profile_picture_url}
-    )
-  end
-
-  defp maybe_load_profile_picture_url(queryable, _), do: queryable
 
   @doc """
   Returns the list of cycles related to student report cards.

--- a/lib/lanttern/students_cycle_info/student_cycle_info.ex
+++ b/lib/lanttern/students_cycle_info/student_cycle_info.ex
@@ -12,6 +12,7 @@ defmodule Lanttern.StudentsCycleInfo.StudentCycleInfo do
   alias Lanttern.Schools.School
   alias Lanttern.Schools.Student
   alias Lanttern.StudentsCycleInfo.StudentCycleInfoAttachment
+  alias Lanttern.Taxonomy.Year
 
   @type t :: %__MODULE__{
           id: pos_integer(),
@@ -20,8 +21,10 @@ defmodule Lanttern.StudentsCycleInfo.StudentCycleInfo do
           profile_picture_url: String.t(),
           student: Student.t(),
           student_id: pos_integer(),
-          cycle: Cycle.t(),
+          cycle: Cycle.t() | Ecto.Association.NotLoaded.t(),
           cycle_id: pos_integer(),
+          year: Year.t() | Ecto.Association.NotLoaded.t(),
+          year_id: pos_integer(),
           school: School.t(),
           school_id: pos_integer(),
           student_cycle_info_attachments: [StudentCycleInfoAttachment.t()],
@@ -38,6 +41,7 @@ defmodule Lanttern.StudentsCycleInfo.StudentCycleInfo do
 
     belongs_to :student, Student
     belongs_to :cycle, Cycle
+    belongs_to :year, Year
     belongs_to :school, School
 
     has_many :student_cycle_info_attachments, StudentCycleInfoAttachment
@@ -54,9 +58,10 @@ defmodule Lanttern.StudentsCycleInfo.StudentCycleInfo do
       :profile_picture_url,
       :student_id,
       :cycle_id,
+      :year_id,
       :school_id
     ])
-    |> validate_required([:student_id, :cycle_id, :school_id])
+    |> validate_required([:student_id, :cycle_id, :year_id, :school_id])
     |> foreign_key_constraint(
       :student_id,
       name: :students_cycle_info_student_id_fkey,

--- a/lib/lanttern_web/live/pages/guardian/guardian_home_live.ex
+++ b/lib/lanttern_web/live/pages/guardian/guardian_home_live.ex
@@ -57,24 +57,6 @@ defmodule LantternWeb.GuardianHomeLive do
         socket.assigns.current_cycle.id,
         check_attachments_for: :student
       )
-      |> case do
-        nil ->
-          # create student cycle info if it does not exist
-          {:ok, info} =
-            StudentsCycleInfo.create_student_cycle_info(
-              %{
-                school_id: socket.assigns.student.school_id,
-                student_id: socket.assigns.student.id,
-                cycle_id: socket.assigns.current_cycle.id
-              },
-              log_profile_id: socket.assigns.current_user.current_profile_id
-            )
-
-          info
-
-        student_cycle_info ->
-          student_cycle_info
-      end
 
     assign(socket, :student_cycle_info, student_cycle_info)
   end

--- a/lib/lanttern_web/live/pages/guardian/guardian_home_live.html.heex
+++ b/lib/lanttern_web/live/pages/guardian/guardian_home_live.html.heex
@@ -46,7 +46,10 @@
     current_profile={@current_user.current_profile}
   />
   <.responsive_container
-    :if={@student_cycle_info.shared_info || @student_cycle_info.has_attachments}
+    :if={
+      @student_cycle_info &&
+        (@student_cycle_info.shared_info || @student_cycle_info.has_attachments)
+    }
     class="mt-20"
   >
     <h3 class="font-display font-black text-xl">

--- a/lib/lanttern_web/live/pages/school/students/id/about_component.ex
+++ b/lib/lanttern_web/live/pages/school/students/id/about_component.ex
@@ -24,104 +24,114 @@ defmodule LantternWeb.StudentLive.AboutComponent do
         show_deactivated
         show_tags
       />
-      <div class="flex items-start gap-20 mt-12">
-        <div class="flex-1">
-          <div class="pb-6 border-b-2 border-ltrn-light">
-            <h4 class="font-display font-black text-lg">{gettext("School area")}</h4>
-            <p class="flex items-center gap-2 mt-2">
-              <.icon name="hero-information-circle-mini" class="text-ltrn-subtle" />
-              {gettext("Access to information in this area is restricted to school staff")}
-            </p>
+      <%= if @student_cycle_info do %>
+        <div class="flex items-start gap-20 mt-12">
+          <div class="flex-1">
+            <div class="pb-6 border-b-2 border-ltrn-light">
+              <h4 class="font-display font-black text-lg">{gettext("School area")}</h4>
+              <p class="flex items-center gap-2 mt-2">
+                <.icon name="hero-information-circle-mini" class="text-ltrn-subtle" />
+                {gettext("Access to information in this area is restricted to school staff")}
+              </p>
+            </div>
+            <div class="py-10 border-b border-ltrn-light">
+              <%= if @is_editing_student_school_info do %>
+                <.live_component
+                  module={StudentCycleInfoFormComponent}
+                  id={"#{@student_cycle_info.id}-school-info-form"}
+                  student_cycle_info={@student_cycle_info}
+                  type="school"
+                  label={gettext("Add school area student info...")}
+                  current_profile_id={@current_user.current_profile_id}
+                  notify_component={@myself}
+                />
+              <% else %>
+                <.empty_state_simple :if={!@student_cycle_info.school_info}>
+                  {gettext("No information about student in school area")}
+                </.empty_state_simple>
+                <.markdown text={@student_cycle_info.school_info} />
+                <.action
+                  type="button"
+                  icon_name="hero-pencil-mini"
+                  class="mt-10"
+                  phx-click="edit_student_school_info"
+                  phx-target={@myself}
+                  disabled={@is_editing_shared_info}
+                >
+                  {gettext("Edit information")}
+                </.action>
+              <% end %>
+            </div>
+            <.live_component
+              module={AttachmentAreaComponent}
+              id="student-cycle-info-school-attachments"
+              class="mt-10"
+              student_cycle_info_id={@student_cycle_info.id}
+              shared_with_student={false}
+              title={gettext("School area attachments")}
+              allow_editing
+              current_user={@current_user}
+            />
           </div>
-          <div class="py-10 border-b border-ltrn-light">
-            <%= if @is_editing_student_school_info do %>
-              <.live_component
-                module={StudentCycleInfoFormComponent}
-                id={"#{@student_cycle_info.id}-school-info-form"}
-                student_cycle_info={@student_cycle_info}
-                type="school"
-                label={gettext("Add school area student info...")}
-                current_profile_id={@current_user.current_profile_id}
-                notify_component={@myself}
-              />
-            <% else %>
-              <.empty_state_simple :if={!@student_cycle_info.school_info}>
-                {gettext("No information about student in school area")}
-              </.empty_state_simple>
-              <.markdown text={@student_cycle_info.school_info} />
-              <.action
-                type="button"
-                icon_name="hero-pencil-mini"
-                class="mt-10"
-                phx-click="edit_student_school_info"
-                phx-target={@myself}
-                disabled={@is_editing_shared_info}
-              >
-                {gettext("Edit information")}
-              </.action>
-            <% end %>
+          <div class="flex-1">
+            <div class="pb-6 border-b-2 border-ltrn-student-lighter">
+              <h4 class="font-display font-black text-lg text-ltrn-student-dark">
+                {gettext("Student area")}
+              </h4>
+              <p class="flex items-center gap-2 mt-2">
+                <.icon name="hero-information-circle-mini" class="text-ltrn-subtle" />
+                {gettext("Information shared with student and guardians")}
+              </p>
+            </div>
+            <div class="py-10 border-b border-ltrn-student-lighter">
+              <%= if @is_editing_shared_info do %>
+                <.live_component
+                  module={StudentCycleInfoFormComponent}
+                  id={"#{@student_cycle_info.id}-student-info-form"}
+                  student_cycle_info={@student_cycle_info}
+                  type="student"
+                  label={gettext("Add student area info...")}
+                  current_profile_id={@current_user.current_profile_id}
+                  notify_component={@myself}
+                />
+              <% else %>
+                <.empty_state_simple :if={!@student_cycle_info.shared_info}>
+                  {gettext("No information in student area")}
+                </.empty_state_simple>
+                <.markdown text={@student_cycle_info.shared_info} />
+                <.action
+                  type="button"
+                  icon_name="hero-pencil-mini"
+                  class="mt-10"
+                  phx-click="edit_student_shared_info"
+                  phx-target={@myself}
+                  disabled={@is_editing_student_school_info}
+                >
+                  {gettext("Edit information")}
+                </.action>
+              <% end %>
+            </div>
+            <.live_component
+              module={AttachmentAreaComponent}
+              id="student-cycle-info-student-attachments"
+              class="mt-10"
+              student_cycle_info_id={@student_cycle_info.id}
+              shared_with_student
+              title={gettext("Student area attachments")}
+              allow_editing
+              current_user={@current_user}
+            />
           </div>
-          <.live_component
-            module={AttachmentAreaComponent}
-            id="student-cycle-info-school-attachments"
-            class="mt-10"
-            student_cycle_info_id={@student_cycle_info.id}
-            shared_with_student={false}
-            title={gettext("School area attachments")}
-            allow_editing
-            current_user={@current_user}
-          />
         </div>
-        <div class="flex-1">
-          <div class="pb-6 border-b-2 border-ltrn-student-lighter">
-            <h4 class="font-display font-black text-lg text-ltrn-student-dark">
-              {gettext("Student area")}
-            </h4>
-            <p class="flex items-center gap-2 mt-2">
-              <.icon name="hero-information-circle-mini" class="text-ltrn-subtle" />
-              {gettext("Information shared with student and guardians")}
-            </p>
-          </div>
-          <div class="py-10 border-b border-ltrn-student-lighter">
-            <%= if @is_editing_shared_info do %>
-              <.live_component
-                module={StudentCycleInfoFormComponent}
-                id={"#{@student_cycle_info.id}-student-info-form"}
-                student_cycle_info={@student_cycle_info}
-                type="student"
-                label={gettext("Add student area info...")}
-                current_profile_id={@current_user.current_profile_id}
-                notify_component={@myself}
-              />
-            <% else %>
-              <.empty_state_simple :if={!@student_cycle_info.shared_info}>
-                {gettext("No information in student area")}
-              </.empty_state_simple>
-              <.markdown text={@student_cycle_info.shared_info} />
-              <.action
-                type="button"
-                icon_name="hero-pencil-mini"
-                class="mt-10"
-                phx-click="edit_student_shared_info"
-                phx-target={@myself}
-                disabled={@is_editing_student_school_info}
-              >
-                {gettext("Edit information")}
-              </.action>
-            <% end %>
-          </div>
-          <.live_component
-            module={AttachmentAreaComponent}
-            id="student-cycle-info-student-attachments"
-            class="mt-10"
-            student_cycle_info_id={@student_cycle_info.id}
-            shared_with_student
-            title={gettext("Student area attachments")}
-            allow_editing
-            current_user={@current_user}
-          />
+      <% else %>
+        <div class="mt-12">
+          <.empty_state_simple>
+            {gettext(
+              "To enable the student info area, please assign a year for the current cycle in the student edit form."
+            )}
+          </.empty_state_simple>
         </div>
-      </div>
+      <% end %>
       <div class="mt-20">
         <h4 class="font-display font-black text-lg mb-4">{gettext("Guardians")}</h4>
         <.empty_state_simple :if={Enum.empty?(@student.guardians)}>
@@ -137,7 +147,7 @@ defmodule LantternWeb.StudentLive.AboutComponent do
         </.fluid_grid>
       </div>
       <.live_component
-        :if={@is_editing_profile_picture}
+        :if={@is_editing_profile_picture && @student_cycle_info}
         module={StudentCycleProfilePictureOverlayComponent}
         id="profile_picture_modal"
         student_cycle_info={@student_cycle_info}
@@ -225,24 +235,6 @@ defmodule LantternWeb.StudentLive.AboutComponent do
         socket.assigns.student.id,
         socket.assigns.current_user.current_profile.current_school_cycle.id
       )
-      |> case do
-        nil ->
-          # create student cycle info if it does not exist
-          {:ok, info} =
-            StudentsCycleInfo.create_student_cycle_info(
-              %{
-                school_id: socket.assigns.student.school_id,
-                student_id: socket.assigns.student.id,
-                cycle_id: socket.assigns.current_user.current_profile.current_school_cycle.id
-              },
-              log_profile_id: socket.assigns.current_user.current_profile_id
-            )
-
-          info
-
-        student_cycle_info ->
-          student_cycle_info
-      end
 
     assign(socket, :student_cycle_info, student_cycle_info)
   end

--- a/lib/lanttern_web/live/pages/student/student_home_live.ex
+++ b/lib/lanttern_web/live/pages/student/student_home_live.ex
@@ -57,24 +57,6 @@ defmodule LantternWeb.StudentHomeLive do
         socket.assigns.current_cycle.id,
         check_attachments_for: :student
       )
-      |> case do
-        nil ->
-          # create student cycle info if it does not exist
-          {:ok, info} =
-            StudentsCycleInfo.create_student_cycle_info(
-              %{
-                school_id: socket.assigns.student.school_id,
-                student_id: socket.assigns.student.id,
-                cycle_id: socket.assigns.current_cycle.id
-              },
-              log_profile_id: socket.assigns.current_user.current_profile_id
-            )
-
-          info
-
-        student_cycle_info ->
-          student_cycle_info
-      end
 
     assign(socket, :student_cycle_info, student_cycle_info)
   end

--- a/lib/lanttern_web/live/pages/student/student_home_live.html.heex
+++ b/lib/lanttern_web/live/pages/student/student_home_live.html.heex
@@ -46,7 +46,10 @@
     current_profile={@current_user.current_profile}
   />
   <.responsive_container
-    :if={@student_cycle_info.shared_info || @student_cycle_info.has_attachments}
+    :if={
+      @student_cycle_info &&
+        (@student_cycle_info.shared_info || @student_cycle_info.has_attachments)
+    }
     class="mt-20"
   >
     <h3 class="font-display font-black text-xl">

--- a/lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex
@@ -25,7 +25,9 @@ defmodule LantternWeb.Schools.StudentFormOverlayComponent do
   alias Lanttern.Identity.User
   alias Lanttern.Schools
   alias Lanttern.Schools.Student
+  alias Lanttern.StudentsCycleInfo
   alias Lanttern.StudentTags
+  alias Lanttern.Taxonomy
 
   # shared
 
@@ -61,6 +63,16 @@ defmodule LantternWeb.Schools.StudentFormOverlayComponent do
             label={gettext("Date of birth")}
             class="mb-6"
             phx-debounce="1500"
+          />
+          <.input
+            id={"year-select-#{@id}"}
+            name="year_id"
+            type="select"
+            label={gettext("Year in %{cycle} (current cycle)", cycle: @current_cycle.name)}
+            value={@selected_year_id}
+            options={@year_options}
+            prompt={gettext("Select a year...")}
+            class="mb-6"
           />
           <.live_component
             module={ClassesFieldComponent}
@@ -269,6 +281,7 @@ defmodule LantternWeb.Schools.StudentFormOverlayComponent do
   defp initialize(%{assigns: %{initialized: false}} = socket) do
     socket
     |> assign_form()
+    |> assign_year_options()
     |> assign_student_tags()
     |> assign_guardians()
     |> assign_guardian_user_emails()
@@ -328,6 +341,28 @@ defmodule LantternWeb.Schools.StudentFormOverlayComponent do
 
   defp ensure_guardians_preload(student), do: student
 
+  defp assign_year_options(socket) do
+    year_options =
+      Taxonomy.list_years()
+      |> Enum.map(&{&1.name, &1.id})
+
+    cycle_id = socket.assigns.current_cycle.id
+    student = socket.assigns.student
+
+    student_cycle_info =
+      if student.id do
+        StudentsCycleInfo.get_student_cycle_info_by_student_and_cycle(student.id, cycle_id)
+      end
+
+    selected_year_id =
+      if student_cycle_info, do: student_cycle_info.year_id, else: nil
+
+    socket
+    |> assign(:year_options, year_options)
+    |> assign(:selected_year_id, selected_year_id)
+    |> assign(:student_cycle_info, student_cycle_info)
+  end
+
   defp assign_student_tags(socket) do
     student_tags = StudentTags.list_student_tags(school_id: socket.assigns.student.school_id)
 
@@ -370,11 +405,13 @@ defmodule LantternWeb.Schools.StudentFormOverlayComponent do
   @impl true
   def handle_event("validate", %{"student" => student_params} = params, socket) do
     guardian_emails = extract_guardian_emails(params)
+    year_id = extract_year_id(params)
 
     socket =
       socket
       |> assign(:guardian_user_emails, guardian_emails)
       |> assign(:guardian_emails_error, nil)
+      |> assign(:selected_year_id, year_id)
       |> assign_validated_form(student_params)
 
     {:noreply, socket}
@@ -417,6 +454,7 @@ defmodule LantternWeb.Schools.StudentFormOverlayComponent do
   def handle_event("save", %{"student" => student_params} = params, socket) do
     student_params = inject_extra_params(socket, student_params)
     guardian_emails = extract_guardian_emails(params)
+    year_id = extract_year_id(params)
 
     invalid_emails =
       guardian_emails
@@ -432,7 +470,7 @@ defmodule LantternWeb.Schools.StudentFormOverlayComponent do
          gettext("Some guardian emails are invalid. Please check and try again.")
        )}
     else
-      save_student(socket, student_params, guardian_emails)
+      save_student(socket, student_params, guardian_emails, year_id)
     end
   end
 
@@ -492,7 +530,7 @@ defmodule LantternWeb.Schools.StudentFormOverlayComponent do
     |> Map.put("guardians_ids", socket.assigns.selected_guardians_ids)
   end
 
-  defp save_student(socket, student_params, guardian_emails) do
+  defp save_student(socket, student_params, guardian_emails, year_id) do
     {student_or_nil, action} =
       if socket.assigns.student.id,
         do: {socket.assigns.student, :updated},
@@ -507,19 +545,25 @@ defmodule LantternWeb.Schools.StudentFormOverlayComponent do
         guardian_emails
       )
 
-    handle_save_result(result, action, socket)
+    handle_save_result(result, action, socket, year_id)
   end
 
-  defp handle_save_result({:ok, student}, action, socket) do
+  defp handle_save_result({:ok, student}, action, socket, year_id) do
+    save_student_cycle_info(student, socket, year_id)
     notify(__MODULE__, {action, student}, socket.assigns)
     {:noreply, push_patch(socket, to: socket.assigns.close_path)}
   end
 
-  defp handle_save_result({:error, {:student, %Ecto.Changeset{} = changeset}}, _action, socket) do
+  defp handle_save_result(
+         {:error, {:student, %Ecto.Changeset{} = changeset}},
+         _action,
+         socket,
+         _year_id
+       ) do
     {:noreply, assign(socket, :form, to_form(changeset))}
   end
 
-  defp handle_save_result({:error, :guardian_accounts}, _action, socket) do
+  defp handle_save_result({:error, :guardian_accounts}, _action, socket, _year_id) do
     socket =
       assign(
         socket,
@@ -529,6 +573,43 @@ defmodule LantternWeb.Schools.StudentFormOverlayComponent do
 
     {:noreply, socket}
   end
+
+  defp save_student_cycle_info(_student, _socket, nil), do: :noop
+  defp save_student_cycle_info(_student, _socket, ""), do: :noop
+
+  defp save_student_cycle_info(student, socket, year_id) do
+    cycle_id = socket.assigns.current_cycle.id
+    profile_id = socket.assigns.current_user.current_profile_id
+
+    year_id =
+      if is_binary(year_id), do: String.to_integer(year_id), else: year_id
+
+    case socket.assigns.student_cycle_info do
+      nil ->
+        StudentsCycleInfo.create_student_cycle_info(
+          %{
+            school_id: student.school_id,
+            student_id: student.id,
+            cycle_id: cycle_id,
+            year_id: year_id
+          },
+          log_profile_id: profile_id
+        )
+
+      existing ->
+        if existing.year_id != year_id do
+          StudentsCycleInfo.update_student_cycle_info(
+            existing,
+            %{year_id: year_id},
+            log_profile_id: profile_id
+          )
+        end
+    end
+  end
+
+  defp extract_year_id(%{"year_id" => ""}), do: nil
+  defp extract_year_id(%{"year_id" => year_id}), do: year_id
+  defp extract_year_id(_), do: nil
 
   defp ensure_at_least_one_email([]), do: [""]
   defp ensure_at_least_one_email(emails), do: emails

--- a/priv/repo/migrations/20260326163603_add_year_id_to_students_cycle_info.exs
+++ b/priv/repo/migrations/20260326163603_add_year_id_to_students_cycle_info.exs
@@ -1,0 +1,11 @@
+defmodule Lanttern.Repo.Migrations.AddYearIdToStudentsCycleInfo do
+  use Ecto.Migration
+
+  def change do
+    alter table(:students_cycle_info) do
+      add :year_id, references(:years, on_delete: :nothing)
+    end
+
+    create index(:students_cycle_info, [:year_id])
+  end
+end

--- a/test/lanttern/reporting_test.exs
+++ b/test/lanttern/reporting_test.exs
@@ -542,6 +542,7 @@ defmodule Lanttern.ReportingTest do
         Lanttern.StudentsCycleInfoFixtures.student_cycle_info_fixture(%{
           school_id: school.id,
           cycle_id: parent_cycle.id,
+          year_id: year.id,
           student_id: student_a_a.id,
           profile_picture_url: "http://example-a-a.com/profile_picture.jpg"
         })
@@ -550,6 +551,7 @@ defmodule Lanttern.ReportingTest do
         Lanttern.StudentsCycleInfoFixtures.student_cycle_info_fixture(%{
           school_id: school.id,
           cycle_id: parent_cycle.id,
+          year_id: year.id,
           student_id: student_j_k.id,
           profile_picture_url: "http://example-j-k.com/profile_picture.jpg"
         })

--- a/test/lanttern/students_cycle_info_test.exs
+++ b/test/lanttern/students_cycle_info_test.exs
@@ -108,6 +108,7 @@ defmodule Lanttern.StudentsCycleInfoTest do
       school = SchoolsFixtures.school_fixture()
       student = SchoolsFixtures.student_fixture(%{school_id: school.id})
       cycle = SchoolsFixtures.cycle_fixture(%{school_id: school.id})
+      year = Lanttern.TaxonomyFixtures.year_fixture()
 
       # profile to test log
       profile = Lanttern.IdentityFixtures.staff_member_profile_fixture()
@@ -118,7 +119,8 @@ defmodule Lanttern.StudentsCycleInfoTest do
         profile_picture_url: "some profile_picture",
         school_id: school.id,
         student_id: student.id,
-        cycle_id: cycle.id
+        cycle_id: cycle.id,
+        year_id: year.id
       }
 
       assert {:ok, %StudentCycleInfo{} = student_cycle_info} =

--- a/test/lanttern_web/live/pages/report_cards/id/report_card_live_test.exs
+++ b/test/lanttern_web/live/pages/report_cards/id/report_card_live_test.exs
@@ -71,10 +71,26 @@ defmodule LantternWeb.ReportCardLiveTest do
           years_ids: [year.id]
         })
 
-      student_a = SchoolsFixtures.student_fixture(%{name: "Student AAA", classes_ids: [class.id]})
+      student_a =
+        SchoolsFixtures.student_fixture(%{
+          name: "Student AAA",
+          school_id: user.current_profile.school_id,
+          classes_ids: [class.id]
+        })
 
-      _student_b =
-        SchoolsFixtures.student_fixture(%{name: "Student BBB", classes_ids: [class.id]})
+      student_b =
+        SchoolsFixtures.student_fixture(%{
+          name: "Student BBB",
+          school_id: user.current_profile.school_id,
+          classes_ids: [class.id]
+        })
+
+      Lanttern.StudentsCycleInfoFixtures.student_cycle_info_fixture(%{
+        school_id: user.current_profile.school_id,
+        cycle_id: parent_cycle.id,
+        year_id: year.id,
+        student_id: student_b.id
+      })
 
       student_a_report_card =
         student_report_card_fixture(%{report_card_id: report_card.id, student_id: student_a.id})

--- a/test/lanttern_web/live/pages/school/students/id/student_live_test.exs
+++ b/test/lanttern_web/live/pages/school/students/id/student_live_test.exs
@@ -71,14 +71,17 @@ defmodule LantternWeb.StudentLiveTest do
   end
 
   describe "student cycle info" do
-    test "student cycle info is created when there's none", %{conn: conn, user: user} do
+    test "shows empty state when no student cycle info exists", %{conn: conn, user: user} do
       school_id = user.current_profile.school_id
       student = SchoolsFixtures.student_fixture(%{school_id: school_id})
 
       {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{student.id}")
 
-      assert view |> has_element?("p", "No information about student in school area")
-      assert view |> has_element?("p", "No information in student area")
+      assert view
+             |> has_element?(
+               "p",
+               "To enable the student info area, please assign a year for the current cycle in the student edit form."
+             )
     end
 
     test "student cycle info displays correctly", %{conn: conn, user: user} do

--- a/test/support/fixtures/students_cycle_info_fixtures.ex
+++ b/test/support/fixtures/students_cycle_info_fixtures.ex
@@ -5,6 +5,7 @@ defmodule Lanttern.StudentsCycleInfoFixtures do
   """
 
   alias Lanttern.SchoolsFixtures
+  alias Lanttern.TaxonomyFixtures
 
   @doc """
   Generate a student_cycle_info.
@@ -16,6 +17,7 @@ defmodule Lanttern.StudentsCycleInfoFixtures do
       |> maybe_inject_student_id()
       |> maybe_inject_cycle_id()
       |> Enum.into(%{
+        year_id: TaxonomyFixtures.maybe_gen_year_id(attrs),
         shared_info: "some shared_info",
         profile_picture_url: "some profile_picture_url",
         school_info: "some school_info"


### PR DESCRIPTION
### Summary

Adds a direct `year` association to `StudentCycleInfo`, decoupling year assignment from class membership. Students now require an explicit year assignment per cycle, and the reporting query for unlinked students uses this new association instead of deriving years through classes.

### Related Issues

- Closes #501

### What This PR Does

- Adds `year_id` field and `belongs_to :year` association to the `StudentCycleInfo` schema, with a migration adding the column and index
- Updates the student form overlay to include a year selector for the current cycle, creating or updating `StudentCycleInfo` records when a year is chosen
- Refactors `Reporting.list_students_without_report_card/1` to find unlinked students via `StudentCycleInfo.year_id` instead of joining through classes/years
- Removes auto-creation of `StudentCycleInfo` records from guardian home, student home, and about component — year assignment is now an explicit action
- Adds nil-safety guards in templates for when `student_cycle_info` doesn't exist yet, showing a helpful empty state message directing users to assign a year

### Impact and Scope

- **Schema:** `StudentCycleInfo` now requires `year_id` (new migration)
- **Reporting:** Unlinked students query simplified — no longer depends on class/year join
- **Student form:** New year select field in the student edit overlay
- **Guardian/Student home views:** No longer auto-create cycle info; gracefully handle nil
- **Student about page:** Shows empty state when no cycle info exists

### Testing Considerations

- Updated reporting tests to include `year_id` in cycle info fixtures
- Updated student live test to verify empty state behavior instead of auto-creation
- Updated report card live test with proper cycle info setup for unlinked students query
- Fixture updated to generate `year_id` by default

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>