### PR TITLE
add ai exploration

### DIFF
--- a/exploration/README.md
+++ b/exploration/README.md
@@ -1,0 +1,11 @@
+# Exploration
+
+Exploratory research documents, architecture analysis, technical spikes, and design investigations.
+
+This directory contains **research and planning artifacts** — not runnable code. Documents here inform architectural decisions and serve as reference material for the development team.
+
+## Contents
+
+| Directory | Topic | Status |
+|-----------|-------|--------|
+| [ai-oriented-features/](ai-oriented-features/) | AI agent architecture evolution for 2026 | Active research |

--- a/exploration/ai-oriented-features/README.md
+++ b/exploration/ai-oriented-features/README.md
@@ -1,0 +1,31 @@
+# AI-Oriented Features — Exploration Documents
+
+Research and architecture planning for Lanttern's AI agent features (2026 roadmap).
+
+## Documents
+
+### Current State
+
+| File | Purpose |
+|------|---------|
+| [how-is-ai-in-lanttern-today.md](how-is-ai-in-lanttern-today.md) | Technical reference of the current AI implementation. Documents both existing features (Agent Chat with LangChain, ILP AI Revision with ReqLLM), their architectures, database schemas, configuration hierarchy, and known gaps. |
+
+### Architecture Plan
+
+| File | Purpose |
+|------|---------|
+| [ai-agent-feature-plan.md](ai-agent-feature-plan.md) | Full architecture plan (English). Covers 8 architectural decisions (LLM client, orchestration, chat UI, streaming, memory, context, observability, monolith vs microservice), 4 deep dives (Vercel AI SDK, Langfuse, microservice ecosystems, frontend stack comparison), target architecture, database schema evolution, 5-phase implementation roadmap, and risk assessment. |
+| [ai-agent-feature-plan-pt.md](ai-agent-feature-plan-pt.md) | Same architecture plan in Portuguese (PT-BR). |
+
+### Q&A
+
+| File | Purpose |
+|------|---------|
+| [ai-agent-feature-qa.md](ai-agent-feature-qa.md) | Anticipated developer questions (English). 17 sections covering every architectural decision with detailed answers — LLM client migration, orchestration trade-offs, frontend stack choices, streaming, memory, context, observability, migration/rollback, testing, performance/cost, security, timeline, Vercel AI SDK specifics, Langfuse specifics, Jido ecosystem, monolith vs microservice, and CopilotKit vs Vercel AI SDK vs assistant-ui. |
+| [ai-agent-feature-qa-pt.md](ai-agent-feature-qa-pt.md) | Same Q&A document in Portuguese (PT-BR). |
+
+## Reading Order
+
+1. Start with **how-is-ai-in-lanttern-today.md** to understand the current implementation
+2. Read **ai-agent-feature-plan.md** (or PT version) for the target architecture and decisions
+3. Consult **ai-agent-feature-qa.md** (or PT version) for specific questions or trade-off details

--- a/exploration/ai-oriented-features/ai-agent-feature-plan-pt.md
+++ b/exploration/ai-oriented-features/ai-agent-feature-plan-pt.md
@@ -1,0 +1,1390 @@
+# Plano de Arquitetura dos AI Agents do Lanttern
+
+> Documento de arquitetura técnica — Abril 2026
+>
+> Audiência: desenvolvedores, arquitetos e tomadores de decisão técnica trabalhando no roadmap de AI do Lanttern.
+>
+> Este documento é **opinionado** — apresenta todas as opções com prós/contras, mas faz recomendações claras com justificativas para cada decisão arquitetural.
+
+---
+
+## Sumário
+
+1. [Contexto e Problema](#1-contexto-e-problema)
+2. [Decisões Arquiteturais](#2-decisões-arquiteturais)
+   - [Decisão 1: Camada de Client LLM](#decisão-1-camada-de-client-llm)
+   - [Decisão 2: Orquestração de Agents](#decisão-2-orquestração-de-agents)
+   - [Decisão 3: Chat UI e Frontend](#decisão-3-chat-ui-e-frontend)
+   - [Decisão 4: Streaming](#decisão-4-streaming)
+   - [Decisão 5: Memória do Usuário](#decisão-5-memória-do-usuário)
+   - [Decisão 6: Contexto Universal de Conversas](#decisão-6-contexto-universal-de-conversas)
+   - [Decisão 7: Observabilidade](#decisão-7-observabilidade)
+   - [Decisão 8: Monolith vs Microservice](#decisão-8-monolith-vs-microservice)
+3. [Deep Dive: Vercel AI SDK](#3-deep-dive-vercel-ai-sdk)
+4. [Deep Dive: Langfuse](#4-deep-dive-langfuse)
+5. [Deep Dive: Arquitetura Microservice e Ecossistemas Cross-Language](#5-deep-dive-arquitetura-microservice-e-ecossistemas-cross-language)
+6. [Deep Dive: Escolhendo o Stack Frontend — CopilotKit + AG-UI vs Vercel AI SDK vs assistant-ui](#6-deep-dive-escolhendo-o-stack-frontend--copilotkit--ag-ui-vs-vercel-ai-sdk-vs-assistant-ui)
+7. [Arquitetura Alvo](#7-arquitetura-alvo)
+8. [Evolução do Schema do Banco de Dados](#8-evolução-do-schema-do-banco-de-dados)
+9. [Roadmap de Implementação](#9-roadmap-de-implementação)
+10. [Avaliação de Riscos](#10-avaliação-de-riscos)
+
+---
+
+## 1. Contexto e Problema
+
+### O que temos hoje
+
+O Lanttern atualmente possui **duas features de AI independentes** construídas em momentos diferentes com bibliotecas diferentes:
+
+| Feature | Biblioteca | Propósito | Assíncrono? |
+|---------|-----------|-----------|-------------|
+| Agent Chat | LangChain 0.4.0 | Planejamento conversacional de aulas | Sim (Oban) |
+| ILP AI Revision | ReqLLM ~> 1.6 | Revisão automatizada de ILPs | Não (síncrono) |
+
+Ambas as features se comunicam exclusivamente com a **API da OpenAI**. Não há streaming — todas as respostas são geradas por completo antes da entrega.
+
+### Por que precisamos refatorar agora
+
+A implementação atual foi projetada como um **proof of concept (POC)**. Com AI agentic sendo a feature central do Lanttern em 2026, continuar iterando sobre a base do POC vai produzir uma bola de neve de dívida técnica. Os problemas específicos:
+
+1. **Overhead de duas bibliotecas**: Manter duas bibliotecas LLM (LangChain + ReqLLM) dobra a carga cognitiva, superfície de dependências e complexidade de configuração.
+2. **Sem streaming**: Os usuários esperam pela geração completa da resposta — UX inaceitável para interações mais longas.
+3. **Sem memória entre conversas**: Cada conversa começa do zero. O agente não tem conhecimento de interações anteriores com o mesmo usuário.
+4. **Contexto hardcoded**: A UI de conversa está amarrada a strands/lessons. A visão é um chat universal e context-aware.
+5. **Resultados de tools em texto puro**: Quando a AI cria uma aula, ela escreve "A aula foi criada" em texto plano. Sem componentes de UI ricos.
+6. **Sem controle de custos**: Dados de tokens são armazenados mas não utilizados. Sem orçamentos, sem limites, sem alertas.
+7. **Sem observabilidade**: Além de contagem de tokens, não há tracing, avaliação ou infraestrutura de gerenciamento de prompts.
+8. **Lock-in em único provedor**: Ambas as bibliotecas estão configuradas exclusivamente para OpenAI sem camada de abstração.
+
+### Escopo deste documento
+
+Este documento define a **arquitetura alvo** e um **roadmap de implementação faseado** para endereçar todos os pontos acima. Nem tudo será construído em um único sprint — o plano se distribui em 5 fases, cada uma de ~2 semanas.
+
+---
+
+## 2. Decisões Arquiteturais
+
+### Decisão 1: Camada de Client LLM
+
+**Pergunta**: Qual biblioteca o Lanttern deve usar para interagir com APIs de LLMs?
+
+#### Opções
+
+| Dimensão | Opção A: Status quo (LangChain + ReqLLM) | Opção B: Consolidar em ReqLLM | Opção C: Stack completa Jido |
+|---|---|---|---|
+| **Custo de migração** | Zero | Moderado (2 arquivos, ~25 pontos de chamada) | Alto (novo framework, novos paradigmas) |
+| **Multi-provider** | Ambas suportam em teoria; código hardcoda `ChatOpenAI` | 10+ provedores nativos (OpenAI, Anthropic, Google, Mistral, Groq, AWS Bedrock...) | Mesmo que ReqLLM (jido_ai wraps req_llm) |
+| **Streaming** | LangChain suporta, não utilizado atualmente | `stream_text/3` com suporte nativo a SSE | Mesmo que ReqLLM |
+| **Tool calling** | LangChain `Function`/`FunctionParam` — verboso | `ReqLLM.Tool` — API mais simples | `jido_action` — actions tipadas com validação em tempo de compilação, auto-conversão para tools de LLM |
+| **Carga cognitiva** | Duas APIs, duas abstrações, duas configs | Uma API, uma abstração, uma config | Um ecossistema, mas grande superfície (jido + jido_ai + jido_action + jido_signal) |
+| **Testes** | LangChain usa Mimic; ReqLLM usa injeção de dependência | Padrão unificado de stub (já temos `ReqLLMStub`) | Novos padrões de teste necessários |
+| **Idiomático Elixir** | LangChain é uma porta, não design nativo Elixir | Nativo Elixir, construído sobre Req | Nativo Elixir |
+| **Maturidade** | LangChain 0.4.0 (cadência de updates incerta) | v1.0+ estável, production-ready | Jido v2.0 (novo, comunidade menor) |
+| **Orquestração incluída?** | Sim (LLMChain com `while_needs_response`) | Não — você constrói o loop de tool-call | Sim (estratégias ReAct, Chain-of-Thought, CoD) |
+
+#### Recomendação: **Opção B — Consolidar em ReqLLM**
+
+**Justificativa:**
+
+1. A superfície de acoplamento com LangChain é pequena e delimitada — exatamente 2 arquivos (`agent_chat.ex` e `chat_response_worker.ex`) com ~25 pontos de chamada. A migração é previsível.
+2. ReqLLM já está no projeto, já testado, e seu padrão de stub (`Lanttern.ReqLLMStub`) está estabelecido.
+3. ReqLLM é uma biblioteca focada (client LLM, não framework) — faz uma coisa bem e deixa a orquestração para a aplicação. Isso combina com a filosofia do Lanttern de ser dono da lógica de negócio.
+4. O loop de tool-calling `while_needs_response` que o LangChain fornece equivale a **20-30 linhas de código Elixir customizado** — não é motivo para manter uma dependência de framework inteira.
+5. Jido (Opção C) adiciona muita superfície de framework para o tamanho atual do time. Introduz novos conceitos (directives, signals, state machines de agentes) que não são necessários para os casos de uso atuais. Pode ser reconsiderado quando a complexidade dos agentes justificar (múltiplos agentes independentes, comunicação agent-to-agent, state machines complexas).
+6. Consolidar em uma biblioteca corta pela metade a superfície de dependências, simplifica testes e remove a configuração do LangChain de `config.exs` e `runtime.exs`.
+
+**O que perdemos do LangChain e como substituir:**
+
+| Feature LangChain | Substituição no ReqLLM |
+|---|---|
+| `LLMChain` com `while_needs_response` | Função customizada `tool_call_loop/3` (~25 linhas) |
+| `ChatOpenAI.new!` | `ReqLLM.generate_text/3` com config de provider |
+| `Function` / `FunctionParam` | Definições `ReqLLM.Tool` |
+| `Message.new_user!` / `new_assistant!` / `new_system!` | `ReqLLM.Context.user/1` / `ReqLLM.Context.assistant/1` / `ReqLLM.Context.system/1` |
+| `ContentPart.content_to_string/1` | `ReqLLM.Response.text/1` |
+| Token metadata de `chain.exchanged_messages` | Campos de usage do `ReqLLM.Response` |
+
+#### Perspectiva cross-language: Como seria em Python ou TypeScript?
+
+| Dimensão | Elixir (ReqLLM) | Python | TypeScript |
+|---|---|---|---|
+| **LLM Client** | ReqLLM (comunidade, 10+ providers) | OpenAI SDK / Anthropic SDK (first-class, oficiais, feature-complete) | OpenAI SDK / Anthropic SDK (equivalente ao Python) |
+| **Tool calling** | `ReqLLM.Tool` — definições manuais | `Instructor` (3M+ downloads, schema-first) ou `Pydantic AI` (tipado, auto-validado) | Vercel AI SDK `tool()` ou validação com schema `zod` |
+| **Structured output** | Validação com Ecto schema (manual) | `Instructor` ou `Pydantic AI` — outputs LLM estruturados automáticos com retries | `zod` + Vercel AI SDK `generateObject()` |
+| **Maturidade** | ReqLLM v1.0 (estável, comunidade pequena) | OpenAI SDK v1.x (comunidade massiva, suporte oficial, milhões de usuários) | OpenAI SDK (features equivalentes, tipos via Zod) |
+| **Multi-provider** | Nativo (10+ via ReqLLM) | Nativo (cada provider tem SDK oficial) + LiteLLM como wrapper unificado | Nativo + Vercel AI SDK abstrai providers |
+
+**Veredito**: Python e TypeScript têm **ferramental de LLM client significativamente melhor** — SDKs oficiais, validação automática de structured output e comunidades maiores. ReqLLM é adequado mas requer mais código customizado. Essa lacuna é real mas gerenciável dentro do `AgentChat.LLM` — a abstração a isola.
+
+---
+
+### Decisão 2: Orquestração de Agents
+
+**Pergunta**: Como o Lanttern deve orquestrar a execução dos AI agents (gerenciamento de jobs, retries, lifecycle)?
+
+#### Opções
+
+| Dimensão | Opção A: Baseado em Oban (atual, aprimorado) | Opção B: Agents GenServer (estilo Jido) | Opção C: Híbrido (Oban + Task.Supervisor) |
+|---|---|---|---|
+| **Funciona hoje** | Sim, comprovado em produção | Não — nova arquitetura | Parcialmente |
+| **Suporte a streaming** | Necessita path paralelo (Task) | Encaixe natural (GenServer envia mensagens incrementais) | Task.Supervisor cuida do path de streaming |
+| **Confiabilidade** | Retries nativos, dead-letter, constraints de unicidade | Precisa construir crash recovery, supervision | Oban para confiabilidade; Tasks para streaming |
+| **Observabilidade** | Dashboard Oban Web já existe | Precisa construir customizado | Oban Web para jobs; telemetry para tasks |
+| **Tratamento de falhas** | Retry automático com backoff | Restart do GenServer via supervisor | Split: retries do Oban para batch; falhas de tasks para streaming |
+| **Testabilidade** | `testing: :manual` — jobs não executam automaticamente | Padrões de teste GenServer | Dois padrões de teste para manter |
+| **Integração com memória** | Worker consulta memória antes de construir prompts | Agent mantém estado da conversa em memória | Mesmo que Opção A |
+| **Complexidade** | Baixa — workers são apenas módulos | Alta — supervision tree, gestão de estado, deploy | Moderada — dois paths de execução |
+
+#### Recomendação: **Opção A — Continuar baseado em Oban, com extensão de streaming (Opção C) quando streaming for adicionado**
+
+**Justificativa:**
+
+1. **Oban funciona.** Fornece retries, constraints de unicidade, pruning, observabilidade (via Oban Web), e isolamento de testes (`testing: :manual`). Substituí-lo seria trocar algo que não está quebrado.
+2. Adicionar streaming depois não requer substituir Oban — significa adicionar um path paralelo usando `Task.Supervisor` para o caso de streaming. O worker pode escolher entre stream ou batch baseado na configuração.
+3. Agents GenServer (Opção B) adicionam complexidade operacional que um time pequeno deve evitar, a menos que haja necessidade clara de estado in-memory. Atualmente, todo o estado está no banco de dados — não há necessidade de state machines in-memory.
+4. Se Jido agents forem necessários no futuro (ex: coordenação multi-agent), eles podem coexistir com Oban. Não é uma decisão excludente.
+
+#### Perspectiva cross-language: Como seria em Python ou TypeScript?
+
+| Dimensão | Elixir (Oban) | Python | TypeScript |
+|---|---|---|---|
+| **Framework de agents** | Custom tool_call_loop (~25 linhas) | **LangGraph** — agents stateful com checkpointing, time-travel debugging, human-in-the-loop, 5 modos de streaming. Padrão da indústria. | **LangGraph.js** — mesmas features, comunidade menor (42k downloads npm semanais vs dominância do Python) |
+| **Multi-agent** | Nada production-ready | **CrewAI** (times de agents baseados em papéis), **AG2/AutoGen** (multi-agent complexo), **Swarm** (lightweight) | LangGraph.js multi-agent, Mastra (emergente) |
+| **Background jobs** | Oban (comprovado, retries, dashboard, backed por Postgres) | **Celery + Redis** (maduro, durável) ou **LangGraph** durable execution | **BullMQ** (911-8.300 jobs/sec, backed por Redis) |
+| **Gestão de estado** | Banco de dados (PostgreSQL) | LangGraph checkpointing (in-memory ou persistente) — pause/resume/time-travel | LangGraph.js checkpointing |
+| **Tolerância a falhas** | Oban retries + supervisors BEAM | Celery retries + LangGraph checkpoint recovery | BullMQ retries |
+
+**Veredito**: A lacuna de orquestração é a **maior lacuna** entre Elixir e Python. LangGraph fornece execução stateful de agents, checkpointing, human-in-the-loop e coordenação multi-agent — nada disso existe em Elixir. Para as necessidades atuais do Lanttern (agents simples request-response), Oban é suficiente. Mas se agents se tornarem stateful (sessões de tutoria, workflows multi-step), as vantagens do LangGraph se tornam convincentes. Esta é a principal razão para considerar um sidecar Python no futuro.
+
+---
+
+### Decisão 3: Chat UI e Frontend
+
+**Pergunta**: Qual tecnologia deve alimentar a interface de usuário do chat de AI?
+
+#### Opções
+
+| Dimensão | Opção A: LiveView Aprimorado | Opção B: React island + Vercel AI SDK | Opção C: React island + assistant-ui | Opção D: CopilotKit |
+|---|---|---|---|---|
+| **Custo de migração** | Zero | Alto (setup React + endpoint SSE + hook bridge) | Alto (setup React + protocolo custom) | Muito alto (adoção de plataforma completa) |
+| **Streaming UX** | LiveView streams + PubSub push token-by-token | Hook `useChat` gerencia nativamente | Hook de streaming custom | Streaming nativo |
+| **Componentes ricos** | Function components no message stream (cards de aula, etc.) | Componentes React para resultados de tool call — total flexibilidade | Mesmo que Vercel | Mesmo porém mais opinionado |
+| **Familiaridade do time** | Alta — time inteiro conhece LiveView | Baixa — setup React em progresso, time aprendendo | Baixa | Baixa |
+| **Auto-scroll, reconnect, abort** | Precisa construir manualmente | `useChat` fornece tudo isso | Parcialmente fornecido | Totalmente fornecido |
+| **Complexidade de build** | Nenhuma | Compilação JSX do esbuild ou Vite para subtree React | Mesmo que Vercel | Mesmo + SDK da plataforma |
+| **Footprint de dependências** | Nenhum | Pacote npm `ai` (~40KB) + React | `@assistant-ui/react` + React | `@copilotkit/react-*` + SDK backend |
+| **Acoplamento backend** | Socket LiveView | Endpoint SSE (Vercel Data Stream Protocol) — separado do LiveView | Protocolo custom | Protocolo CopilotKit |
+| **Model agnostic** | Sim (backend escolhe modelo) | Sim (backend faz stream, SDK é model-agnostic) | Sim | Sim |
+| **Adoção da comunidade** | Comunidade Phoenix | Padrão da indústria para AI chat | Crescente, mais nova | Grande, foco enterprise |
+
+#### Recomendação: **Opção A (LiveView Aprimorado) agora; transição para Opção B (Vercel AI SDK) quando setup React estiver pronto**
+
+**Justificativa:**
+
+1. **Pragmatismo imediato**: A integração React está em progresso mas não está pronta. Bloquear o trabalho de arquitetura AI em um setup React atrasaria o deliverable. LiveView consegue entregar tudo necessário para o v0: exibição de mensagens, estados de loading, e até streaming via PubSub.
+
+2. **LiveView lida com componentes ricos nativamente**: Quando a AI cria uma aula, o `ConversationComponent` pode renderizar um `<.lesson_card>` function component inline no message stream. Isso requer zero React. A extensão do schema de mensagem (Phase 2) habilita isso: armazenar `ui_component: "lesson_card"` e `ui_data: %{lesson_id: 123}` no metadata da mensagem, então fazer pattern-match no template.
+
+3. **O Vercel AI SDK é a escolha correta a longo prazo**: Quando React islands estiverem disponíveis, o hook `useChat` fornece gerenciamento de streaming, auto-scroll, updates otimistas, abort handling, e rendering de tool call — tudo que seria um esforço significativo para construir em LiveView. O caminho de transição é limpo porque o contrato do backend (`AgentChat` context, Oban workers, PubSub) é UI-agnostic.
+
+4. **Evitar CopilotKit**: Seu SDK backend conflita com a arquitetura Elixir-centric do Lanttern. assistant-ui é uma alternativa viável ao Vercel AI SDK mas tem comunidade menor e menos documentação de integração para backends não-Next.js.
+
+**Plano de transição**:
+- Fases 1-3: Usar LiveView para UI do chat. Construir toda infraestrutura backend (abstração LLM, contexto, memória) sem acoplar a nenhum framework frontend.
+- Fases 4-5: Quando React islands estiverem prontas, criar um React island de chat usando Vercel AI SDK. Adicionar um endpoint SSE no Phoenix que fala o Vercel Data Stream Protocol. Ambos os paths LiveView e React podem coexistir durante a transição.
+
+#### Perspectiva cross-language
+
+A decisão de Chat UI é majoritariamente **language-agnostic no backend** — o frontend é React independente da linguagem. Porém, com um backend TypeScript, o Vercel AI SDK seria **nativo** (sem bridge SSE necessário — o backend produz o stream diretamente). Com um backend Python (FastAPI), streaming SSE também é nativo (`StreamingResponse`). Com Elixir, precisamos de um controller Phoenix customizado para produzir o protocolo Vercel — factível mas mais trabalho manual.
+
+**Veredito**: TypeScript tem uma leve vantagem para integração de Chat UI (Vercel AI SDK nativo). Python e Elixir são equivalentes (ambos precisam de um endpoint SSE). Isso não justifica uma mudança de linguagem já que a camada de UI é uma tradução fina.
+
+---
+
+### Decisão 4: Streaming
+
+**Pergunta**: Como o Lanttern deve entregar respostas de AI ao usuário em tempo real?
+
+#### Opções
+
+| Dimensão | Opção A: Sem streaming (atual) | Opção B: Streaming via LiveView PubSub | Opção C: Endpoint SSE (Vercel Data Stream Protocol) |
+|---|---|---|---|
+| **UX** | Usuário espera pela resposta completa (pode ser 10-30 segundos) | Tokens aparecem conforme são gerados | Mesmo que B |
+| **Implementação** | Nada a fazer | Worker/Task chama ReqLLM com streaming; faz broadcast de chunks via PubSub; ConversationComponent appenda chunks | Controller Phoenix retorna `text/event-stream`; `useChat` do Vercel AI SDK consome |
+| **Mudanças no backend** | Nenhuma | `AgentChat.LLM` precisa de path de streaming; eventos PubSub para chunks | Novo controller + handler de response SSE |
+| **Mudanças no frontend** | Nenhuma | ConversationComponent precisa de buffer de chunks + animação | React island com hook `useChat` |
+| **Tool calls durante stream** | N/A | Worker pausa stream, executa tool, retoma | Vercel SDK lida via tipo de evento `9:` |
+| **Funciona com LiveView** | Sim | Sim | Não (requer React) |
+| **Funciona com React** | Sim (mas UX ruim) | Não (React não recebe PubSub) | Sim (projetado para isso) |
+
+#### Recomendação: **Opção B para Phase 2 (streaming LiveView); adicionar Opção C na Phase 5 quando React estiver pronto**
+
+**Justificativa:**
+
+1. **Streaming é uma melhoria de UX, não um bloqueador de arquitetura.** Phase 1 deve focar em consolidação de bibliotecas e abstração. Streaming pode vir depois que a fundação estiver sólida.
+
+2. **Opção B mantém tudo dentro do paradigma LiveView** — sem endpoint de API separado, sem handling adicional de auth/CSRF, sem dependência de React. Usa a infraestrutura PubSub existente que já conecta o Oban worker ao LiveView.
+
+3. **O protocolo de streaming é aditivo**: Quando React estiver pronto (Phase 5), Opção C (endpoint SSE) é adicionada junto com Opção B, não substituindo. O backend pode suportar ambos os paths simultaneamente — o Oban worker produz chunks, que são entregues via PubSub (para LiveView) ou SSE (para React).
+
+**Design do streaming PubSub:**
+
+```
+Novos eventos PubSub:
+  {:conversation, {:chunk, %{text: "texto parcial", index: 0}}}
+  {:conversation, {:tool_call_start, %{name: "create_lesson", args: %{...}}}}
+  {:conversation, {:tool_call_result, %{name: "create_lesson", result: %{...}}}}
+  {:conversation, {:message_complete, %Message{}}}
+
+ConversationComponent:
+  - Mantém assign `streaming_buffer` (acumula chunks)
+  - Em `:chunk` → appenda ao buffer, re-renderiza mensagem em streaming
+  - Em `:message_complete` → finaliza buffer na entrada do stream, salva no DB
+```
+
+#### Perspectiva cross-language
+
+| Dimensão | Elixir (PubSub) | Python (FastAPI) | TypeScript (Node.js) |
+|---|---|---|---|
+| **Streaming para o client** | PubSub → LiveView push (customizado) | `StreamingResponse` (SSE nativo) | Vercel AI SDK `streamText()` (nativo, zero config) |
+| **Streaming LangGraph** | N/A | **5 modos de streaming**: tokens, events, updates, messages, custom. O streaming mais avançado de qualquer framework. | LangGraph.js — mesmos 5 modos |
+| **Tool calls durante stream** | Lógica manual de pause/resume | LangGraph lida automaticamente com `astream_events` | LangGraph.js ou Vercel AI SDK tipo de evento `9:` |
+| **Reconexão** | Customizado (precisa construir) | Customizado (precisa construir) | Vercel AI SDK `useChat` lida automaticamente |
+
+**Veredito**: Python (LangGraph) tem as **melhores capacidades de streaming** — 5 modos distintos que cobrem todo caso de uso (streaming de tokens, updates de estado, eventos de tool call, dados customizados). TypeScript (Vercel AI SDK) tem a melhor integração de streaming no frontend. A abordagem PubSub do Elixir funciona mas requer mais código customizado para cenários avançados. Para streaming simples de tokens, os três são adequados.
+
+---
+
+### Decisão 5: Memória do Usuário
+
+**Pergunta**: Como o agente deve lembrar de informações entre conversas?
+
+#### Abordagem de design: **Memória baseada em resumos hierárquicos**
+
+**Por que não replay de histórico bruto?** Armazenar e reproduzir histórico bruto de conversas como "memória" é proibitivo em custo. Um usuário com 50 conversas de 20 mensagens cada exigiria injetar ~1000 mensagens em cada novo prompt — estourando a janela de contexto e o orçamento de tokens.
+
+**Por que resumos?** No encerramento da conversa (ou em checkpoints), um job em background resume a conversa em entradas de memória compactas. Esses resumos são injetados como mensagem de sistema Layer 0 (antes da configuração da escola) em conversas futuras — adicionando ~200-500 tokens de contexto ao invés de milhares.
+
+#### Design do schema
+
+```
+user_ai_memories
+  id              :bigint PK
+  profile_id      :bigint FK -> profiles (indexado)
+  school_id       :bigint FK -> schools (indexado)
+  category        :string  -- "preference" | "topic_expertise" | "interaction_style" | "context"
+  summary         :text    -- texto de memória comprimido
+  source_type     :string  -- "conversation" | "system" | "manual"
+  source_id       :bigint  -- nullable, FK para conversa que produziu esta memória
+  relevance_score :float   -- para ranking na recuperação (0.0-1.0)
+  expires_at      :utc_datetime -- nullable, para memórias com tempo limitado
+  inserted_at     :utc_datetime
+  updated_at      :utc_datetime
+```
+
+#### Ciclo de vida da memória
+
+1. **Criação**: Após o fim de uma conversa (ou em checkpoints periódicos), um job Oban `MemorySummaryWorker` resume a conversa e faz upsert de entradas de memória.
+2. **Injeção**: Antes de construir system prompts, `add_memory_system_messages/2` consulta as memórias recentes/relevantes do usuário e as injeta como Layer 0 (antes de knowledge/guardrails da escola). Memórias são ordenadas por `relevance_score` e limitadas (ex: top 10 entradas) para controlar tamanho do prompt.
+3. **Decay**: Memórias têm `expires_at` opcional para informações com tempo limitado. Um cron job faz prune de entradas expiradas.
+4. **Atualização**: O job de sumarização pode atualizar memórias existentes (ex: "usuário prefere planos de aula detalhados" é refinado ao longo do tempo) em vez de sempre criar novas.
+5. **Gestão manual**: Staff pode visualizar e deletar suas próprias memórias via página de configurações.
+
+#### System prompt com memória (hierarquia de 6 camadas)
+
+```
+Layer 0: Memória do Usuário (NOVO)
+  └── Fonte: tabela user_ai_memories
+  └── Tag: <user_memory>
+            <preferences>...</preferences>
+            <topic_expertise>...</topic_expertise>
+            <interaction_history>...</interaction_history>
+          </user_memory>
+
+Layer 1: Knowledge & Guardrails da Escola (inalterado)
+Layer 2: Configuração do Agent (inalterado)
+Layer 3: Contexto do Staff Member (inalterado)
+Layer 4: Template de Aula (inalterado)
+Layer 5: Contexto Curricular (inalterado)
+```
+
+Memória é posicionada antes da configuração da escola porque muda mais frequentemente (por-usuário, por-conversa), enquanto configuração da escola é relativamente estática. Esta ordenação maximiza a efetividade do prompt caching — as camadas estáticas permanecem na mesma posição entre chamadas.
+
+#### Perspectiva cross-language
+
+| Dimensão | Elixir (customizado) | Python | TypeScript |
+|---|---|---|---|
+| **Sistema de memória** | Tabela customizada `user_ai_memories` + job de sumarização | **mem0** (camada de memória gerenciada, auto-categoriza, vector search), **MemGPT/Letta** (memória auto-editável, storage em camadas), **LangGraph checkpointing** (persistência de estado de conversa com time-travel) | LangGraph.js checkpointing, implementações customizadas |
+| **Vector search para memórias** | pgvector (funciona, integração manual) | Módulos de memória do **LlamaIndex**, pgvector, Pinecone, Qdrant — todos com integrações first-class | pgvector, Pinecone — similar ao Python |
+| **Sumarização** | Job Oban customizado + chamada LLM | mem0 lida automaticamente, ou `summarize_messages` built-in do LangGraph | Customizado ou LangGraph.js |
+
+**Veredito**: Python tem **sistemas de memória especializados** (mem0, MemGPT/Letta) que não existem em Elixir. Porém, estes são mais valiosos para agents complexos com longos históricos de interação. Nossa memória customizada baseada em resumos é mais simples e mais adequada às necessidades school-scoped do Lanttern. Se os requisitos de memória crescerem significativamente (ex: retrieval semântico baseado em vetores sobre milhares de conversas), o ecossistema Python se torna mais atrativo.
+
+---
+
+### Decisão 6: Contexto Universal de Conversas
+
+**Pergunta**: Como conversas devem ser vinculadas a entidades arbitrárias (strands, lessons, ILPs, assessments, etc.)?
+
+#### Limitação atual
+
+A tabela `strand_agent_conversations` é hardcoded para strands e lessons:
+
+```sql
+strand_agent_conversations
+  conversation_id → agent_conversations
+  strand_id → strands
+  lesson_id → lessons (nullable)
+```
+
+Isso não acomoda novos tipos de contexto (ILPs, assessments, students, etc.) sem novas tabelas de junção para cada tipo de entidade.
+
+#### Recomendação: **Tabela polimórfica de context links**
+
+```sql
+conversation_contexts
+  id                :bigint PK
+  conversation_id   :bigint FK -> agent_conversations (CASCADE DELETE)
+  context_type      :string  -- "strand" | "lesson" | "ilp" | "assessment" | ...
+  context_id        :bigint  -- FK para a entidade relevante
+  context_metadata  :jsonb   -- snapshot dos dados de contexto no momento da conversa
+  inserted_at       :utc_datetime
+
+  UNIQUE(conversation_id, context_type, context_id)
+```
+
+#### Decisões-chave de design
+
+1. **Múltiplos contextos por conversa**: Uma conversa sobre uma aula dentro de um strand tem dois context links: `{type: "strand", id: 1}` e `{type: "lesson", id: 5}`. Isso é mais flexível do que forçar um único contexto.
+
+2. **context_metadata JSONB**: Armazena um snapshot dos dados de contexto relevantes no momento da criação da conversa. Isso é útil para auditoria (o que o agente viu?) e para casos onde a entidade fonte muda após a conversa.
+
+3. **Sem FK constraint em context_id**: Porque `context_id` pode referenciar diferentes tabelas dependendo do `context_type`, não podemos usar uma foreign key de banco de dados. A integridade referencial é garantida na camada de aplicação via `ContextResolver`.
+
+4. **Caminho de migração**: Dados de `strand_agent_conversations` são migrados para `conversation_contexts` (uma linha por strand, uma por lesson onde aplicável). A tabela antiga permanece como está, conforme regra 7 do CLAUDE.md (padrão é dívida técnica, não refatoração).
+
+#### Pipeline de resolução de contexto
+
+```elixir
+# Em AgentChat.ContextResolver
+def resolve_contexts(conversation_id) do
+  conversation_id
+  |> list_conversation_contexts()
+  |> Enum.flat_map(&context_to_system_messages/1)
+end
+
+defp context_to_system_messages(%{context_type: "strand", context_id: id}) do
+  # Carrega strand com subjects, years, moments, curriculum items
+  # Constrói system messages XML <strand_context>
+end
+
+defp context_to_system_messages(%{context_type: "lesson", context_id: id}) do
+  # Carrega lesson com moment, subjects, tags
+  # Constrói system messages XML <lesson_context>
+end
+
+defp context_to_system_messages(%{context_type: "ilp", context_id: id}) do
+  # Carrega ILP com template, sections, entries
+  # Constrói system messages XML <ilp_context>
+end
+```
+
+Adicionar um novo tipo de contexto requer apenas adicionar uma nova cláusula `context_to_system_messages/1` — sem mudanças de schema, sem migrations.
+
+#### Perspectiva cross-language
+
+A resolução de contexto é **profundamente acoplada ao domínio do Lanttern** — carregar strands, lessons, ILPs requer queries em Ecto schemas com associações preloaded, enforcement de autorização via Scope e respeito ao isolamento por escola. Esta é a decisão **mais afetada pela escolha monolith vs microservice**.
+
+| Cenário | Monolith Elixir | Microservice Python/TS |
+|---|---|---|
+| **Carregando contexto** | Query Ecto direta com preloads — 1 chamada ao DB, ~5ms | Microservice chama API interna do Phoenix → Phoenix faz query no DB → serializa → retorna JSON. Múltiplos hops, ~50-100ms. |
+| **Novo tipo de contexto** | Adicionar uma cláusula de função no ContextResolver | Adicionar endpoint de API no Phoenix + código client em Python/TS + mapeamento de serialização |
+| **Autorização** | Pattern-match de `school_id` no function head (Scope nativo) | Precisa passar token de Scope para o microservice ou duplicar lógica de auth |
+| **Freshness dos dados** | Sempre ao vivo do DB | Risco de dados stale se caching, ou latência extra se sempre buscando |
+
+**Veredito**: Resolução de contexto é o **argumento mais forte para manter AI no monolith Elixir**. Movê-la para um microservice não a simplifica — adiciona uma fronteira de rede no ponto de acoplamento mais apertado. Um microservice Python/TS precisaria ou acessar o banco do Lanttern diretamente (acoplamento forte, schema compartilhado, coordenação de migrations) ou chamar APIs internas para cada lookup de contexto (latência, complexidade).
+
+---
+
+### Decisão 7: Observabilidade
+
+**Pergunta**: Como o Lanttern deve monitorar, avaliar e gerenciar qualidade e custos dos AI agents?
+
+#### Opções
+
+| Dimensão | Opção A: Custom (DB + Telemetry) | Opção B: Langfuse (self-hosted) | Opção C: Langfuse Cloud | Opção D: LangSmith | Opção E: Helicone |
+|---|---|---|---|---|---|
+| **Propriedade dos dados** | Total | Total (sua infraestrutura) | Gerenciado pela Langfuse (regiões EU/US, GDPR compliant) | Gerenciado pela LangChain | Gerenciado pela Helicone |
+| **Custo** | Apenas storage no DB | Software gratuito + infra ($500-5k/mês) | Gratuito até $199+/mês | $39/seat/mês | Baseado em uso |
+| **Esforço de setup** | Precisa construir tudo | Docker Compose (dev) ou K8s/Helm (prod) | Signup SaaS | Signup SaaS | Setup de proxy |
+| **Tracing** | Manual (log no DB) | Tracing distribuído, hierarquia de spans, sessions | Mesmo | Mesmo | Auto-trace baseado em proxy |
+| **Gestão de prompts** | Nenhuma (prompts no código) | Versionamento, caching, playground | Mesmo | Sim | Não |
+| **Avaliação** | Nenhuma | LLM-as-judge, labeling manual, datasets | Mesmo | Sim | Não |
+| **Tracking de custos** | Agregar de `llm_calls` | Por-modelo, por-usuário, por-session | Mesmo | Sim | Sim (feature principal) |
+| **Integração Elixir** | Telemetry nativo | OpenTelemetry ou REST API | Mesmo | SDKs Python/JS apenas | Proxy HTTP (language-agnostic) |
+| **Vendor lock-in** | Nenhum | Baixo (open source, dados migrável) | Médio (migração para self-host) | Alto (proprietário, focado em LangChain) | Médio |
+
+#### Recomendação: **Abordagem faseada — Custom (Phase 1-2) → Langfuse Cloud (Phase 3) → Langfuse self-hosted (Phase 5+)**
+
+**Justificativa:**
+
+1. **Phase 1-2 (Custom)**: A tabela `llm_calls` existente já captura o necessário para tracking básico de custos. Adicionar eventos `:telemetry` para chamadas LLM (`:lanttern, :llm, :call, :start/:stop`) e um cron job Oban periódico para agregar custos por escola. Isso é baixo esforço e integra com o LiveDashboard existente.
+
+2. **Phase 3 (Langfuse Cloud)**: Uma vez que o sistema de memória esteja implementado e as conversas se tornem mais complexas, adotar Langfuse Cloud para tracing e avaliação adequados. O tier Cloud começa gratuito (50k traces/mês) e escala para $29/mês (1M traces). Integração via OpenTelemetry — que tem forte suporte no Elixir/BEAM — ou REST API direta.
+
+3. **Phase 5+ (Langfuse self-hosted)**: Quando o volume de traces justificar ou sensibilidade de dados exigir, migrar para Langfuse self-hosted no Kubernetes. A transição é direta porque a camada de integração (OpenTelemetry) não muda.
+
+**Por que não LangSmith?** É proprietário, focado em LangChain (estamos removendo LangChain), e tem pricing por-seat. **Por que não Helicone?** É baseado em proxy, que não se encaixa em nossa arquitetura de Oban workers (a chamada LLM acontece server-side, não via proxy). **Por que Langfuse?** Open source, self-hostable, framework-agnostic, sem pricing por-seat, e sua arquitetura v4 (backed por ClickHouse) lida bem com escala.
+
+Veja [Seção 4: Deep Dive: Langfuse](#4-deep-dive-langfuse) para análise técnica completa.
+
+#### Perspectiva cross-language
+
+| Dimensão | Elixir | Python | TypeScript |
+|---|---|---|---|
+| **Integração Langfuse** | OpenTelemetry ou REST API (sem SDK oficial) | **SDK oficial** — decorators nativos, auto-tracing, gestão de prompts | **SDK oficial** — mesmas features que Python |
+| **LangSmith** | Sem SDK (apenas REST) | **Integração nativa** — auto-traces de chamadas LangChain/LangGraph, playground, datasets | LangChain.js auto-tracing |
+| **Frameworks de avaliação** | Nenhum | **DeepEval** (testes de LLM estilo pytest — detecção de alucinação, scoring de relevância, checagem de toxicidade), **RAGAS** (avaliação de RAG baseada em pesquisa), **PromptFoo** (red-teaming de segurança, teste de prompt injection) | PromptFoo (funciona com TS), outros limitados |
+| **Gestão de prompts** | Apenas em código (system prompts em `agent_chat.ex`) | Versionamento de prompts Langfuse/LangSmith, **DSPy** (otimização automática de prompts) | Versionamento de prompts Langfuse |
+
+**Veredito**: Python tem um **ecossistema de observabilidade e avaliação significativamente melhor**. DeepEval, RAGAS e PromptFoo não têm equivalentes em Elixir — e avaliação é crítica para educação (segurança, garantia de qualidade). Esta é uma lacuna genuína. A abordagem faseada com Langfuse mitiga a lacuna de observabilidade, mas frameworks de avaliação permanecem uma vantagem exclusiva do Python. Se avaliação rigorosa de qualidade de AI se tornar um requisito, este é o segundo argumento mais forte (após orquestração) para um sidecar Python.
+
+---
+
+### Decisão 8: Monolith vs Microservice — AI deve viver fora do Elixir?
+
+**Pergunta**: Ganharíamos ferramental significativamente melhor construindo features de AI como um serviço separado em Python ou TypeScript?
+
+#### A resposta honesta: sim, o ferramental é melhor. A questão é se vale o custo.
+
+O ecossistema de AI do Python é **objetivamente mais rico** que o do Elixir. As comparações cross-language nas Decisões 1-7 acima mostram lacunas reais em orquestração (LangGraph), avaliação (DeepEval/RAGAS), memória (mem0) e SDKs de providers (oficiais vs comunidade). Estas não são teóricas — representam ferramentas production-ready com grandes comunidades.
+
+Mas qualidade de ferramental é apenas uma variável. A equação completa inclui custo operacional, acoplamento de domínio, expertise do time e complexidade arquitetural.
+
+#### Opções
+
+| Dimensão | Opção A: Monolith Elixir | Opção B: Sidecar Python (co-deployed) | Opção C: Microservice completo (deploy separado) |
+|---|---|---|---|
+| **Acesso ao ecossistema AI** | Apenas Elixir (ReqLLM, código customizado) | **Ecossistema Python completo** (LangGraph, DeepEval, SDKs oficiais) | Ecossistema completo Python ou TS |
+| **Deployment** | Unidade única | Unidade única (mesmo pod/VM) | Unidades separadas |
+| **Overhead de latência** | 0ms (in-process) | +5-10ms (localhost HTTP) | +25-50ms (network hop) |
+| **Execução de tools** | Chamada direta de função (`Lessons.create_lesson/3`) | HTTP interno para Phoenix → lógica de negócio | API externa → Phoenix → lógica de negócio |
+| **Carregamento de contexto** | Query Ecto direta (~5ms) | HTTP para Phoenix → query Ecto → serializar (~50-100ms) | Mesmo que sidecar mas pela rede |
+| **Streaming PubSub** | Nativo | Bridge Redis ou webhook → Phoenix PubSub | Mesmo que sidecar |
+| **Multiplicador de custo de infra** | 1x | 1.1-1.3x | 3.75-6x |
+| **Requisito de time** | Devs Elixir | Elixir + 1-2 devs Python | Elixir + 2-4 devs Python + engenheiro de plataforma |
+| **Auth/Scope** | Pattern matching nativo | Precisa passar scope ou duplicar auth | Mesmo + camada de auth de rede |
+| **Acesso ao DB** | Compartilhado (Ecto) | PostgreSQL compartilhado (direto ou via API) | DB separado ou compartilhado (ambos têm problemas) |
+| **Testabilidade** | Suite de testes única | Duas suites de teste, testes de integração necessários | Mesmo + contract testing |
+| **Quando escolher** | AI é simples, time é pequeno, acoplamento de domínio é apertado | Precisa de capacidades Python específicas, tem expertise Python | AI precisa escalar independentemente, time >50 |
+
+#### O trade-off central: Ecossistema vs Integração de Domínio
+
+O AI agent do Lanttern não é um chatbot standalone — ele penetra profundamente no domínio da aplicação:
+
+1. **System prompts** carregam de 6+ tabelas (configs de escola, agents, staff, templates, strands, lessons)
+2. **Execução de tools** chama funções de negócio com autorização Scope e audit logging
+3. **Updates em tempo real** fluem pelo Phoenix PubSub
+4. **Injeção de memória** consulta memórias de usuário school-scoped
+5. **Resolução de contexto** carrega entidades polimórficas com associações Ecto
+
+Uma fronteira de microservice cortaria através desses pontos de acoplamento. O microservice ou:
+- **Acessa o DB do Lanttern diretamente** (acoplamento forte, schema compartilhado, coordenação de migrations) — derrota o propósito da separação
+- **Chama APIs do Phoenix para tudo** (latência, risco de stale, superfície de API para manter) — adiciona complexidade
+
+#### Recomendação: **Opção A (monolith Elixir) agora, com caminho claro para Opção B (sidecar Python) quando necessidades específicas surgirem**
+
+**Justificativa:**
+
+1. **Necessidades atuais são atendidas.** O Lanttern precisa de um client LLM, tool calling, streaming e memória. ReqLLM + código customizado entrega isso. As features avançadas do LangGraph (checkpointing, multi-agent) ainda não são necessárias.
+
+2. **Acoplamento de domínio é o fator decisivo.** O acoplamento mais apertado está em carregamento de contexto e execução de tools — ambos requerem acesso direto a Ecto schemas e autorização via Scope. Um microservice adiciona fricção no pior ponto possível.
+
+3. **Dados da indústria corroboram.** 42% das organizações que adotaram microservices consolidaram de volta (pesquisa CNCF 2025). Amazon Prime Video alcançou 90% de redução de custos migrando de microservices para monolith.
+
+4. **A válvula de escape do sidecar existe.** `AgentChat.LLM` é projetado para que a chamada de orquestração LLM possa ser redirecionada para um serviço externo. Quando capacidades Python forem necessárias, extraímos APENAS a orquestração LLM para um sidecar FastAPI co-deployed — sem mover lógica de domínio, auth ou acesso a dados.
+
+#### Quando adotar um sidecar Python (Opção B)
+
+| Gatilho | Por quê | O que extrair |
+|---|---|---|
+| Coordenação multi-agent necessária | LangGraph/CrewAI não têm equivalente em Elixir | Apenas orquestração de agents |
+| RAG sobre grandes corpora de documentos | LlamaIndex está muito à frente | Processamento de documentos + retrieval |
+| Avaliação rigorosa necessária | DeepEval/RAGAS/PromptFoo são Python-only | Pipeline de avaliação |
+| Engenheiro de AI Python contratado | Pode ser dono do sidecar sem sobrecarregar o time Elixir | O que fizer mais sentido para ele |
+| Time cresce além de 30 engenheiros | Velocidade independente do time de AI justificada | Orquestração completa de AI |
+
+Veja [Seção 5: Deep Dive: Arquitetura Microservice](#5-deep-dive-arquitetura-microservice-e-ecossistemas-cross-language) para comparações detalhadas de ecossistema, diagramas de arquitetura e análise de custos.
+
+---
+
+## 3. Deep Dive: Vercel AI SDK
+
+### O que é
+
+O Vercel AI SDK (pacote npm `ai`) é um toolkit TypeScript para construir aplicações com AI. Apesar do nome, é **framework-agnostic** — funciona com React, Vue, Svelte e qualquer backend que produza o protocolo de streaming correto.
+
+### Arquitetura
+
+```
+┌─────────────────────────────────────────────────┐
+│  Aplicação React                                  │
+│                                                   │
+│  hook useChat()                                   │
+│    ├── Gerencia estado de mensagens (user + asst) │
+│    ├── Lida com streaming (auto-appenda tokens)   │
+│    ├── Abort / retry / reload                     │
+│    ├── Gerenciamento de auto-scroll               │
+│    ├── Rendering de tool calls                    │
+│    └── Endpoint de API configurável               │
+│                                                   │
+│  Renderers customizados de tool calls             │
+│    └── ex: <LessonCard> para create_lesson        │
+└───────────────────────┬─────────────────────────┘
+                        │ POST /api/chat
+                        │ Content-Type: text/event-stream
+                        │ x-vercel-ai-ui-message-stream: v1
+                        ▼
+┌─────────────────────────────────────────────────┐
+│  Backend (endpoint SSE Phoenix)                   │
+│                                                   │
+│  Produz Server-Sent Events por protocolo:         │
+│    0:{text}              → token de texto         │
+│    9:{tool_call_json}    → tool call iniciado     │
+│    a:{tool_result_json}  → resultado de tool call │
+│    e:{finish_json}       → stream finalizado      │
+│    d:{usage_json}        → metadata de uso tokens │
+│                                                   │
+│  O backend controla modelo, prompts, tools —      │
+│  o SDK apenas consome o stream.                   │
+└─────────────────────────────────────────────────┘
+```
+
+### Como integra com Phoenix
+
+1. **Endpoint SSE**: Um controller Phoenix dedicado (`AiStreamController`) lida com requests `POST /api/chat`. Autentica o usuário (cookie de sessão ou token), constrói o request LLM via `AgentChat.LLM`, faz stream de chunks do ReqLLM, e formata conforme o Vercel Data Stream Protocol.
+
+2. **React island**: A UI do chat é montada como um React island dentro de uma página LiveView via Phoenix hook. O componente React usa `useChat({ api: "/api/chat" })` para conectar ao endpoint SSE.
+
+3. **Bridge LiveView**: Dados não-chat (info do strand, configurações do usuário, navegação) continuam fluindo pelo LiveView. O React island recebe props iniciais do LiveView e pode comunicar de volta via eventos customizados.
+
+### Prós
+
+| Vantagem | Detalhe |
+|---|---|
+| **Streaming "just works"** | `useChat` lida com consumo de SSE, estado de mensagens, buffering, reconexão — zero código customizado |
+| **Rendering de tool calls** | Quando o LLM chama uma tool, o SDK fornece callback para renderizar componentes React customizados (ex: `<LessonCard>`) em vez de texto puro |
+| **Auto-scroll** | Gerenciamento de scroll nativo para interfaces de chat |
+| **Abort / retry** | Usuário pode cancelar uma resposta em streaming ou tentar novamente uma falha — `useChat` gerencia as transições de estado |
+| **Model agnostic** | O SDK não se importa com qual modelo o backend usa. Apenas consome o protocolo de stream. |
+| **Comunidade enorme** | O SDK de frontend AI mais adotado. Padrões battle-tested, documentação extensiva, updates frequentes. |
+| **Leve** | O pacote `ai` tem ~40KB. Sem runtime pesado. |
+
+### Contras
+
+| Desvantagem | Detalhe |
+|---|---|
+| **Requer React** | Lanttern é atualmente puro LiveView. Setup React está em progresso mas não pronto. |
+| **Endpoint SSE = superfície de API paralela** | O endpoint SSE é separado do LiveView. Precisa de autenticação própria, proteção CSRF, rate limiting. |
+| **Complexidade do bridge LiveView ↔ React** | Comunicar entre estado LiveView e um React island requer uma camada de bridge via hooks. Sincronização de estado complexa pode ser tricky. |
+| **Dois paradigmas de rendering** | O app teria LiveView para tudo exceto chat, e React para chat. Esta abordagem de paradigma duplo adiciona overhead cognitivo. |
+| **Mudanças no build tooling** | esbuild precisa ser configurado para compilar JSX, ou um pipeline Vite separado é necessário para o subtree React. |
+| **Não necessário para v0** | LiveView consegue entregar streaming via PubSub e componentes ricos via function components. O valor do SDK só se materializa em escala ou para padrões interativos complexos. |
+
+### Comparação com alternativas
+
+| Feature | Vercel AI SDK | CopilotKit | assistant-ui |
+|---|---|---|---|
+| **Escopo** | Hooks de streaming frontend | Plataforma completa (frontend + backend) | Componentes React headless para chat |
+| **Acoplamento backend** | Nenhum — qualquer backend SSE | SDK backend CopilotKit obrigatório | Nenhum — qualquer backend |
+| **Streaming** | SSE (Data Stream Protocol) | AG-UI Protocol | Adapters customizados |
+| **UI de tool calls** | Renderers customizados por tool | Rendering de actions nativo | Renderers customizados |
+| **Complexidade** | Baixa (apenas hooks) | Alta (plataforma completa) | Média (biblioteca de componentes) |
+| **Melhor para** | Backend customizado + frontend React | Apps AI full-stack | Máxima customização de UI |
+| **Risco para Lanttern** | Baixo (focado, leve) | Alto (dependência de plataforma, conflita com backend Elixir) | Médio (comunidade menor) |
+
+### Recomendação para o Lanttern
+
+**Curto prazo (Phase 1-3)**: Não adotar o Vercel AI SDK. Usar LiveView para a UI do chat. A arquitetura backend deve ser projetada como UI-agnostic, para que a transição para React seja seamless quando pronta.
+
+**Médio prazo (Phase 4-5)**: Uma vez que React islands estejam operacionais, adotar o Vercel AI SDK para a interface de chat. Implementar um controller Phoenix SSE que fala o Vercel Data Stream Protocol. Manter LiveView como framework geral da página, com o chat como React island.
+
+**Evitar CopilotKit**: Seu SDK backend conflita com a arquitetura Elixir-centric do Lanttern. assistant-ui é uma alternativa viável se o time preferir mais controle sobre a UI, mas a comunidade e documentação do Vercel AI SDK o tornam a aposta mais segura.
+
+---
+
+## 4. Deep Dive: Langfuse
+
+### O que é
+
+Langfuse é uma **plataforma open-source de engenharia LLM** (adquirida pela ClickHouse em 2026, 24k+ stars no GitHub). Diferente de ferramentas de APM genéricas, ele entende nativamente conceitos específicos de LLM: uso de tokens, parâmetros de modelo, pares prompt/completion, scores de avaliação e sessões de conversa.
+
+### Arquitetura (v4 — atual)
+
+```
+┌──────────────────────────────────────────────────┐
+│  Plataforma Langfuse                              │
+│                                                   │
+│  ┌─────────────┐    ┌──────────────────────────┐ │
+│  │   Web        │    │  Worker (Node.js)         │ │
+│  │  (Next.js)   │    │  - Filas async BullMQ     │ │
+│  │  - UI        │    │  - Processamento eventos  │ │
+│  │  - REST API  │    │  - Pipelines avaliação    │ │
+│  │  - OTLP API  │    └──────────┬───────────────┘ │
+│  └──────┬───────┘               │                 │
+│         │                       │                 │
+│  ┌──────▼───────────────────────▼───────────────┐ │
+│  │  ClickHouse (OLAP — traces, observations)     │ │
+│  │  - Modelo de dados observation-centric (v4)   │ │
+│  │  - Formato colunar para queries analíticas    │ │
+│  │  - 20x mais rápido que v3                     │ │
+│  └──────────────────────────────────────────────┘ │
+│  ┌──────────────────────────────────────────────┐ │
+│  │  PostgreSQL (metadata — users, projects)      │ │
+│  └──────────────────────────────────────────────┘ │
+│  ┌──────────────────────────────────────────────┐ │
+│  │  Redis/Valkey (filas + cache)                 │ │
+│  └──────────────────────────────────────────────┘ │
+│  ┌──────────────────────────────────────────────┐ │
+│  │  S3/Blob (persistência de eventos + exports)  │ │
+│  └──────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────┘
+```
+
+### Features principais
+
+| Feature | O que faz | Por que importa para o Lanttern |
+|---|---|---|
+| **Tracing Distribuído** | Hierarquia de spans: Traces > Observations (spans/generations/events). Agrupamento por sessão. | Rastrear ciclo de vida completo da conversa: mensagem do usuário → construção de prompt → chamada LLM → execução de tool → resposta. Identificar gargalos. |
+| **Gestão de Prompts** | Controle de versão, branching, caching, playground para testes. | Atualmente, prompts vivem no código (`agent_chat.ex`). Langfuse permite iteração de prompts por não-desenvolvedores sem deploys. |
+| **Avaliação** | LLM-as-judge, labeling manual, pipelines de eval customizados, testes de regressão baseados em datasets. | Medir e melhorar qualidade do agente ao longo do tempo. Responder: "Nossos planos de aula estão melhorando?" |
+| **Tracking de Custos** | Cálculo de custos por-modelo, por-usuário, por-sessão. Pricing customizado de modelos. | Substituir agregação manual da `llm_calls` por dashboards automatizados. Visibilidade de custos por-escola. |
+| **Feedback de Usuários** | Coletar thumbs up/down, ratings, feedback customizado sobre outputs AI. | Fechar o loop de feedback. Professores avaliam planos de aula → dados fluem de volta para melhorar prompts. |
+| **Analytics** | Dashboards customizados, análise de sessões, tracking de comportamento de usuários. | Entender como professores usam o agente. Quais tools são mais chamadas? Onde conversas falham? |
+
+### Self-hosting
+
+| Opção | Infraestrutura | Caso de uso |
+|---|---|---|
+| **Docker Compose** | VM única, 4+ vCPUs, 16GB+ RAM. Containers PostgreSQL + ClickHouse + Redis + Langfuse. | Desenvolvimento/staging. Não recomendado para produção (sem HA). |
+| **Kubernetes (Helm)** | Cluster K8s com bancos gerenciados. Helm charts fornecidos. Min 2 réplicas web do Langfuse. | Produção. HA completo e auto-scaling. Pode apontar para instâncias existentes de PostgreSQL/ClickHouse/Redis. |
+
+**Requisitos de infraestrutura:**
+- Todos os componentes devem rodar com **timezone UTC** (não-UTC causa resultados de query incorretos)
+- Mínimo: 2 instâncias web, auto-scale em 50% CPU
+- Replicação adequada de Redis/ClickHouse para HA
+
+**Custo de self-hosting:**
+| Escala | Custo infra/mês | Custo DevOps/mês | Total |
+|---|---|---|---|
+| Pequena (<1M traces/mês) | $500-1.000 | ~$2.000 | ~$2.500 |
+| Média (1-10M traces/mês) | $2.000-3.000 | ~$3.000 | ~$5.000 |
+| Grande (10M+ traces/mês) | $5.000-15.000 | ~$5.000 | ~$10.000+ |
+
+### Integração com Elixir
+
+Não há SDK oficial Elixir da Langfuse. Opções de integração:
+
+| Abordagem | Esforço | Qualidade | Recomendado? |
+|---|---|---|---|
+| **OpenTelemetry** | Médio | Excelente — suporte nativo BEAM, tracing distribuído, protocolo padrão | **Sim (recomendado)** |
+| **REST API** | Baixo | Bom para casos simples. Batching manual necessário. | Para início rápido |
+| **SDK da comunidade** (`workera-ai/langfuse_sdk`) | Baixo | Mantido pela comunidade, não oficial. Verificar maturidade. | Avaliar antes de depender |
+
+**Padrão de integração recomendado:**
+
+```
+Aplicação Phoenix (Elixir)
+    ↓
+AgentChat.LLM (chamadas ReqLLM)
+    ↓ wrap com spans OpenTelemetry
+opentelemetry-erlang (pacote hex)
+    ↓ export OTLP
+Langfuse /api/public/otel endpoint
+    ↓
+ClickHouse (traces/observations)
+```
+
+**Implementação prática:**
+
+```elixir
+# Em AgentChat.LLM, envolver chamadas LLM com telemetry
+def run_completion(model, messages, tools, opts) do
+  metadata = %{model: model, provider: "openai"}
+
+  :telemetry.span([:lanttern, :llm, :call], metadata, fn ->
+    result = do_llm_call(model, messages, tools, opts)
+
+    end_metadata =
+      case result do
+        {:ok, response} ->
+          %{tokens_in: response.usage.input, tokens_out: response.usage.output}
+        {:error, _} ->
+          %{error: true}
+      end
+
+    {result, Map.merge(metadata, end_metadata)}
+  end)
+end
+```
+
+A biblioteca OpenTelemetry se inscreve nesses eventos de telemetry e os exporta como spans para o endpoint OTLP da Langfuse. Isso é não-invasivo — o código de negócio emite eventos, a camada de infraestrutura cuida da exportação.
+
+### Comparação de pricing
+
+| Plano | Mensal | Traces/mês | Por 100K extra | Usuários | Retenção |
+|---|---|---|---|---|---|
+| **Hobby (Gratuito)** | $0 | 50.000 | — | 2 | 30 dias |
+| **Core** | $29 | 1.000.000 | $8 | Ilimitados | 90 dias |
+| **Pro** | $199 | 5.000.000 | $8 | Ilimitados | 2 anos |
+| **Self-hosted** | $0 (software) | Ilimitados | — | Ilimitados | Ilimitado |
+
+### Recomendação para o Lanttern
+
+**Phase 1-2**: Usar telemetry customizado + tabela `llm_calls` existente. Adicionar eventos `:telemetry` para chamadas LLM. Criar cron job Oban para agregar custos por escola.
+
+**Phase 3**: Adotar Langfuse Cloud (tier Hobby gratuito ou Core $29). Integrar via OpenTelemetry. Usar para tracing, dashboards de custo e experimentos iniciais de avaliação.
+
+**Phase 5+**: Avaliar Langfuse self-hosted quando (a) volume de traces exceder 5M/mês, (b) sensibilidade de dados exigir on-premises, ou (c) features avançadas como gestão de prompts justificarem o investimento em infraestrutura.
+
+---
+
+## 5. Deep Dive: Arquitetura Microservice e Ecossistemas Cross-Language
+
+### Ecossistema Python de AI — O que o Elixir não tem
+
+#### Orquestração de Agents
+
+| Framework | Status | O que faz | Equivalente Elixir |
+|---|---|---|---|
+| **LangGraph** | Production-ready (v1.0, Out 2025) | Agents stateful com checkpointing, time-travel debugging, human-in-the-loop, 5 modos de streaming, durable execution | **Nada** — nosso custom tool_call_loop é ~5% do feature set do LangGraph |
+| **CrewAI** | Production-ready | Times multi-agent baseados em papéis. Defina agents com roles, goals, tools e deixe-os colaborar. | **Nada** — nenhum framework multi-agent em Elixir |
+| **AG2/AutoGen** | Quase pronto (v1.0 vindo) | Cenários multi-agent complexos com execução de código, uso de tools e human-in-the-loop | **Nada** |
+| **LlamaIndex** | Production-ready | Agents RAG-first, document loaders, chunking, vector stores, pipelines de retrieval | **Nada** — precisa construir RAG manualmente |
+
+#### Structured Output e Validação
+
+| Framework | Status | O que faz | Equivalente Elixir |
+|---|---|---|---|
+| **Instructor** | Production-ready (3M+ downloads/mês) | Outputs LLM estruturados schema-first com retries automáticos e validação | Validação com Ecto schema (manual, sem lógica de retry LLM) |
+| **Pydantic AI** | Production-ready | Agents type-safe com dependency injection, streaming e observabilidade built-in | Nada equivalente |
+| **DSPy** | Emergente | Otimização automática de prompts — escreve e ajusta prompts algoritmicamente | **Nada** — capacidade única |
+
+#### Avaliação e Segurança
+
+| Framework | Status | O que faz | Equivalente Elixir |
+|---|---|---|---|
+| **DeepEval** | Production-ready | Testes unitários estilo pytest para LLMs — detecção de alucinação, scoring de relevância, checagem de toxicidade | **Nada** |
+| **RAGAS** | Production-ready | Avaliação de RAG baseada em pesquisa — faithfulness, relevância de resposta, precisão de contexto | **Nada** |
+| **PromptFoo** | Production-ready | Red-teaming de segurança, teste de prompt injection, detecção de output nocivo | **Nada** |
+
+#### Sistemas de Memória
+
+| Sistema | O que faz | Equivalente Elixir |
+|---|---|---|
+| **mem0** | Camada de memória gerenciada — auto-categoriza, vector search, scoping por user/session/agent | Tabela customizada `user_ai_memories` (mais simples, mas adequada) |
+| **MemGPT/Letta** | Memória de agent auto-editável com storage em camadas (core/archival/recall) | Nada equivalente |
+| **LangGraph checkpointing** | Persistência de estado de conversa com time-travel e branching | Nada — usamos banco de dados para estado |
+
+### Ecossistema TypeScript de AI — A opção frontend-native
+
+| Framework | Ponto forte | O que adiciona sobre Elixir |
+|---|---|---|
+| **Vercel AI SDK** | Streaming SSE nativo, `useChat`, rendering de tool calls | Sem bridge Phoenix necessário — backend e frontend falam a mesma linguagem |
+| **LangChain.js** | Framework AI JS mais abrangente | Suporte RAG, agent chains — mas um port do Python, não design nativo TS |
+| **LangGraph.js** | Mesmas features que LangGraph Python | Agents stateful, streaming, checkpointing — em TypeScript |
+| **Mastra** | Framework AI TypeScript-native | Abstrações limpas, routing built-in, emergente mas bem financiado |
+
+### Diagramas de arquitetura
+
+#### Opção B: Sidecar Python (co-deployed)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Same pod / VM / deployment unit                              │
+│                                                               │
+│  ┌─────────────────────┐     ┌─────────────────────────────┐ │
+│  │  Phoenix (Elixir)    │     │  FastAPI (Python)            │ │
+│  │                      │     │                              │ │
+│  │  • LiveView UI       │     │  • LLM orchestration         │ │
+│  │  • Scope/Auth        │     │  • LangGraph agents          │ │
+│  │  • Business logic    │     │  • Streaming (SSE)           │ │
+│  │  • Ecto/DB access    │     │  • Evaluation (DeepEval)     │ │
+│  │  • PubSub            │     │  • Memory (mem0)             │ │
+│  │  • Oban jobs         │     │                              │ │
+│  │                      │◄────┤  Tool calls: POST            │ │
+│  │  Internal API:       │     │  /internal/tools/create_lesson│ │
+│  │  POST /internal/     │────►│                              │ │
+│  │  tools/*             │     │  Context: GET                │ │
+│  │                      │     │  /internal/context/:conv_id  │ │
+│  └──────────┬───────────┘     └──────────────┬──────────────┘ │
+│             │                                │                │
+│             └──────────┬─────────────────────┘                │
+│                        ▼                                      │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │  Shared PostgreSQL (+ pgvector)                          │ │
+│  │  Shared Redis (Oban + FastAPI cache + PubSub bridge)     │ │
+│  └─────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Fluxo de dados para uma mensagem do usuário (sidecar):**
+
+```
+1. User submits prompt → Phoenix LiveView
+2. Phoenix saves message to DB, sets conversation "processing"
+3. Phoenix calls FastAPI: POST http://localhost:8000/chat
+   Body: {conversation_id, user_id, scope_token, model, tools_enabled}
+4. FastAPI loads context: GET http://localhost:4000/internal/context/{conv_id}
+   Phoenix returns: {system_messages, memories, tool_definitions}
+5. FastAPI runs LangGraph agent with streaming
+6. On tool call: FastAPI calls Phoenix: POST http://localhost:4000/internal/tools/create_lesson
+   Phoenix executes with Scope auth, returns result
+7. On text chunk: FastAPI publishes to Redis
+   Phoenix PubSub bridge picks up → broadcasts to LiveView
+8. On completion: FastAPI calls Phoenix: POST http://localhost:4000/internal/messages
+   Phoenix saves assistant message + model_call to DB
+```
+
+#### Opção C: Microservice completo (deploy separado)
+
+```
+┌─────────────────────────┐         ┌─────────────────────────┐
+│  Phoenix (Elixir)        │         │  AI Service (Python)     │
+│  Deployment A            │         │  Deployment B            │
+│                          │         │                          │
+│  • LiveView UI           │  gRPC   │  • LangGraph agents      │
+│  • Scope/Auth            │◄───────►│  • LLM orchestration     │
+│  • Business logic        │  or     │  • Evaluation pipeline   │
+│  • Ecto/DB              │  REST   │  • Memory management     │
+│  • PubSub               │         │  • RAG (if needed)       │
+│  • Oban                  │         │                          │
+│                          │         │                          │
+│  PostgreSQL A            │         │  PostgreSQL B (optional)  │
+│  (domain data)           │         │  (AI state, vectors)     │
+│                          │         │  Redis (Celery queues)   │
+└─────────────────────────┘         └─────────────────────────┘
+```
+
+**Complexidade adicional na Opção C:**
+- Service discovery e health checks
+- Autenticação de rede entre serviços
+- Versionamento de API e contract testing
+- Tracing distribuído entre serviços
+- Deploys coordenados (breaking changes)
+- Dois pipelines separados de CI/CD
+
+### Comparação de custos operacionais
+
+| Dimensão | Opção A: Monolith Elixir | Opção B: Sidecar Python | Opção C: Microservice completo |
+|---|---|---|---|
+| **Infraestrutura** | ~$5K/mês | ~$5.5-6.5K/mês (+10-30%) | ~$18-30K/mês (3.75-6x) |
+| **Engenheiros necessários** | 2-3 Elixir | 2-3 Elixir + 1-2 Python | 2-3 Elixir + 2-4 Python + 1 plataforma |
+| **Complexidade de deploy** | Pipeline único | Pipeline único (mesma unidade) | Dois pipelines + coordenação |
+| **Monitoramento** | LiveDashboard + Oban Web | Mesmo + métricas FastAPI | Tracing distribuído obrigatório |
+| **Resposta a incidentes** | Um codebase para debugar | Dois codebases, mesmo host | Dois codebases, problemas de rede |
+| **Tempo até primeira feature** | Rápido (sem setup) | +1-2 semanas (setup FastAPI, camada bridge) | +4-6 semanas (infra, networking, auth) |
+
+### Realidade do pool de contratação
+
+| Linguagem | Desenvolvedores globais | Especializados em AI | Dificuldade de contratação para roles de AI |
+|---|---|---|---|
+| **Python** | ~3.2M contribuidores | 95% do trabalho de AI | Moderada — grande pool, alta demanda |
+| **TypeScript** | ~3M contribuidores | ~5% do trabalho de AI | Fácil (geral) / Difícil (específico para AI) |
+| **Elixir** | ~50K contribuidores | <1% do trabalho de AI | Muito difícil — pool minúsculo, quase nenhuma especialização em AI |
+
+**Implicação prática**: Se o Lanttern precisar contratar um engenheiro de AI, ele quase certamente será um desenvolvedor Python. O padrão sidecar (Opção B) é a forma natural de integrar a expertise dele sem reescrever o codebase Elixir.
+
+---
+
+## 6. Deep Dive: Escolhendo o Stack Frontend — CopilotKit + AG-UI vs Vercel AI SDK vs assistant-ui
+
+### O AG-UI Protocol
+
+AG-UI (Agent-User Interaction Protocol) é um **padrão aberto** para comunicação agent↔frontend, adotado por Google, AWS, LangChain, Microsoft, Mastra e PydanticAI. Define um formato de eventos SSE estruturado, projetado especificamente para AI agents — não apenas chatbots.
+
+**Tipos de evento:**
+
+| Evento | Propósito | Exemplo |
+|---|---|---|
+| `RUN_STARTED` / `RUN_FINISHED` | Tracking de lifecycle do agent | Mostrar indicador "pensando..." |
+| `TEXT_MESSAGE_START` / `CONTENT` / `END` | Streaming de tokens | Exibir texto conforme é gerado |
+| `TOOL_CALL_START` / `TOOL_CALL_END` | Tracking de execução de tools | Mostrar "criando aula..." com spinner |
+| `STATE_SNAPSHOT` | Broadcast de estado completo do agent | Sincronizar estado da conversa ao reconectar |
+| `STATE_DELTA` | Updates incrementais de estado | Atualizar elementos UI específicos em tempo real |
+| `STEP_STARTED` / `STEP_FINISHED` | Tracking de workflows multi-step | Mostrar progresso através do workflow do agent |
+
+**Comparação com Vercel Data Stream Protocol:**
+
+| Aspecto | AG-UI Protocol | Vercel Data Stream Protocol |
+|---|---|---|
+| **Projetado para** | AI agents com estado complexo | Interfaces de chat com streaming de texto |
+| **Gestão de estado** | First-class (snapshots + deltas) | Não suportado |
+| **Human-in-the-loop** | Eventos nativos para workflows de aprovação | Não suportado |
+| **Detalhe de tool call** | Start, args, progresso, resultado, end | Start, resultado apenas |
+| **Lifecycle do agent** | Eventos completos de lifecycle | Apenas sinal de done |
+| **Workflows multi-step** | Eventos de tracking de steps | Não suportado |
+| **Adoção** | Google, AWS, Microsoft, LangChain | Ecossistema Vercel |
+| **Maturidade** | Mais novo (2025), crescendo rapidamente | Estabelecido (2024), amplamente usado |
+
+### CopilotKit — Plataforma completa implementando AG-UI
+
+CopilotKit é uma plataforma React que implementa o AG-UI Protocol, fornecendo componentes pré-prontos para interfaces de AI agents.
+
+**Componentes:** `<CopilotChat>`, `<CopilotPopup>`, `<CopilotSidebar>`, `<CopilotTextarea>`
+
+**Features principais:**
+- **Generative UI**: Agent pode renderizar componentes React customizados inline (ex: lesson cards, diálogos de aprovação)
+- **Sincronização de estado**: Sync em tempo real entre estado do agent e UI via eventos STATE_SNAPSHOT/DELTA
+- **Human-in-the-loop**: Workflows de aprovação nativos (agent pausa, mostra UI de aprovação, retoma na ação do usuário)
+- **Auto-tool rendering**: Tool calls automaticamente renderizam como elementos UI interativos
+- **LangGraph nativo**: Integração direta via AG-UI — nenhuma camada de conversão necessária
+
+**Prós:** UX de agent mais rica out of the box, protocolo AG-UI aberto, backing corporativo forte, open source core
+
+**Contras:** Mais opinionado, modelo freemium, comunidade menor que Vercel AI SDK (~15k vs ~60k stars), footprint de dependência maior
+
+### assistant-ui — Componentes headless de chat
+
+assistant-ui é uma biblioteca de componentes React headless especificamente para interfaces de chat AI. Mais leve que CopilotKit e dá mais controle sobre a UI.
+
+**Features principais:**
+- **LangGraphMessageAccumulator**: Handler de streaming eficiente para eventos LangGraph
+- **Componentes headless**: Você controla cada detalhe visual (sem estilos por padrão)
+- **Adapter LangGraph Cloud**: Conexão direta à API do LangGraph Cloud/Studio
+- **Conteúdo rico**: Markdown, code highlighting, attachments, voice input
+- **UX de produção**: Auto-scroll, retry, abort, reconexão
+
+**Prós:** Máxima customização visual, mais leve que CopilotKit, boa integração LangGraph, totalmente open source
+
+**Contras:** Sem sincronização de estado, sem human-in-the-loop, sem generative UI, comunidade menor (~5k stars)
+
+### Vercel AI SDK — Hooks leves de streaming
+
+Já coberto no [Deep Dive: Vercel AI SDK](#3-deep-dive-vercel-ai-sdk). Adições para esta comparação:
+
+**Limitações com backend LangGraph:** O adapter `@ai-sdk/langchain` converte o stream rico do LangGraph para o Data Stream Protocol mais simples. Essa conversão é **lossy** — eventos STATE, eventos de lifecycle e progresso detalhado de tools são descartados. Para chat simples, essa perda não importa. Para UX de agent (indicadores de status, workflows de aprovação, state sync), importa.
+
+### Tabela de comparação: Todas as quatro opções
+
+| Dimensão | CopilotKit + AG-UI | assistant-ui | Vercel AI SDK | AG-UI direto (sem lib) |
+|---|---|---|---|---|
+| **Protocolo** | AG-UI (eventos ricos) | Adapters customizados | Data Stream Protocol | AG-UI (raw) |
+| **Eventos suportados** | TEXT, TOOL_CALL, STATE, HUMAN_APPROVAL, lifecycle | TEXT, TOOL_CALL (via adapters) | Texto + tool calls básicos | Todos os eventos AG-UI |
+| **State sync** | Sim (snapshots + deltas) | Não | Não | Sim (handling manual) |
+| **Human-in-the-loop** | Nativo | Não | Não | Sim (manual) |
+| **Fit com LangGraph** | Mapeamento nativo 1:1 | Via LangGraphMessageAccumulator | Adapter com perda de info | 1:1 (manual) |
+| **Comunidade** | ~15k stars + Google/AWS/MS | ~5k stars | ~60k stars | Padrão aberto, emergente |
+| **Complexidade** | Opinionado (plataforma) | Headless (flexível) | Leve (apenas hooks) | DIY (máx controle) |
+| **Customização UI** | Média (componentes prontos) | Alta (headless, sem estilos) | Média (hooks + custom) | Total |
+| **Backend Python** | Nativo via AG-UI Python SDK | Via adapter LangGraph Cloud | Via fastapi-ai-sdk | Nativo |
+| **Backend TypeScript** | Suportado | Suportado | Nativo | Suportado |
+| **Backend Elixir** | Via endpoint SSE | Via endpoint SSE | Via endpoint SSE | Via endpoint SSE |
+| **Pricing** | Open source + cloud pago | Open source | Open source | Open source |
+| **Melhor para** | Agents complexos, UX rica | Chat customizável | Chat simples, qualquer backend | Controle total, time experiente |
+
+### Quando usar cada — Exemplos de aplicações
+
+**CopilotKit + AG-UI** — Melhor para interações complexas com agents:
+- Plataforma educacional onde AI cria aulas e o professor aprova antes de salvar
+- Agent de CRM que preenche forms, sugere ações e espera confirmação do usuário
+- Sistema multi-agent onde a UI mostra qual agent está ativo e seu step atual
+- Assistente de IDE que edita código e mostra diffs inline para aprovação
+
+**assistant-ui** — Melhor para interfaces de chat customizáveis:
+- Chat com attachments, voice input e rendering rico de markdown
+- Projeto com design system existente que deve ser aplicado à UI de chat
+- Integração com LangGraph Cloud onde o adapter cuida do backend
+- App centrada em chat onde customização visual é mais importante que features de estado do agent
+
+**Vercel AI SDK** — Melhor para chat simples e rápido de construir:
+- Chatbot de suporte ao cliente com Q&A de texto
+- Ferramenta de geração de conteúdo (escrever emails, resumir documentos)
+- Features de autocompletion/sugestão
+- Qualquer chat que não precisa de UI rica de tool call ou awareness de estado do agent
+
+### Análise para requisitos do Lanttern
+
+| Requisito Lanttern | CopilotKit | assistant-ui | Vercel AI SDK | Vencedor |
+|---|---|---|---|---|
+| Lesson card inline no chat | Tool rendering nativo | Custom (headless) | Custom renderer | **CopilotKit** |
+| Professor aprova criação de aula | Human-in-the-loop nativo | Não suporta | Não suporta | **CopilotKit** |
+| Streaming de tokens | Sim | Sim | Sim | Empate |
+| Status do agent ("criando aula...") | Eventos STATE_DELTA | Não suporta | Não suporta | **CopilotKit** |
+| Backend LangGraph (sidecar Python) | Mapeamento nativo | Via adapter | Adapter com perda | **CopilotKit** |
+| Backend LiveView (monolith Elixir) | Endpoint SSE necessário | Endpoint SSE necessário | Endpoint SSE necessário | Empate |
+| Customização visual (match design Lanttern) | Média | **Alta** | Média | **assistant-ui** |
+| Comunidade e longevidade | Menor + backing corporativo | Pequena | Grande | Vercel (leve vantagem) |
+| Simplicidade de setup | Médio | Simples | Mais simples | Vercel |
+
+### Recomendação para o Lanttern (condicional)
+
+**Se sidecar Python for adotado (backend LangGraph):**
+→ **CopilotKit + AG-UI** — As features de UX de agent (human-in-the-loop, state sync, tool rendering) mapeiam diretamente para os requisitos do Lanttern. O workflow de aprovação de aulas sozinho justifica esta escolha.
+
+**Se monolith Elixir continuar (sem LangGraph):**
+→ **Vercel AI SDK** — Mais leve, mais simples, suficiente para chat básico com tool calls. O agent não tem os eventos ricos de estado do LangGraph, então as features avançadas do AG-UI seriam overhead não utilizado.
+
+**Se ainda no LiveView (Fases 1-3):**
+→ **Nenhum dos dois** — Usar LiveView PubSub para streaming e function components Phoenix para UI rica. Todas as três opções React requerem o setup de React islands.
+
+**Independente da escolha**, a arquitetura backend (`AgentChat.LLM`, `AgentChat.Tools`, `AgentChat.ContextResolver`) permanece a mesma. A decisão de frontend é independente e reversível.
+
+---
+
+## 7. Arquitetura Alvo
+
+### Diagrama de arquitetura
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        CAMADA UI                                  │
+│                                                                   │
+│  Fases 1-3: LiveView                                              │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │ StrandChatLive / LessonChatLive / UniversalChatLive        │  │
+│  │   └── ConversationComponent (LiveComponent)                │  │
+│  │         - Rendering do message stream                      │  │
+│  │         - Componentes inline ricos (cards de aula, etc.)   │  │
+│  │         - Formulário de prompt, seletores agent/template   │  │
+│  │         - Recebe updates push via PubSub                   │  │
+│  └────────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  Fase 5+: React island (aditivo, não substituindo)                │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │ ChatIsland (React + Vercel AI SDK)                         │  │
+│  │   - useChat() conectado ao endpoint SSE /api/chat          │  │
+│  │   - Renderers customizados de tool calls (LessonCard, etc.)│  │
+│  │   - Auto-scroll, abort, retry                              │  │
+│  └────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │
+          ┌────────────────────┼─────────────────────┐
+          │ 1. Usuário submete │ 6. PubSub broadcast  │ (ou SSE para React)
+          │    prompt          │    {:message_added}   │
+          ▼                    │                       │
+┌──────────────────────────────┴───────────────────────────────────┐
+│                     CAMADA DE CONTEXTO                             │
+│                                                                   │
+│  Lanttern.AgentChat (módulo de contexto)                          │
+│    - create_conversation_with_message/3                           │
+│    - add_user_message/3                                           │
+│    - add_assistant_message/3                                      │
+│    - list_conversation_messages/2                                 │
+│    - subscribe/broadcast PubSub                                   │
+│                                                                   │
+│  Lanttern.AgentChat.LLM (NOVO — abstração LLM)                   │
+│    - run_completion/4  (substitui run_llm_chain)                  │
+│    - stream_completion/4  (Phase 4)                               │
+│    - build_messages/3                                             │
+│    - tool_call_loop/3  (substitui while_needs_response LangChain) │
+│    - extract_response/1                                           │
+│    → Usa ReqLLM internamente. NENHUM tipo LLM vaza pra fora.     │
+│                                                                   │
+│  Lanttern.AgentChat.Tools (NOVO — registro de tools)              │
+│    - define_tools/2  (retorna specs de tools para LLM)            │
+│    - execute_tool/3  (despacha para funções de contexto de neg.)  │
+│    - Tools: create_lesson, update_lesson, set_conversation_title  │
+│                                                                   │
+│  Lanttern.AgentChat.Memory (NOVO — Phase 3)                       │
+│    - list_user_memories/2                                         │
+│    - create_memory/2                                              │
+│    - summarize_conversation/2                                     │
+│    - inject_memory_messages/2                                     │
+│                                                                   │
+│  Lanttern.AgentChat.ContextResolver (NOVO — Phase 2)              │
+│    - resolve/1  (conversation_id -> system messages)              │
+│    - register_context/3                                           │
+│    - context_to_system_messages/1  (por context_type)             │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │
+          ┌────────────────────┼─────────────────────┐
+          │ 2. Oban.insert()   │ 5. AgentChat         │
+          │                    │    .add_assistant_msg  │
+          ▼                    │    .broadcast          │
+┌──────────────────────────────┴───────────────────────────────────┐
+│                      CAMADA DE WORKERS                            │
+│                                                                   │
+│  Lanttern.ChatResponseWorker (Oban, queue: :ai)                   │
+│    1. Resolver scope do user_id                                   │
+│    2. Resolver modelo (args → config escola → app default)        │
+│    3. Buscar conversa + mensagens                                 │
+│    4. Injetar memória  (AgentChat.Memory — Phase 3)               │
+│    5. Resolver contexto (AgentChat.ContextResolver — Phase 2)     │
+│    6. Chamar AgentChat.LLM.run_completion/4                       │
+│    7. Lidar com tool calls via AgentChat.Tools                    │
+│    8. Persistir resposta + model call                             │
+│    9. Broadcast via PubSub                                        │
+│   10. Trigger atualização de memória (Phase 3)                    │
+│                                                                   │
+│  Lanttern.MemorySummaryWorker (NOVO — Phase 3, Oban, queue: :ai)  │
+│    - Acionado após fim de conversa                                │
+│    - Resume conversa em entradas de memória                       │
+│                                                                   │
+│  Lanttern.CostAggregationWorker (NOVO — Phase 4, Oban cron)       │
+│    - Agregação periódica de llm_calls para relatórios de custo    │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │
+                               │ 3. ReqLLM.generate_text/3
+                               │    (ou stream_text/3 na Phase 4)
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                  CAMADA DE CLIENT LLM                             │
+│                                                                   │
+│  ReqLLM (unificado, baseado em Req)                               │
+│    - OpenAI, Anthropic, Google, Mistral, Groq, AWS Bedrock...     │
+│    - Suporte a tool calling                                       │
+│    - Suporte a streaming SSE                                      │
+│    - Middleware Req para retries, logging, telemetry               │
+│                                                                   │
+│  LLMDB (catálogo de validação de modelos)                         │
+│    - LLMDB.allowed?/1                                             │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │
+                               │ 4. Eventos Telemetry
+                               │    [:lanttern, :llm, :call, ...]
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                 CAMADA DE OBSERVABILIDADE                         │
+│                                                                   │
+│  Fases 1-2: Telemetry + tabela llm_calls + LiveDashboard          │
+│  Fase 3+:   OpenTelemetry → Langfuse (Cloud ou self-hosted)       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Regras de fronteira entre módulos
+
+| Módulo | Responsabilidade | Depende De | NÃO depende de |
+|---|---|---|---|
+| `AgentChat` | Acesso a dados (CRUD), PubSub | Ecto, PubSub | ReqLLM, qualquer lib LLM |
+| `AgentChat.LLM` | Interação LLM: prompts, completion, tool loop | ReqLLM, LLMDB | Ecto, PubSub, Oban |
+| `AgentChat.Tools` | Definições de tools e dispatch de execução | Contextos de negócio (Lessons, etc.) | ReqLLM, Ecto |
+| `AgentChat.Memory` | CRUD de memória, sumarização, injeção | Ecto, AgentChat.LLM (para sumarização) | PubSub, Oban |
+| `AgentChat.ContextResolver` | Resolução polimórfica de contexto | Ecto, contextos de negócio | LLM, PubSub |
+| `ChatResponseWorker` | Orquestração: conecta todos os módulos | Todos os módulos AgentChat | LiveView |
+| `ConversationComponent` | Rendering UI, interação do usuário | AgentChat (contexto apenas) | LLM, Tools, Memory, Worker |
+
+**Fronteira crítica**: Nenhum tipo de biblioteca LLM vaza para fora de `AgentChat.LLM`. O módulo de contexto trabalha com strings e maps Elixir puros. Se ReqLLM for substituído depois, apenas `AgentChat.LLM` muda.
+
+---
+
+## 8. Evolução do Schema do Banco de Dados
+
+### Phase 1: Contextos polimórficos de conversa
+
+```sql
+-- Substituir strand_agent_conversations por context links polimórficos
+CREATE TABLE conversation_contexts (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES agent_conversations(id) ON DELETE CASCADE,
+  context_type VARCHAR(50) NOT NULL,
+  context_id BIGINT NOT NULL,
+  context_metadata JSONB DEFAULT '{}',
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_conversation_contexts_unique
+  ON conversation_contexts(conversation_id, context_type, context_id);
+
+CREATE INDEX idx_conversation_contexts_type_id
+  ON conversation_contexts(context_type, context_id);
+```
+
+**Migração de dados**: Migrar linhas de `strand_agent_conversations` para `conversation_contexts`:
+- Cada linha se torna 1 ou 2 linhas em `conversation_contexts` (`context_type: "strand"` + opcionalmente `context_type: "lesson"`)
+- Deixar `strand_agent_conversations` como está (dívida técnica, regra 7 do CLAUDE.md)
+
+### Phase 2: Metadata de mensagens + memória de usuário
+
+```sql
+-- Metadata rica de mensagens (tool calls, componentes UI)
+ALTER TABLE agent_messages ADD COLUMN metadata JSONB DEFAULT '{}';
+
+-- Memória AI do usuário
+CREATE TABLE user_ai_memories (
+  id BIGSERIAL PRIMARY KEY,
+  profile_id BIGINT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  school_id BIGINT NOT NULL REFERENCES schools(id) ON DELETE CASCADE,
+  category VARCHAR(50) NOT NULL DEFAULT 'general',
+  summary TEXT NOT NULL,
+  source_type VARCHAR(50) NOT NULL DEFAULT 'conversation',
+  source_id BIGINT,
+  relevance_score FLOAT DEFAULT 1.0,
+  expires_at TIMESTAMP,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_user_ai_memories_profile ON user_ai_memories(profile_id);
+CREATE INDEX idx_user_ai_memories_school ON user_ai_memories(school_id);
+```
+
+**Estrutura do metadata de mensagens:**
+
+```json
+{
+  "tool_calls": [
+    {"name": "create_lesson", "args": {"moment_id": 1, "description": "..."}}
+  ],
+  "tool_results": [
+    {"name": "create_lesson", "result": {"lesson_id": 42, "status": "ok"}}
+  ],
+  "ui_component": "lesson_card",
+  "ui_data": {"lesson_id": 42, "lesson_name": "Introdução a Frações"}
+}
+```
+
+### Phase 3: Agregação de tracking de custos
+
+```sql
+CREATE TABLE ai_usage_reports (
+  id BIGSERIAL PRIMARY KEY,
+  school_id BIGINT NOT NULL REFERENCES schools(id),
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  total_prompt_tokens BIGINT DEFAULT 0,
+  total_completion_tokens BIGINT DEFAULT 0,
+  total_estimated_cost_cents INTEGER DEFAULT 0,
+  model_breakdown JSONB DEFAULT '{}',
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_ai_usage_reports_school_period
+  ON ai_usage_reports(school_id, period_start, period_end);
+```
+
+### Phase 4: Configuração de orçamento de tokens
+
+```sql
+-- Adicionar à tabela school_ai_configs existente
+ALTER TABLE school_ai_configs ADD COLUMN monthly_token_budget BIGINT;
+ALTER TABLE school_ai_configs ADD COLUMN budget_alert_threshold FLOAT DEFAULT 0.8;
+```
+
+---
+
+## 9. Roadmap de Implementação
+
+### Phase 1: Consolidação de Bibliotecas + Abstração LLM (~2 semanas)
+
+**Objetivo**: Remover dependência do LangChain; estabelecer fronteiras de módulos limpas.
+
+| Passo | Tarefa | Arquivos afetados | Risco |
+|---|---|---|---|
+| 1.1 | Criar módulo `Lanttern.AgentChat.LLM` com `run_completion/4` que wrappa ReqLLM | Novo: `lib/lanttern/agent_chat/llm.ex` | Baixo |
+| 1.2 | Criar módulo `Lanttern.AgentChat.Tools`; extrair definições de tools de `agent_chat.ex` | Novo: `lib/lanttern/agent_chat/tools.ex`; Modificado: `agent_chat.ex` | Baixo |
+| 1.3 | Implementar tool call loop em `AgentChat.LLM` (substitui `while_needs_response`) | `agent_chat/llm.ex` | **Médio** — deve lidar com tool calls multi-turn corretamente |
+| 1.4 | Reescrever `run_llm_chain/4` para usar `AgentChat.LLM.run_completion/4` | `agent_chat.ex` | Médio |
+| 1.5 | Reescrever `ChatResponseWorker` para usar `AgentChat.LLM` ao invés de `ChatOpenAI` | `workers/chat_response_worker.ex` | Médio |
+| 1.6 | Reescrever `rename_conversation_based_on_chain/3` para usar `AgentChat.LLM` | `agent_chat.ex` | Baixo |
+| 1.7 | Atualizar testes: substituir mocks Mimic do LangChain por stubs ReqLLM | Arquivos de teste | Médio |
+| 1.8 | Remover `{:langchain, "0.4.0"}` de `mix.exs`; remover config LangChain | `mix.exs`, `config/*.exs` | Baixo |
+| 1.9 | Adicionar eventos `:telemetry` para chamadas LLM | `agent_chat/llm.ex` | Baixo |
+
+**Entregável**: Todas as features AI funcionam identicamente ao que é hoje, mas utilizando ReqLLM através da abstração `AgentChat.LLM`. LangChain removido das dependências.
+
+**Verificação**:
+- Todos os testes existentes passam
+- Teste manual: criar conversa, enviar mensagem, verificar resposta
+- Teste manual: usar tool create_lesson, verificar que aula é criada
+- Teste manual: verificar que auto-rename funciona
+- `mix deps` não mostra dependência do LangChain
+
+### Phase 2: Contexto Universal + Mensagens Ricas (~2 semanas)
+
+**Objetivo**: Sistema polimórfico de contexto; metadata de mensagens para UI rica.
+
+| Passo | Tarefa |
+|---|---|
+| 2.1 | Criar migration e schema Ecto para `conversation_contexts` |
+| 2.2 | Criar módulo `Lanttern.AgentChat.ContextResolver` |
+| 2.3 | Escrever migração de dados de `strand_agent_conversations` para `conversation_contexts` |
+| 2.4 | Adicionar coluna `metadata` JSONB em `agent_messages` |
+| 2.5 | Modificar `ChatResponseWorker` para usar `ContextResolver` na construção de system prompts |
+| 2.6 | Quando tools executam (ex: `create_lesson`), armazenar referência da entidade no metadata da mensagem |
+| 2.7 | Modificar `ConversationComponent` para renderizar componentes inline ricos baseados em `message.metadata` |
+| 2.8 | Criar componente inline de card de aula para o conversation stream |
+
+**Entregável**: Conversas podem ser vinculadas a qualquer tipo de entidade. Resultados de tool calls renderizam como componentes UI ricos (cards de aula) ao invés de texto plano.
+
+**Verificação**:
+- Conversas de strand existentes continuam funcionando (migração de dados verificada)
+- Novas conversas criam linhas em `conversation_contexts`
+- Quando AI cria uma aula, um card de aula aparece inline no chat
+- Context resolver carrega system messages corretas por tipo de entidade
+
+### Phase 3: Sistema de Memória (~2 semanas)
+
+**Objetivo**: Memória de usuário entre conversas.
+
+| Passo | Tarefa |
+|---|---|
+| 3.1 | Criar migration e schema Ecto para `user_ai_memories` |
+| 3.2 | Criar módulo `Lanttern.AgentChat.Memory` |
+| 3.3 | Criar job Oban `Lanttern.MemorySummaryWorker` |
+| 3.4 | Adicionar injeção de memória Layer 0 na construção de prompts |
+| 3.5 | Adicionar lógica de close/checkpoint de conversa que aciona sumarização de memória |
+| 3.6 | Adicionar página de gestão de memória (staff pode visualizar/deletar próprias memórias) |
+| 3.7 | Integrar Langfuse Cloud (OpenTelemetry ou REST API) |
+
+**Entregável**: O agente lembra preferências do usuário e interações passadas entre conversas. Langfuse fornece tracing e dashboards de custo.
+
+**Verificação**:
+- Completar uma conversa, iniciar uma nova — agente referencia informações da conversa anterior
+- Entradas de memória visíveis nas configurações do staff
+- Deletar uma memória remove-a de prompts futuros
+- Dashboard Langfuse mostra traces com contagem de tokens
+
+### Phase 4: Streaming + Controles de Custo (~2 semanas)
+
+**Objetivo**: Streaming de tokens em tempo real; limites de uso.
+
+| Passo | Tarefa |
+|---|---|
+| 4.1 | Adicionar path de streaming em `AgentChat.LLM` usando streaming do ReqLLM |
+| 4.2 | Adicionar eventos PubSub de chunk (`{:chunk, text}`) |
+| 4.3 | Atualizar `ConversationComponent` para rendering incremental de mensagens |
+| 4.4 | Criar tabela `ai_usage_reports` e `CostAggregationWorker` |
+| 4.5 | Adicionar `monthly_token_budget` a `school_ai_configs` |
+| 4.6 | Adicionar verificação de enforcement de orçamento antes de chamadas LLM |
+| 4.7 | Adicionar dashboard de uso para admins de escola |
+
+**Entregável**: Respostas AI em streaming. Escolas podem definir orçamentos de tokens. Relatórios de uso.
+
+**Verificação**:
+- Tokens aparecem conforme são gerados (sem mais espera pela resposta completa)
+- Enforcement de orçamento previne chamadas quando orçamento é excedido
+- Dashboard de uso mostra breakdown de custo por-escola, por-modelo
+
+### Phase 5: File Uploads + Avaliação React (Sprint 5+)
+
+**Objetivo**: Suporte a contexto baseado em arquivos; avaliar React para UI do chat.
+
+| Passo | Tarefa |
+|---|---|
+| 5.1 | Adicionar suporte a upload de arquivos em conversas (LiveView uploads) |
+| 5.2 | Extração de texto de PDF/documentos para injeção de contexto |
+| 5.3 | Criar controller Phoenix SSE para Vercel AI SDK Data Stream Protocol |
+| 5.4 | Criar React island de chat com hook `useChat` do Vercel AI SDK |
+| 5.5 | Avaliar deploy self-hosted do Langfuse |
+| 5.6 | Implementar enforcement server-side de cooldown do ILP |
+
+**Entregável**: Uploads de arquivo funcionam. React island de chat disponível junto com versão LiveView.
+
+---
+
+## 10. Avaliação de Riscos
+
+| Risco | Probabilidade | Impacto | Mitigação |
+|---|---|---|---|
+| API de tool call do ReqLLM não suporta loop multi-turn | Média | **Alto** | Verificar API de tool calling do ReqLLM no Phase 1 Passo 1.3 antes de comprometer. Fallback: implementar loop de tool call via HTTP raw (ReqLLM é apenas Req por baixo). |
+| Extração de tokens do ReqLLM difere do formato de metadata do LangChain | Média | Baixo | Escrever adapter em `AgentChat.LLM` que normaliza formato de resposta. Isolado por design. |
+| Sumarização de memória produz resumos de baixa qualidade | Média | Médio | Começar com resumos extrativos simples. Iterar na qualidade do prompt. Limitar tamanho da memória. Permitir que usuários deletem memórias ruins. |
+| Tabela polimórfica de contexto causa complexidade de queries | Baixa | Baixo | Índice em `(context_type, context_id)`. Queries são sempre scoped por `conversation_id` (FK indexada). |
+| Streaming LiveView tem latência perceptível vs SSE | Baixa | Baixo | Broadcast PubSub é sub-milissegundo dentro do mesmo node. UX aceitável. |
+| Biblioteca ReqLLM deixa de ser mantida | Baixa | **Alto** | A camada de abstração (`AgentChat.LLM`) isola o app — substituição afeta exatamente um módulo. |
+| Setup de React islands demora mais que o esperado | Média | Baixo | Arquitetura é UI-agnostic por design. Path LiveView continua funcionando independente do timeline do React. |
+| Complexidade de integração Langfuse com Elixir | Média | Médio | Começar com REST API (mais simples). Graduar para OpenTelemetry quando confortável. SDK da comunidade como bridge. |
+| Breaking changes ao migrar do LangChain | Baixa | Médio | Migração é reescrita de 2 arquivos, não refatoração do app inteiro. Testes abrangentes validam comportamento. |
+| Tool call loop tem edge cases (timeout, execução parcial) | Média | Médio | Copiar padrão battle-tested de timeout do LangChain (5 min). Adicionar tratamento de erro estruturado. Testar com chamadas de tool simuladas com lentidão. |

--- a/exploration/ai-oriented-features/ai-agent-feature-plan.md
+++ b/exploration/ai-oriented-features/ai-agent-feature-plan.md
@@ -1,0 +1,1415 @@
+# Lanttern AI Agent Architecture Plan
+
+> Technical architecture document — April 2026
+>
+> Audience: developers, architects, and technical decision-makers working on Lanttern's AI roadmap.
+>
+> This document is **opinionated** — it presents all options with pros/cons but makes clear recommendations with justifications for each architectural decision.
+
+---
+
+## Table of Contents
+
+1. [Context & Problem Statement](#1-context--problem-statement)
+2. [Architectural Decisions](#2-architectural-decisions)
+   - [Decision 1: LLM Client Layer](#decision-1-llm-client-layer)
+   - [Decision 2: Agent Orchestration](#decision-2-agent-orchestration)
+   - [Decision 3: Chat UI & Frontend](#decision-3-chat-ui--frontend)
+   - [Decision 4: Streaming](#decision-4-streaming)
+   - [Decision 5: User Memory](#decision-5-user-memory)
+   - [Decision 6: Universal Conversation Context](#decision-6-universal-conversation-context)
+   - [Decision 7: Observability](#decision-7-observability)
+   - [Decision 8: Monolith vs Microservice](#decision-8-monolith-vs-microservice)
+3. [Deep Dive: Vercel AI SDK](#3-deep-dive-vercel-ai-sdk)
+4. [Deep Dive: Langfuse](#4-deep-dive-langfuse)
+5. [Deep Dive: Microservice Architecture & Cross-Language Ecosystems](#5-deep-dive-microservice-architecture--cross-language-ecosystems)
+6. [Deep Dive: Choosing a Frontend Stack — CopilotKit + AG-UI vs Vercel AI SDK vs assistant-ui](#6-deep-dive-choosing-a-frontend-stack--copilotkit--ag-ui-vs-vercel-ai-sdk-vs-assistant-ui)
+7. [Target Architecture](#7-target-architecture)
+8. [Database Schema Evolution](#8-database-schema-evolution)
+9. [Implementation Roadmap](#9-implementation-roadmap)
+10. [Risk Assessment](#10-risk-assessment)
+
+---
+
+## 1. Context & Problem Statement
+
+### What we have today
+
+Lanttern currently has **two independent AI features** built at different times using different libraries:
+
+| Feature | Library | Purpose | Async? |
+|---------|---------|---------|--------|
+| Agent Chat | LangChain 0.4.0 | Conversational lesson planning | Yes (Oban) |
+| ILP AI Revision | ReqLLM ~> 1.6 | Automated ILP review | No (synchronous) |
+
+Both features communicate exclusively with **OpenAI's API**. There is no streaming — all responses are generated in full before delivery.
+
+### Why we need to refactor now
+
+The current implementation was designed as a **proof of concept (POC)**. With agentic AI being Lanttern's core 2026 feature, continuing to iterate on the POC foundation will produce a snowball of technical debt. The specific issues:
+
+1. **Dual library overhead**: Maintaining two LLM libraries (LangChain + ReqLLM) doubles cognitive load, dependency surface, and config complexity.
+2. **No streaming**: Users wait for full response generation — unacceptable UX for longer interactions.
+3. **No cross-conversation memory**: Every conversation starts from zero. The agent has no awareness of previous interactions with the same user.
+4. **Hardcoded context**: The conversation UI is tied to strands/lessons. The vision is a universal, context-aware chat.
+5. **Text-only tool results**: When the AI creates a lesson, it writes "The lesson was created" in plain text. No rich UI components.
+6. **No cost controls**: Token data is stored but not acted upon. No budgets, no limits, no alerts.
+7. **No observability**: Beyond token counts, there's no tracing, evaluation, or prompt management infrastructure.
+8. **Single provider lock-in**: Both libraries are configured exclusively for OpenAI with no abstraction layer.
+
+### Scope of this document
+
+This document defines the **target architecture** and a **phased implementation roadmap** to address all of the above. Not everything will be built in a single sprint — the plan spreads across 5 phases, each ~2 weeks.
+
+---
+
+## 2. Architectural Decisions
+
+### Decision 1: LLM Client Layer
+
+**Question**: Which library should Lanttern use to interact with LLM APIs?
+
+#### Options
+
+| Dimension | Option A: Status quo (LangChain + ReqLLM) | Option B: Consolidate on ReqLLM | Option C: Full Jido stack |
+|---|---|---|---|
+| **Migration cost** | Zero | Moderate (2 files, ~25 API call sites) | High (new framework, new paradigms) |
+| **Multi-provider** | Both support it in theory; code hardcodes `ChatOpenAI` | 10+ providers native (OpenAI, Anthropic, Google, Mistral, Groq, AWS Bedrock...) | Same as ReqLLM (jido_ai wraps req_llm) |
+| **Streaming** | LangChain supports it, not currently used | `stream_text/3` native SSE support | Same as ReqLLM |
+| **Tool calling** | LangChain `Function`/`FunctionParam` — verbose | `ReqLLM.Tool` — simpler API | `jido_action` — typed actions with compile-time validation, auto-convert to LLM tools |
+| **Cognitive load** | Two APIs, two abstractions, two configs | One API, one abstraction, one config | One ecosystem, but large surface area (jido + jido_ai + jido_action + jido_signal) |
+| **Testing** | LangChain uses Mimic; ReqLLM uses dependency injection | Unified stub pattern (already have `ReqLLMStub`) | New test patterns needed |
+| **Elixir idiom** | LangChain is a port, not native Elixir design | Native Elixir, built on Req | Native Elixir |
+| **Maturity** | LangChain 0.4.0 (unclear update cadence) | v1.0+ stable, production-ready | Jido v2.0 (new, smaller community) |
+| **Orchestration included?** | Yes (LLMChain with `while_needs_response`) | No — you build the tool-call loop | Yes (ReAct, Chain-of-Thought, CoD strategies) |
+
+#### Recommendation: **Option B — Consolidate on ReqLLM**
+
+**Justification:**
+
+1. The LangChain coupling surface is small and bounded — exactly 2 files (`agent_chat.ex` and `chat_response_worker.ex`) with ~25 API call sites. The migration is predictable.
+2. ReqLLM is already in the project, already tested, and its stub pattern (`Lanttern.ReqLLMStub`) is established.
+3. ReqLLM is a focused library (LLM client, not framework) — it does one thing well and leaves orchestration to the application. This matches Lanttern's philosophy of owning business logic.
+4. The `while_needs_response` tool-calling loop that LangChain provides is **20-30 lines of custom Elixir code** — not a reason to keep an entire framework dependency.
+5. Jido (Option C) adds too much framework surface for the current team size. It introduces new concepts (directives, signals, agent state machines) that are not needed for the current use cases. It can be reconsidered when agent complexity warrants it (multiple independent agents, agent-to-agent communication, complex state machines).
+6. Consolidating to one library halves the dependency surface, simplifies testing, and removes the LangChain config from `config.exs` and `runtime.exs`.
+
+**What we lose from LangChain and how to replace it:**
+
+| LangChain feature | Replacement in ReqLLM |
+|---|---|
+| `LLMChain` with `while_needs_response` | Custom `tool_call_loop/3` function (~25 lines) |
+| `ChatOpenAI.new!` | `ReqLLM.generate_text/3` with provider config |
+| `Function` / `FunctionParam` | `ReqLLM.Tool` definitions |
+| `Message.new_user!` / `new_assistant!` / `new_system!` | `ReqLLM.Context.user/1` / `ReqLLM.Context.assistant/1` / `ReqLLM.Context.system/1` |
+| `ContentPart.content_to_string/1` | `ReqLLM.Response.text/1` |
+| Token metadata from `chain.exchanged_messages` | `ReqLLM.Response` usage fields |
+
+#### Cross-language perspective: What would this look like in Python or TypeScript?
+
+| Dimension | Elixir (ReqLLM) | Python | TypeScript |
+|---|---|---|---|
+| **LLM Client** | ReqLLM (community, 10+ providers) | OpenAI SDK / Anthropic SDK (first-class, official, feature-complete) | OpenAI SDK / Anthropic SDK (equal to Python) |
+| **Tool calling** | `ReqLLM.Tool` — manual definitions | `Instructor` (3M+ downloads, schema-first) or `Pydantic AI` (typed, auto-validated) | Vercel AI SDK `tool()` or `zod` schema validation |
+| **Structured output** | Ecto schema validation (manual) | `Instructor` or `Pydantic AI` — automatic structured LLM outputs with retries | `zod` + Vercel AI SDK `generateObject()` |
+| **Maturity** | ReqLLM v1.0 (stable, small community) | OpenAI SDK v1.x (massive community, official support, millions of users) | OpenAI SDK (equal features, Zod-powered types) |
+| **Multi-provider** | Native (10+ via ReqLLM) | Native (each provider has official SDK) + LiteLLM as unified wrapper | Native + Vercel AI SDK abstracts providers |
+
+**Verdict**: Python and TypeScript have **significantly better LLM client tooling** — official SDKs, automatic structured output validation, and larger communities. ReqLLM is adequate but requires more custom code. This gap is real but manageable within `AgentChat.LLM` — the abstraction isolates it.
+
+---
+
+### Decision 2: Agent Orchestration
+
+**Question**: How should Lanttern orchestrate AI agent execution (job management, retries, lifecycle)?
+
+#### Options
+
+| Dimension | Option A: Oban-based (current, enhanced) | Option B: GenServer agents (Jido-style) | Option C: Hybrid (Oban + Task.Supervisor) |
+|---|---|---|---|
+| **Works today** | Yes, proven in production | No — new architecture | Partially |
+| **Streaming support** | Requires parallel path (Task) | Natural fit (GenServer sends incremental messages) | Task.Supervisor handles streaming path |
+| **Reliability** | Built-in retries, dead-letter, unique constraints | Must build crash recovery, supervision | Oban for reliability; Tasks for streaming |
+| **Observability** | Oban Web dashboard already exists | Must build custom | Oban Web for jobs; telemetry for tasks |
+| **Failure handling** | Automatic retry with backoff | GenServer restart via supervisor | Split: Oban retries for batch; task failures for streaming |
+| **Testability** | `testing: :manual` — jobs don't auto-execute | GenServer testing patterns | Two test patterns to maintain |
+| **Memory integration** | Worker queries memory before building prompts | Agent holds conversation state in memory | Same as Option A |
+| **Complexity** | Low — workers are just modules | High — supervision tree, state management, deployment | Moderate — two execution paths |
+
+#### Recommendation: **Option A — Continue Oban-based, with streaming extension (Option C) when streaming is added**
+
+**Justification:**
+
+1. **Oban works.** It provides retries, unique constraints, pruning, observability (via Oban Web), and test isolation (`testing: :manual`). Replacing it would be replacing something that isn't broken.
+2. Adding streaming later does not require replacing Oban — it means adding a parallel path using `Task.Supervisor` for the streaming case. The worker can choose to stream or batch based on configuration.
+3. GenServer agents (Option B) add operational complexity that a small team should avoid unless there is a clear need for in-memory agent state. Currently, all state is in the database — there's no need for in-memory state machines.
+4. If Jido agents are needed in the future (e.g., multi-agent coordination), they can coexist with Oban. This is not an either-or decision.
+
+#### Cross-language perspective: What would this look like in Python or TypeScript?
+
+| Dimension | Elixir (Oban) | Python | TypeScript |
+|---|---|---|---|
+| **Agent framework** | Custom tool_call_loop (~25 lines) | **LangGraph** — stateful agents with checkpointing, time-travel debugging, human-in-the-loop, 5 streaming modes. Industry standard. | **LangGraph.js** — same features, smaller community (42k weekly npm downloads vs Python's dominance) |
+| **Multi-agent** | Nothing production-ready | **CrewAI** (role-based agent teams), **AG2/AutoGen** (complex multi-agent), **Swarm** (lightweight) | LangGraph.js multi-agent, Mastra (emerging) |
+| **Background jobs** | Oban (proven, retries, dashboard, Postgres-backed) | **Celery + Redis** (mature, durable) or **LangGraph** durable execution | **BullMQ** (911-8,300 jobs/sec, Redis-backed) |
+| **State management** | Database (PostgreSQL) | LangGraph checkpointing (in-memory or persistent) — pause/resume/time-travel | LangGraph.js checkpointing |
+| **Fault tolerance** | Oban retries + BEAM supervisors | Celery retries + LangGraph checkpoint recovery | BullMQ retries |
+
+**Verdict**: The orchestration gap is the **largest gap** between Elixir and Python. LangGraph provides stateful agent execution, checkpointing, human-in-the-loop, and multi-agent coordination — none of which exist in Elixir. For Lanttern's current needs (simple request-response agents), Oban is sufficient. But if agents become stateful (tutoring sessions, multi-step workflows), LangGraph's advantages become compelling. This is the primary reason to consider a Python sidecar in the future.
+
+---
+
+### Decision 3: Chat UI & Frontend
+
+**Question**: What technology should power the AI chat user interface?
+
+#### Options
+
+| Dimension | Option A: Enhanced LiveView | Option B: React island + Vercel AI SDK | Option C: React island + assistant-ui | Option D: CopilotKit |
+|---|---|---|---|---|
+| **Migration cost** | Zero | High (React setup + SSE endpoint + hook bridge) | High (React setup + custom protocol) | Very high (full platform adoption) |
+| **Streaming UX** | LiveView streams + PubSub token-by-token push | `useChat` hook handles natively | Custom streaming hook | Built-in streaming |
+| **Rich components** | Function components in message stream (lesson cards, etc.) | React components for tool call results — full flexibility | Same as Vercel | Same but more opinionated |
+| **Team familiarity** | High — entire team knows LiveView | Low — React setup in progress, team learning | Low | Low |
+| **Auto-scroll, reconnect, abort** | Must build manually | `useChat` provides all of these | Partially provided | Fully provided |
+| **Build complexity** | None | esbuild JSX compilation or Vite for React subtree | Same as Vercel | Same + platform SDK |
+| **Dependency footprint** | None | `ai` npm package (~40KB) + React | `@assistant-ui/react` + React | `@copilotkit/react-*` + backend SDK |
+| **Backend coupling** | LiveView socket | SSE endpoint (Vercel Data Stream Protocol) — separate from LiveView | Custom protocol | CopilotKit protocol |
+| **Model agnostic** | Yes (backend chooses model) | Yes (backend streams, SDK is model-agnostic) | Yes | Yes |
+| **Community adoption** | Phoenix community | Industry standard for AI chat | Growing, newer | Large, enterprise-focused |
+
+#### Recommendation: **Option A (Enhanced LiveView) now; transition to Option B (Vercel AI SDK) when React setup is ready**
+
+**Justification:**
+
+1. **Immediate pragmatism**: The React integration is in progress but not ready. Blocking AI architecture work on a React setup would delay the deliverable. LiveView can deliver everything needed for v0: message display, loading states, and even streaming via PubSub.
+
+2. **LiveView handles rich components natively**: When the AI creates a lesson, the `ConversationComponent` can render a `<.lesson_card>` function component inline in the message stream. This requires zero React. The message schema extension (Phase 2) enables this: store `ui_component: "lesson_card"` and `ui_data: %{lesson_id: 123}` in message metadata, then pattern-match in the template.
+
+3. **The Vercel AI SDK is the right long-term choice**: Once React islands are available, the `useChat` hook provides streaming management, auto-scroll, optimistic updates, abort handling, and tool call rendering — all things that would be significant effort to build in LiveView. The transition path is clean because the backend contract (`AgentChat` context, Oban workers, PubSub) is UI-agnostic.
+
+4. **Avoid CopilotKit**: It's a full platform with its own backend framework, which conflicts with Lanttern's Elixir-centric architecture. assistant-ui is a viable alternative to Vercel AI SDK but has a smaller community and less integration documentation for non-Next.js backends.
+
+**Transition plan**:
+- Phase 1-3: Use LiveView for chat UI. Build all backend infrastructure (LLM abstraction, context, memory) without coupling to any frontend framework.
+- Phase 4-5: When React islands are ready, create a chat React island using Vercel AI SDK. Add an SSE endpoint in Phoenix that speaks the Vercel Data Stream Protocol. Both LiveView and React paths can coexist during transition.
+
+#### Cross-language perspective
+
+The Chat UI decision is mostly **language-agnostic on the backend** — the frontend is React regardless. However, with a TypeScript backend, the Vercel AI SDK would be **native** (no SSE bridge needed — the backend produces the stream directly). With a Python backend (FastAPI), SSE streaming is also native (`StreamingResponse`). With Elixir, we need a custom Phoenix controller to produce the Vercel protocol — doable but more manual work.
+
+**Verdict**: TypeScript has a slight edge for chat UI integration (native Vercel AI SDK). Python and Elixir are equivalent (both need an SSE endpoint). This doesn't justify a language change since the UI layer is a thin translation.
+
+---
+
+### Decision 4: Streaming
+
+**Question**: How should Lanttern deliver AI responses to the user in real-time?
+
+#### Options
+
+| Dimension | Option A: No streaming (current) | Option B: LiveView PubSub streaming | Option C: SSE endpoint (Vercel Data Stream Protocol) |
+|---|---|---|---|
+| **UX** | User waits for full response (can be 10-30 seconds) | Tokens appear as they're generated | Same as B |
+| **Implementation** | Nothing to do | Worker/Task calls ReqLLM with streaming; broadcasts chunks via PubSub; ConversationComponent appends chunks | Phoenix controller returns `text/event-stream`; Vercel AI SDK `useChat` consumes |
+| **Backend changes** | None | `AgentChat.LLM` needs streaming path; PubSub events for chunks | New controller + SSE response handler |
+| **Frontend changes** | None | ConversationComponent needs chunk buffer + animation | React island with `useChat` hook |
+| **Tool calls during stream** | N/A | Worker pauses stream, executes tool, resumes | Vercel SDK handles via `9:` event type |
+| **Works with LiveView** | Yes | Yes | No (requires React) |
+| **Works with React** | Yes (but poor UX) | No (React doesn't receive PubSub) | Yes (designed for this) |
+
+#### Recommendation: **Option B for Phase 2 (LiveView streaming); add Option C in Phase 5 when React is ready**
+
+**Justification:**
+
+1. **Streaming is a UX improvement, not a blocking architecture issue.** Phase 1 should focus on library consolidation and abstraction. Streaming can follow once the foundation is solid.
+
+2. **Option B keeps everything within the LiveView paradigm** — no separate API endpoint, no additional auth/CSRF handling, no React dependency. It uses the existing PubSub infrastructure that already connects the Oban worker to the LiveView.
+
+3. **The streaming protocol is additive**: When React is ready (Phase 5), Option C (SSE endpoint) is added alongside Option B, not replacing it. The backend can support both paths simultaneously — the Oban worker produces chunks, which are delivered via PubSub (for LiveView) or SSE (for React).
+
+**PubSub streaming design:**
+
+```
+New PubSub events:
+  {:conversation, {:chunk, %{text: "partial text", index: 0}}}
+  {:conversation, {:tool_call_start, %{name: "create_lesson", args: %{...}}}}
+  {:conversation, {:tool_call_result, %{name: "create_lesson", result: %{...}}}}
+  {:conversation, {:message_complete, %Message{}}}
+
+ConversationComponent:
+  - Maintains `streaming_buffer` assign (accumulates chunks)
+  - On `:chunk` → append to buffer, re-render streaming message
+  - On `:message_complete` → finalize buffer into stream entry, save to DB
+```
+
+#### Cross-language perspective
+
+| Dimension | Elixir (PubSub) | Python (FastAPI) | TypeScript (Node.js) |
+|---|---|---|---|
+| **Streaming to client** | PubSub → LiveView push (custom) | `StreamingResponse` (native SSE) | Vercel AI SDK `streamText()` (native, zero config) |
+| **LangGraph streaming** | N/A | **5 streaming modes**: tokens, events, updates, messages, custom. The most advanced streaming in any framework. | LangGraph.js — same 5 modes |
+| **Tool calls in stream** | Manual pause/resume logic | LangGraph handles automatically with `astream_events` | LangGraph.js or Vercel AI SDK `9:` event type |
+| **Reconnection** | Custom (must build) | Custom (must build) | Vercel AI SDK `useChat` handles automatically |
+
+**Verdict**: Python (LangGraph) has the **best streaming capabilities** — 5 distinct modes that cover every use case (token streaming, state updates, tool call events, custom data). TypeScript (Vercel AI SDK) has the best frontend streaming integration. Elixir's PubSub approach works but requires more custom code for advanced scenarios. For simple token streaming, all three are adequate.
+
+---
+
+### Decision 5: User Memory
+
+**Question**: How should the agent remember information across conversations?
+
+#### Design approach: **Hierarchical summary-based memory**
+
+**Why not raw history replay?** Storing and replaying raw conversation history as "memory" is cost-prohibitive. A user with 50 conversations of 20 messages each would require injecting ~1000 messages into every new prompt — blowing the context window and token budget.
+
+**Why summaries?** At conversation close (or at checkpoints), a background job summarizes the conversation into compact memory entries. These summaries are injected as a Layer 0 system message (before school config) in future conversations — adding ~200-500 tokens of context instead of thousands.
+
+#### Schema design
+
+```
+user_ai_memories
+  id              :bigint PK
+  profile_id      :bigint FK -> profiles (indexed)
+  school_id       :bigint FK -> schools (indexed)
+  category        :string  -- "preference" | "topic_expertise" | "interaction_style" | "context"
+  summary         :text    -- compressed memory text
+  source_type     :string  -- "conversation" | "system" | "manual"
+  source_id       :bigint  -- nullable, FK to conversation that produced this memory
+  relevance_score :float   -- for ranking during retrieval (0.0-1.0)
+  expires_at      :utc_datetime -- nullable, for time-bounded memories
+  inserted_at     :utc_datetime
+  updated_at      :utc_datetime
+```
+
+#### Memory lifecycle
+
+1. **Creation**: After a conversation ends (or at periodic checkpoints), a `MemorySummaryWorker` Oban job summarizes the conversation and upserts memory entries.
+2. **Injection**: Before building system prompts, `add_memory_system_messages/2` queries the user's recent/relevant memories and injects them as Layer 0 (before school knowledge/guardrails). Memories are sorted by `relevance_score` and capped (e.g., top 10 entries) to control prompt size.
+3. **Decay**: Memories have optional `expires_at` for time-bounded information. A cron job prunes expired entries.
+4. **Update**: The summarization job can update existing memories (e.g., "user prefers detailed lesson plans" gets refined over time) rather than always creating new ones.
+5. **Manual management**: Staff can view and delete their own memories via a settings page.
+
+#### System prompt with memory (6-layer hierarchy)
+
+```
+Layer 0: User Memory (NEW)
+  └── Source: user_ai_memories table
+  └── Tag: <user_memory>
+            <preferences>...</preferences>
+            <topic_expertise>...</topic_expertise>
+            <interaction_history>...</interaction_history>
+          </user_memory>
+
+Layer 1: School Knowledge & Guardrails (unchanged)
+Layer 2: Agent Configuration (unchanged)
+Layer 3: Staff Member Context (unchanged)
+Layer 4: Lesson Template (unchanged)
+Layer 5: Curriculum Context (unchanged)
+```
+
+Memory is placed before school config because it changes most frequently (per-user, per-conversation), while school config is relatively static. This ordering maximizes prompt caching effectiveness — the static layers remain in the same position across calls.
+
+#### Cross-language perspective
+
+| Dimension | Elixir (custom) | Python | TypeScript |
+|---|---|---|---|
+| **Memory system** | Custom `user_ai_memories` table + summarization job | **mem0** (managed memory layer, auto-categorizes, vector search), **MemGPT/Letta** (self-editing memory, tiered storage), **LangGraph checkpointing** (conversation state persistence with time-travel) | LangGraph.js checkpointing, custom implementations |
+| **Vector search for memories** | pgvector (works, manual integration) | **LlamaIndex** memory modules, pgvector, Pinecone, Qdrant — all with first-class integrations | pgvector, Pinecone — similar to Python |
+| **Summarization** | Custom Oban job + LLM call | mem0 handles automatically, or LangGraph's `summarize_messages` built-in | Custom or LangGraph.js |
+
+**Verdict**: Python has **specialized memory systems** (mem0, MemGPT/Letta) that don't exist in Elixir. However, these are most valuable for complex agents with long interaction histories. Our custom summary-based memory is simpler and more tailored to Lanttern's school-scoped needs. If memory requirements grow significantly (e.g., vector-based semantic retrieval over thousands of conversations), Python's ecosystem becomes more attractive.
+
+---
+
+### Decision 6: Universal Conversation Context
+
+**Question**: How should conversations be linked to arbitrary entities (strands, lessons, ILPs, assessments, etc.)?
+
+#### Current limitation
+
+The `strand_agent_conversations` table is hardcoded to strands and lessons:
+
+```sql
+strand_agent_conversations
+  conversation_id → agent_conversations
+  strand_id → strands
+  lesson_id → lessons (nullable)
+```
+
+This cannot accommodate new context types (ILPs, assessments, students, etc.) without new join tables for each entity type.
+
+#### Recommendation: **Polymorphic context link table**
+
+```sql
+conversation_contexts
+  id                :bigint PK
+  conversation_id   :bigint FK -> agent_conversations (CASCADE DELETE)
+  context_type      :string  -- "strand" | "lesson" | "ilp" | "assessment" | ...
+  context_id        :bigint  -- FK to the relevant entity
+  context_metadata  :jsonb   -- snapshot of context data at conversation time
+  inserted_at       :utc_datetime
+
+  UNIQUE(conversation_id, context_type, context_id)
+```
+
+#### Key design decisions
+
+1. **Multiple contexts per conversation**: A conversation about a lesson within a strand has two context links: `{type: "strand", id: 1}` and `{type: "lesson", id: 5}`. This is more flexible than forcing a single context.
+
+2. **context_metadata JSONB**: Stores a snapshot of relevant context data at conversation creation time. This is useful for audit (what did the agent see?) and for cases where the source entity changes after the conversation.
+
+3. **No FK constraint on context_id**: Because `context_id` can reference different tables depending on `context_type`, we cannot use a database foreign key. Referential integrity is enforced at the application level via `ContextResolver`.
+
+4. **Migration path**: Data from `strand_agent_conversations` is migrated into `conversation_contexts` (one row per strand, one per lesson where applicable). The old table is left as-is per CLAUDE.md rule 7 (default is tech debt, not refactoring).
+
+#### Context resolution pipeline
+
+```elixir
+# In AgentChat.ContextResolver
+def resolve_contexts(conversation_id) do
+  conversation_id
+  |> list_conversation_contexts()
+  |> Enum.flat_map(&context_to_system_messages/1)
+end
+
+defp context_to_system_messages(%{context_type: "strand", context_id: id}) do
+  # Load strand with subjects, years, moments, curriculum items
+  # Build <strand_context> XML system messages
+end
+
+defp context_to_system_messages(%{context_type: "lesson", context_id: id}) do
+  # Load lesson with moment, subjects, tags
+  # Build <lesson_context> XML system messages
+end
+
+defp context_to_system_messages(%{context_type: "ilp", context_id: id}) do
+  # Load ILP with template, sections, entries
+  # Build <ilp_context> XML system messages
+end
+```
+
+Adding a new context type requires only adding a new `context_to_system_messages/1` clause — no schema changes, no migrations.
+
+#### Cross-language perspective
+
+Context resolution is **deeply coupled to Lanttern's domain** — loading strands, lessons, ILPs requires querying Ecto schemas with preloaded associations, enforcing Scope authorization, and respecting school isolation. This is the decision **most affected by the monolith vs microservice choice**.
+
+| Scenario | Elixir monolith | Python/TS microservice |
+|---|---|---|
+| **Loading context** | Direct Ecto query with preloads — 1 DB call, ~5ms | Microservice calls Phoenix internal API → Phoenix queries DB → serializes → returns JSON. Multiple hops, ~50-100ms. |
+| **New context type** | Add one function clause in ContextResolver | Add API endpoint in Phoenix + client code in Python/TS + serialization mapping |
+| **Authorization** | Pattern-match `school_id` in function head (native Scope) | Must pass Scope token to microservice or duplicate auth logic |
+| **Data freshness** | Always live from DB | Risk of stale data if caching, or extra latency if always fetching |
+
+**Verdict**: Context resolution is the **strongest argument for keeping AI in the Elixir monolith**. Moving it to a microservice doesn't simplify it — it adds a network boundary across the tightest coupling point. A Python/TS microservice would either need to access Lanttern's database directly (tight coupling, defeats the purpose) or call internal APIs for every context lookup (latency, complexity).
+
+---
+
+### Decision 7: Observability
+
+**Question**: How should Lanttern monitor, evaluate, and manage AI agent quality and costs?
+
+#### Options
+
+| Dimension | Option A: Custom (DB + Telemetry) | Option B: Langfuse (self-hosted) | Option C: Langfuse Cloud | Option D: LangSmith | Option E: Helicone |
+|---|---|---|---|---|---|
+| **Data ownership** | Full | Full (your infrastructure) | Langfuse-managed (EU/US regions, GDPR compliant) | LangChain-managed | Helicone-managed |
+| **Cost** | DB storage only | Free software + infra ($500-5k/mo) | Free to $199+/mo | $39/seat/mo | Usage-based |
+| **Setup effort** | Must build everything | Docker Compose (dev) or K8s/Helm (prod) | SaaS signup | SaaS signup | Proxy setup |
+| **Tracing** | Manual (log to DB) | Distributed tracing, span hierarchy, sessions | Same | Same | Proxy-based auto-trace |
+| **Prompt management** | None (prompts in code) | Versioning, caching, playground | Same | Yes | No |
+| **Evaluation** | None | LLM-as-judge, manual labeling, datasets | Same | Yes | No |
+| **Cost tracking** | Aggregate from `llm_calls` | Per-model, per-user, per-session | Same | Yes | Yes (primary feature) |
+| **Elixir integration** | Native telemetry | OpenTelemetry or REST API | Same | Python/JS SDKs only | HTTP proxy (language-agnostic) |
+| **Vendor lock-in** | None | Low (open source, can migrate data) | Medium (migration to self-host) | High (proprietary, LangChain-focused) | Medium |
+
+#### Recommendation: **Phased approach — Custom (Phase 1-2) → Langfuse Cloud (Phase 3) → Langfuse self-hosted (Phase 5+)**
+
+**Justification:**
+
+1. **Phase 1-2 (Custom)**: The existing `llm_calls` table already captures what is needed for basic cost tracking. Add `:telemetry` events for LLM calls (`:lanttern, :llm, :call, :start/:stop`) and a periodic Oban cron job to aggregate costs per school. This is low-effort and integrates with the existing LiveDashboard.
+
+2. **Phase 3 (Langfuse Cloud)**: Once the memory system is in place and conversations become more complex, adopt Langfuse Cloud for proper tracing and evaluation. The Cloud tier starts free (50k traces/month) and scales to $29/month (1M traces). Integration via OpenTelemetry — which has strong Elixir/BEAM support — or direct REST API.
+
+3. **Phase 5+ (Langfuse self-hosted)**: When trace volume justifies it or data sensitivity requires it, migrate to self-hosted Langfuse on Kubernetes. The transition is straightforward because the integration layer (OpenTelemetry) doesn't change.
+
+**Why not LangSmith?** It's proprietary, LangChain-focused (we're removing LangChain), and has per-seat pricing. **Why not Helicone?** It's proxy-based, which doesn't fit our Oban worker architecture (the LLM call happens server-side, not via a proxy). **Why Langfuse?** Open source, self-hostable, framework-agnostic, no per-seat pricing, and its v4 architecture (ClickHouse-backed) handles scale well.
+
+See [Section 4: Deep Dive: Langfuse](#4-deep-dive-langfuse) for complete technical analysis.
+
+#### Cross-language perspective
+
+| Dimension | Elixir | Python | TypeScript |
+|---|---|---|---|
+| **Langfuse integration** | OpenTelemetry or REST API (no official SDK) | **Official SDK** — native decorators, auto-tracing, prompt management | **Official SDK** — same features as Python |
+| **LangSmith** | No SDK (REST only) | **Native integration** — auto-traces LangChain/LangGraph calls, playground, datasets | LangChain.js auto-tracing |
+| **Evaluation frameworks** | None | **DeepEval** (pytest-like LLM testing), **RAGAS** (RAG evaluation), **PromptFoo** (red-teaming/safety) | PromptFoo (works with TS), limited others |
+| **Prompt management** | Code-only (system prompts in `agent_chat.ex`) | Langfuse/LangSmith prompt versioning, **DSPy** (automatic prompt optimization) | Langfuse prompt versioning |
+
+**Verdict**: Python has a **significantly better observability and evaluation ecosystem**. DeepEval, RAGAS, and PromptFoo have no Elixir equivalents — and evaluation is critical for education (safety, quality assurance). This is a genuine gap. The phased Langfuse approach mitigates the observability gap, but evaluation frameworks remain a Python-only advantage. If rigorous AI quality evaluation becomes a requirement, this is the second strongest argument (after orchestration) for a Python sidecar.
+
+---
+
+### Decision 8: Monolith vs Microservice — Should AI Live Outside Elixir?
+
+**Question**: Would we get significantly better tooling by building AI features as a separate service in Python or TypeScript?
+
+#### The honest answer: Yes, the tooling is better. The question is whether it's worth the cost.
+
+Python's AI ecosystem is **objectively richer** than Elixir's. The cross-language comparisons in Decisions 1-7 above show real gaps in orchestration (LangGraph), evaluation (DeepEval/RAGAS), memory (mem0), and provider SDKs (official vs community). These aren't theoretical — they represent production-ready tools with large communities.
+
+But tooling quality is only one variable. The full equation includes operational cost, domain coupling, team expertise, and architectural complexity.
+
+#### Options
+
+| Dimension | Option A: Elixir monolith | Option B: Python sidecar (co-deployed) | Option C: Full microservice (separate deploy) |
+|---|---|---|---|
+| **AI ecosystem access** | Elixir only (ReqLLM, custom code) | **Full Python ecosystem** (LangGraph, DeepEval, official SDKs) | Full Python or TS ecosystem |
+| **Deployment** | Single unit | Single unit (same pod/VM) | Separate units |
+| **Latency overhead** | 0ms (in-process) | +5-10ms (localhost HTTP) | +25-50ms (network hop) |
+| **Tool execution** | Direct function call (`Lessons.create_lesson/3`) | Internal HTTP to Phoenix → business logic | External API → Phoenix → business logic |
+| **Context loading** | Direct Ecto query (~5ms) | HTTP to Phoenix → Ecto query → serialize (~50-100ms) | Same as sidecar but across network |
+| **PubSub streaming** | Native | Redis bridge or webhook → Phoenix PubSub | Same as sidecar |
+| **Infra cost multiplier** | 1x | 1.1-1.3x | 3.75-6x |
+| **Team requirement** | Elixir devs | Elixir + 1-2 Python devs | Elixir + 2-4 Python devs + platform engineer |
+| **Auth/Scope** | Native pattern matching | Must pass scope or duplicate auth | Same + network auth layer |
+| **DB access** | Shared (Ecto) | Shared PostgreSQL (direct or via API) | Separate DB or shared (both have issues) |
+| **Testability** | Single test suite | Two test suites, integration tests needed | Same + contract testing |
+| **When to choose** | AI is simple, team is small, domain coupling is tight | Need specific Python capabilities, have Python expertise | AI must scale independently, team >50 |
+
+#### The core trade-off: Ecosystem vs Domain Integration
+
+Lanttern's AI agent is not a standalone chatbot — it reaches deep into the application domain:
+
+1. **System prompts** load from 6+ tables (school configs, agents, staff, templates, strands, lessons)
+2. **Tool execution** calls business functions with Scope authorization and audit logging
+3. **Real-time updates** flow through Phoenix PubSub
+4. **Memory injection** queries school-scoped user memories
+5. **Context resolution** loads polymorphic entities with Ecto associations
+
+A microservice boundary would cut across these coupling points. The microservice either:
+- **Accesses Lanttern's DB directly** (tight coupling, shared schema, migration coordination) — defeats the purpose of separation
+- **Calls Phoenix APIs for everything** (latency, staleness risk, API surface to maintain) — adds complexity
+
+#### Recommendation: **Option A (Elixir monolith) now, with a clear path to Option B (Python sidecar) when specific needs arise**
+
+**Justification:**
+
+1. **Current needs are served.** Lanttern needs an LLM client, tool calling, streaming, and memory. ReqLLM + custom code delivers this. LangGraph's advanced features (checkpointing, multi-agent) are not yet needed.
+
+2. **Domain coupling is the decisive factor.** The tightest coupling is context loading and tool execution — both require direct access to Ecto schemas and Scope authorization. A microservice adds friction at the worst possible point.
+
+3. **Industry data supports this.** 42% of organizations that adopted microservices have consolidated back (CNCF 2025 survey). Amazon Prime Video achieved 90% cost reduction migrating from microservices to monolith.
+
+4. **The sidecar escape hatch exists.** `AgentChat.LLM` is designed so the LLM orchestration call can be redirected to an external service. When Python capabilities are needed, we extract ONLY the LLM orchestration to a co-deployed FastAPI sidecar — without moving domain logic, auth, or data access.
+
+#### When to adopt a Python sidecar (Option B)
+
+| Trigger | Why | What to extract |
+|---|---|---|
+| Multi-agent coordination needed | LangGraph/CrewAI have no Elixir equivalent | Agent orchestration only |
+| RAG over large document corpora | LlamaIndex is far ahead | Document processing + retrieval |
+| Rigorous evaluation required | DeepEval/RAGAS/PromptFoo are Python-only | Evaluation pipeline |
+| Python AI engineer hired | Can own the sidecar without burdening Elixir team | Whatever they're best at |
+| Team grows beyond 30 engineers | Independent AI team velocity justified | Full AI orchestration |
+
+See [Section 5: Deep Dive: Microservice Architecture](#5-deep-dive-microservice-architecture--cross-language-ecosystems) for detailed ecosystem comparisons, architecture diagrams, and cost analysis.
+
+---
+
+## 3. Deep Dive: Vercel AI SDK
+
+### What it is
+
+The Vercel AI SDK (`ai` npm package) is a TypeScript toolkit for building AI-powered applications. Despite the name, it is **framework-agnostic** — it works with React, Vue, Svelte, and any backend that produces the correct streaming protocol.
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│  React Application                               │
+│                                                   │
+│  useChat() hook                                   │
+│    ├── Manages message state (user + assistant)   │
+│    ├── Handles streaming (auto-appends tokens)    │
+│    ├── Abort / retry / reload                     │
+│    ├── Auto-scroll management                     │
+│    ├── Tool call rendering                        │
+│    └── Configurable API endpoint                  │
+│                                                   │
+│  Custom tool call renderers                       │
+│    └── e.g., <LessonCard> for create_lesson       │
+└───────────────────────┬─────────────────────────┘
+                        │ POST /api/chat
+                        │ Content-Type: text/event-stream
+                        │ x-vercel-ai-ui-message-stream: v1
+                        ▼
+┌─────────────────────────────────────────────────┐
+│  Backend (Phoenix SSE endpoint)                   │
+│                                                   │
+│  Produces Server-Sent Events per protocol:        │
+│    0:{text}              → text token             │
+│    9:{tool_call_json}    → tool call started      │
+│    a:{tool_result_json}  → tool call result       │
+│    e:{finish_json}       → stream finished        │
+│    d:{usage_json}        → token usage metadata   │
+│                                                   │
+│  The backend controls model, prompts, tools —     │
+│  the SDK only consumes the stream.                │
+└─────────────────────────────────────────────────┘
+```
+
+### How it integrates with Phoenix
+
+1. **SSE endpoint**: A dedicated Phoenix controller (`AiStreamController`) handles `POST /api/chat` requests. It authenticates the user (session cookie or token), builds the LLM request via `AgentChat.LLM`, streams chunks from ReqLLM, and formats them per the Vercel Data Stream Protocol.
+
+2. **React island**: The chat UI is mounted as a React island within a LiveView page via a Phoenix hook. The React component uses `useChat({ api: "/api/chat" })` to connect to the SSE endpoint.
+
+3. **LiveView bridge**: Non-chat data (strand info, user settings, navigation) continues to flow through LiveView. The React island receives initial props from LiveView and can communicate back via custom events.
+
+### Pros
+
+| Advantage | Detail |
+|---|---|
+| **Streaming "just works"** | `useChat` handles SSE consumption, message state, buffering, reconnect — zero custom code |
+| **Tool call rendering** | When the LLM calls a tool, the SDK provides a callback to render custom React components (e.g., `<LessonCard>`) instead of plain text |
+| **Auto-scroll** | Built-in scroll management for chat interfaces |
+| **Abort / retry** | User can abort a streaming response or retry a failed one — `useChat` handles the state transitions |
+| **Model agnostic** | The SDK doesn't care what model the backend uses. It only consumes the stream protocol. |
+| **Massive community** | The most widely adopted AI frontend SDK. Battle-tested patterns, extensive documentation, frequent updates. |
+| **Lightweight** | The `ai` package is ~40KB. No heavy runtime. |
+
+### Cons
+
+| Disadvantage | Detail |
+|---|---|
+| **Requires React** | Lanttern is currently pure LiveView. React setup is in progress but not ready. |
+| **SSE endpoint = parallel API surface** | The SSE endpoint is separate from LiveView. It needs its own authentication, CSRF protection, rate limiting. |
+| **LiveView ↔ React bridge complexity** | Communicating between LiveView state and a React island requires a hook bridge layer. Complex state synchronization can be tricky. |
+| **Two rendering paradigms** | The app would have LiveView for everything except chat, and React for chat. This dual-paradigm approach adds cognitive overhead. |
+| **Build tooling changes** | esbuild must be configured to compile JSX, or a separate Vite pipeline is needed for the React subtree. |
+| **Not needed for v0** | LiveView can deliver streaming via PubSub and rich components via function components. The SDK's value only materializes at scale or for complex interactive patterns. |
+
+### Comparison with alternatives
+
+| Feature | Vercel AI SDK | CopilotKit | assistant-ui |
+|---|---|---|---|
+| **Scope** | Frontend streaming hooks | Full platform (frontend + backend) | Headless React chat components |
+| **Backend coupling** | None — any SSE backend | CopilotKit backend SDK required | None — any backend |
+| **Streaming** | SSE (Data Stream Protocol) | AG-UI Protocol | Custom adapters |
+| **Tool call UI** | Custom renderers per tool | Built-in action rendering | Custom renderers |
+| **Complexity** | Low (just hooks) | High (full platform) | Medium (component library) |
+| **Best for** | Custom backend + React frontend | Full-stack AI apps | Maximum UI customization |
+| **Risk for Lanttern** | Low (focused, lightweight) | High (platform dependency, conflicts with Elixir backend) | Medium (smaller community) |
+
+### Recommendation for Lanttern
+
+**Short-term (Phase 1-3)**: Do not adopt the Vercel AI SDK. Use LiveView for the chat UI. The backend architecture should be designed to be UI-agnostic, so the transition to React is seamless when ready.
+
+**Medium-term (Phase 4-5)**: Once React islands are operational, adopt the Vercel AI SDK for the chat interface. Implement a Phoenix SSE controller that speaks the Vercel Data Stream Protocol. Keep LiveView as the overall page framework, with the chat as a React island.
+
+**Avoid CopilotKit**: Its backend SDK conflicts with Lanttern's Elixir-centric architecture. assistant-ui is a viable alternative if the team prefers more control over the UI, but Vercel AI SDK's community and documentation make it the safer bet.
+
+---
+
+## 4. Deep Dive: Langfuse
+
+### What it is
+
+Langfuse is an **open-source LLM engineering platform** (acquired by ClickHouse in 2026, 24k+ GitHub stars). Unlike general-purpose APM tools, it natively understands LLM-specific concepts: token usage, model parameters, prompt/completion pairs, evaluation scores, and conversation sessions.
+
+### Architecture (v4 — current)
+
+```
+┌──────────────────────────────────────────────────┐
+│  Langfuse Platform                                │
+│                                                   │
+│  ┌─────────────┐    ┌──────────────────────────┐ │
+│  │   Web        │    │  Worker (Node.js)         │ │
+│  │  (Next.js)   │    │  - BullMQ async queues    │ │
+│  │  - UI        │    │  - Event processing       │ │
+│  │  - REST API  │    │  - Evaluation pipelines   │ │
+│  │  - OTLP API  │    └──────────┬───────────────┘ │
+│  └──────┬───────┘               │                 │
+│         │                       │                 │
+│  ┌──────▼───────────────────────▼───────────────┐ │
+│  │  ClickHouse (OLAP — traces, observations)     │ │
+│  │  - Observation-centric data model (v4)        │ │
+│  │  - Columnar format for analytical queries     │ │
+│  │  - 20x faster queries than v3                 │ │
+│  └──────────────────────────────────────────────┘ │
+│  ┌──────────────────────────────────────────────┐ │
+│  │  PostgreSQL (metadata — users, projects)      │ │
+│  └──────────────────────────────────────────────┘ │
+│  ┌──────────────────────────────────────────────┐ │
+│  │  Redis/Valkey (queues + cache)                │ │
+│  └──────────────────────────────────────────────┘ │
+│  ┌──────────────────────────────────────────────┐ │
+│  │  S3/Blob (event persistence + exports)        │ │
+│  └──────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────┘
+```
+
+### Core features
+
+| Feature | What it does | Why it matters for Lanttern |
+|---|---|---|
+| **Distributed Tracing** | Span hierarchy: Traces > Observations (spans/generations/events). Session grouping. | Track entire conversation lifecycle: user message → prompt building → LLM call → tool execution → response. Identify bottlenecks. |
+| **Prompt Management** | Version control, branching, caching, playground for testing. | Currently, prompts live in code (`agent_chat.ex`). Langfuse enables non-developer prompt iteration without deployments. |
+| **Evaluation** | LLM-as-judge, manual labeling, custom eval pipelines, dataset-based regression testing. | Measure and improve agent quality over time. Answer: "Are our lesson plans getting better?" |
+| **Cost Tracking** | Per-model, per-user, per-session cost calculation. Custom model pricing. | Replace the manual `llm_calls` aggregation with automated dashboards. Per-school cost visibility. |
+| **User Feedback** | Collect thumbs up/down, ratings, custom feedback on AI outputs. | Close the feedback loop. Teachers rate lesson plans → data flows back to improve prompts. |
+| **Analytics** | Custom dashboards, session analysis, user behavior tracking. | Understand how teachers use the agent. Which tools are called most? Where do conversations fail? |
+
+### Self-hosting
+
+| Option | Infrastructure | Use case |
+|---|---|---|
+| **Docker Compose** | Single VM, 4+ vCPUs, 16GB+ RAM. PostgreSQL + ClickHouse + Redis + Langfuse containers. | Development/staging. Not recommended for production (no HA). |
+| **Kubernetes (Helm)** | K8s cluster with managed databases. Helm charts provided. Min 2 Langfuse web replicas. | Production. Full HA and auto-scaling. Can point to existing PostgreSQL/ClickHouse/Redis instances. |
+
+**Infrastructure requirements:**
+- All components must run with **UTC timezone** (non-UTC causes incorrect query results)
+- Minimum: 2 web instances, auto-scale at 50% CPU
+- Proper Redis/ClickHouse replication for HA
+
+**Cost of self-hosting:**
+| Scale | Infra cost/month | DevOps cost/month | Total |
+|---|---|---|---|
+| Small (<1M traces/mo) | $500-1,000 | ~$2,000 | ~$2,500 |
+| Medium (1-10M traces/mo) | $2,000-3,000 | ~$3,000 | ~$5,000 |
+| Large (10M+ traces/mo) | $5,000-15,000 | ~$5,000 | ~$10,000+ |
+
+### Elixir integration
+
+There is no official Elixir SDK from Langfuse. Integration options:
+
+| Approach | Effort | Quality | Recommended? |
+|---|---|---|---|
+| **OpenTelemetry** | Medium | Excellent — native BEAM support, distributed tracing, standard protocol | **Yes (recommended)** |
+| **REST API** | Low | Good for simple use cases. Manual batching needed. | For quick start |
+| **Community SDK** (`workera-ai/langfuse_sdk`) | Low | Community-maintained, not official. Check maturity. | Evaluate before relying |
+
+**Recommended integration pattern:**
+
+```
+Phoenix Application (Elixir)
+    ↓
+AgentChat.LLM (ReqLLM calls)
+    ↓ wrap with OpenTelemetry spans
+opentelemetry-erlang (hex package)
+    ↓ OTLP export
+Langfuse /api/public/otel endpoint
+    ↓
+ClickHouse (traces/observations)
+```
+
+**Practical implementation:**
+
+```elixir
+# In AgentChat.LLM, wrap LLM calls with telemetry
+def run_completion(model, messages, tools, opts) do
+  metadata = %{model: model, provider: "openai"}
+
+  :telemetry.span([:lanttern, :llm, :call], metadata, fn ->
+    result = do_llm_call(model, messages, tools, opts)
+
+    end_metadata =
+      case result do
+        {:ok, response} ->
+          %{tokens_in: response.usage.input, tokens_out: response.usage.output}
+        {:error, _} ->
+          %{error: true}
+      end
+
+    {result, Map.merge(metadata, end_metadata)}
+  end)
+end
+```
+
+The OpenTelemetry library subscribes to these telemetry events and exports them as spans to Langfuse's OTLP endpoint. This is non-invasive — the business code emits events, the infrastructure layer handles export.
+
+### Pricing comparison
+
+| Plan | Monthly | Traces/month | Per 100K extra | Users | Retention |
+|---|---|---|---|---|---|
+| **Hobby (Free)** | $0 | 50,000 | — | 2 | 30 days |
+| **Core** | $29 | 1,000,000 | $8 | Unlimited | 90 days |
+| **Pro** | $199 | 5,000,000 | $8 | Unlimited | 2 years |
+| **Self-hosted** | $0 (software) | Unlimited | — | Unlimited | Unlimited |
+
+### Recommendation for Lanttern
+
+**Phase 1-2**: Use custom telemetry + existing `llm_calls` table. Add `:telemetry` events for LLM calls. Create an Oban cron job to aggregate costs per school.
+
+**Phase 3**: Adopt Langfuse Cloud (free Hobby tier or $29 Core). Integrate via OpenTelemetry. Use for tracing, cost dashboards, and initial evaluation experiments.
+
+**Phase 5+**: Evaluate self-hosted Langfuse when either (a) trace volume exceeds 5M/month, (b) data sensitivity requires on-premises, or (c) advanced features like prompt management justify the infrastructure investment.
+
+---
+
+## 5. Deep Dive: Microservice Architecture & Cross-Language Ecosystems
+
+### Python AI ecosystem — What Elixir doesn't have
+
+#### Agent Orchestration
+
+| Framework | Status | What it does | Elixir equivalent |
+|---|---|---|---|
+| **LangGraph** | Production-ready (v1.0, Oct 2025) | Stateful agents with checkpointing, time-travel debugging, human-in-the-loop, 5 streaming modes, durable execution | **Nothing** — our custom tool_call_loop is ~5% of LangGraph's feature set |
+| **CrewAI** | Production-ready | Multi-agent role-based teams. Define agents with roles, goals, tools, and let them collaborate. | **Nothing** — no multi-agent framework in Elixir |
+| **AG2/AutoGen** | Near-ready (v1.0 coming) | Complex multi-agent scenarios with code execution, tool use, and human-in-the-loop | **Nothing** |
+| **LlamaIndex** | Production-ready | RAG-first agents, document loaders, chunking, vector stores, retrieval pipelines | **Nothing** — must build RAG manually |
+
+#### Structured Output & Validation
+
+| Framework | Status | What it does | Elixir equivalent |
+|---|---|---|---|
+| **Instructor** | Production-ready (3M+ downloads/month) | Schema-first structured LLM outputs with automatic retries and validation | Ecto schema validation (manual, no LLM retry logic) |
+| **Pydantic AI** | Production-ready | Type-safe agents with dependency injection, streaming, and built-in observability | Nothing equivalent |
+| **DSPy** | Emerging | Automatic prompt optimization — writes and tunes prompts algorithmically | **Nothing** — unique capability |
+
+#### Evaluation & Safety
+
+| Framework | Status | What it does | Elixir equivalent |
+|---|---|---|---|
+| **DeepEval** | Production-ready | Pytest-like unit testing for LLMs — hallucination detection, relevancy scoring, toxicity checks | **Nothing** |
+| **RAGAS** | Production-ready | Research-backed RAG evaluation — faithfulness, answer relevancy, context precision | **Nothing** |
+| **PromptFoo** | Production-ready | Security red-teaming, prompt injection testing, harmful output detection | **Nothing** |
+
+#### Memory Systems
+
+| System | What it does | Elixir equivalent |
+|---|---|---|
+| **mem0** | Managed memory layer — auto-categorizes, vector search, user/session/agent scoping | Custom `user_ai_memories` table (simpler, but tailored) |
+| **MemGPT/Letta** | Self-editing agent memory with tiered storage (core/archival/recall) | Nothing equivalent |
+| **LangGraph checkpointing** | Conversation state persistence with time-travel and branching | Nothing — we use database for state |
+
+### TypeScript AI ecosystem — The frontend-native option
+
+| Framework | Strength | What it adds over Elixir |
+|---|---|---|
+| **Vercel AI SDK** | Native SSE streaming, `useChat`, tool call rendering | No Phoenix bridge needed — backend and frontend speak the same language |
+| **LangChain.js** | Most comprehensive JS AI framework | RAG support, agent chains — but a port from Python, not native TS design |
+| **LangGraph.js** | Same features as Python LangGraph | Stateful agents, streaming, checkpointing — in TypeScript |
+| **Mastra** | TypeScript-native AI framework | Clean abstractions, built-in routing, emerging but well-funded |
+
+### Architecture diagrams
+
+#### Option B: Python sidecar (co-deployed)
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Same pod / VM / deployment unit                              │
+│                                                               │
+│  ┌─────────────────────┐     ┌─────────────────────────────┐ │
+│  │  Phoenix (Elixir)    │     │  FastAPI (Python)            │ │
+│  │                      │     │                              │ │
+│  │  • LiveView UI       │     │  • LLM orchestration         │ │
+│  │  • Scope/Auth        │     │  • LangGraph agents          │ │
+│  │  • Business logic    │     │  • Streaming (SSE)           │ │
+│  │  • Ecto/DB access    │     │  • Evaluation (DeepEval)     │ │
+│  │  • PubSub            │     │  • Memory (mem0)             │ │
+│  │  • Oban jobs         │     │                              │ │
+│  │                      │◄────┤  Tool calls: POST            │ │
+│  │  Internal API:       │     │  /internal/tools/create_lesson│ │
+│  │  POST /internal/     │────►│                              │ │
+│  │  tools/*             │     │  Context: GET                │ │
+│  │                      │     │  /internal/context/:conv_id  │ │
+│  └──────────┬───────────┘     └──────────────┬──────────────┘ │
+│             │                                │                │
+│             └──────────┬─────────────────────┘                │
+│                        ▼                                      │
+│  ┌─────────────────────────────────────────────────────────┐ │
+│  │  Shared PostgreSQL (+ pgvector)                          │ │
+│  │  Shared Redis (Oban + FastAPI cache + PubSub bridge)     │ │
+│  └─────────────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────────────┘
+```
+
+**Data flow for a user message (sidecar):**
+
+```
+1. User submits prompt → Phoenix LiveView
+2. Phoenix saves message to DB, sets conversation "processing"
+3. Phoenix calls FastAPI: POST http://localhost:8000/chat
+   Body: {conversation_id, user_id, scope_token, model, tools_enabled}
+4. FastAPI loads context: GET http://localhost:4000/internal/context/{conv_id}
+   Phoenix returns: {system_messages, memories, tool_definitions}
+5. FastAPI runs LangGraph agent with streaming
+6. On tool call: FastAPI calls Phoenix: POST http://localhost:4000/internal/tools/create_lesson
+   Phoenix executes with Scope auth, returns result
+7. On text chunk: FastAPI publishes to Redis
+   Phoenix PubSub bridge picks up → broadcasts to LiveView
+8. On completion: FastAPI calls Phoenix: POST http://localhost:4000/internal/messages
+   Phoenix saves assistant message + model_call to DB
+```
+
+#### Option C: Full microservice (separate deployment)
+
+```
+┌─────────────────────────┐         ┌─────────────────────────┐
+│  Phoenix (Elixir)        │         │  AI Service (Python)     │
+│  Deployment A            │         │  Deployment B            │
+│                          │         │                          │
+│  • LiveView UI           │  gRPC   │  • LangGraph agents      │
+│  • Scope/Auth            │◄───────►│  • LLM orchestration     │
+│  • Business logic        │  or     │  • Evaluation pipeline   │
+│  • Ecto/DB              │  REST   │  • Memory management     │
+│  • PubSub               │         │  • RAG (if needed)       │
+│  • Oban                  │         │                          │
+│                          │         │                          │
+│  PostgreSQL A            │         │  PostgreSQL B (optional)  │
+│  (domain data)           │         │  (AI state, vectors)     │
+│                          │         │  Redis (Celery queues)   │
+└─────────────────────────┘         └─────────────────────────┘
+```
+
+**Additional complexity in Option C:**
+- Service discovery and health checks
+- Network authentication between services
+- API versioning and contract testing
+- Distributed tracing across services
+- Coordinated deployments (breaking changes)
+- Two separate CI/CD pipelines
+
+### Operational cost comparison
+
+| Dimension | Option A: Elixir monolith | Option B: Python sidecar | Option C: Full microservice |
+|---|---|---|---|
+| **Infrastructure** | ~$5K/month | ~$5.5-6.5K/month (+10-30%) | ~$18-30K/month (3.75-6x) |
+| **Engineers needed** | 2-3 Elixir | 2-3 Elixir + 1-2 Python | 2-3 Elixir + 2-4 Python + 1 platform |
+| **Deployment complexity** | Single pipeline | Single pipeline (same unit) | Two pipelines + coordination |
+| **Monitoring** | LiveDashboard + Oban Web | Same + FastAPI metrics | Distributed tracing required |
+| **Incident response** | One codebase to debug | Two codebases, same host | Two codebases, network issues |
+| **Time to first feature** | Fast (no setup) | +1-2 weeks (FastAPI setup, bridge layer) | +4-6 weeks (infra, networking, auth) |
+
+### Hiring pool reality
+
+| Language | Global developers | AI-specialized | Hiring difficulty for AI roles |
+|---|---|---|---|
+| **Python** | ~3.2M contributors | 95% of AI work | Moderate — large pool, high demand |
+| **TypeScript** | ~3M contributors | ~5% of AI work | Easy (general) / Hard (AI-specific) |
+| **Elixir** | ~50K contributors | <1% of AI work | Very hard — tiny pool, almost no AI specialization |
+
+**Practical implication**: If Lanttern needs to hire an AI engineer, they will almost certainly be a Python developer. The sidecar pattern (Option B) is the natural way to integrate their expertise without rewriting the Elixir codebase.
+
+---
+
+## 6. Deep Dive: Choosing a Frontend Stack — CopilotKit + AG-UI vs Vercel AI SDK vs assistant-ui
+
+### The AG-UI Protocol
+
+AG-UI (Agent-User Interaction Protocol) is an **open standard** for agent-to-frontend communication, adopted by Google, AWS, LangChain, Microsoft, Mastra, and PydanticAI. It defines a structured SSE event format designed specifically for AI agents — not just chatbots.
+
+**Event types:**
+
+| Event | Purpose | Example |
+|---|---|---|
+| `RUN_STARTED` / `RUN_FINISHED` | Agent lifecycle tracking | Show "thinking..." indicator |
+| `TEXT_MESSAGE_START` / `CONTENT` / `END` | Token streaming | Display text as it's generated |
+| `TOOL_CALL_START` / `TOOL_CALL_END` | Tool execution tracking | Show "creating lesson..." with spinner |
+| `STATE_SNAPSHOT` | Full agent state broadcast | Sync entire conversation state on reconnect |
+| `STATE_DELTA` | Incremental state updates | Update specific UI elements in real-time |
+| `STEP_STARTED` / `STEP_FINISHED` | Multi-step workflow tracking | Show progress through agent workflow |
+
+**Comparison with Vercel Data Stream Protocol:**
+
+| Aspect | AG-UI Protocol | Vercel Data Stream Protocol |
+|---|---|---|
+| **Designed for** | AI agents with complex state | Chat interfaces with text streaming |
+| **State management** | First-class (snapshots + deltas) | Not supported |
+| **Human-in-the-loop** | Native events for approval workflows | Not supported |
+| **Tool call detail** | Start, args, progress, result, end | Start, result only |
+| **Agent lifecycle** | Full lifecycle events | Done signal only |
+| **Multi-step workflows** | Step tracking events | Not supported |
+| **Adoption** | Google, AWS, Microsoft, LangChain | Vercel ecosystem |
+| **Maturity** | Newer (2025), growing rapidly | Established (2024), widely used |
+
+### CopilotKit — Full platform implementing AG-UI
+
+CopilotKit is a React platform that implements the AG-UI Protocol, providing pre-built components for AI agent interfaces.
+
+**Components:** `<CopilotChat>`, `<CopilotPopup>`, `<CopilotSidebar>`, `<CopilotTextarea>`
+
+**Key features:**
+- **Generative UI**: Agent can render custom React components inline (e.g., lesson cards, approval dialogs)
+- **State synchronization**: Real-time sync between agent state and UI via STATE_SNAPSHOT/DELTA events
+- **Human-in-the-loop**: Built-in approval workflows (agent pauses, shows approval UI, resumes on user action)
+- **Auto-tool rendering**: Tool calls automatically render as interactive UI elements
+- **LangGraph native**: Direct integration via AG-UI — no conversion layer needed
+
+**Pros:**
+- Richest agent UX out of the box — state sync, tool rendering, human-in-the-loop all work natively
+- AG-UI Protocol means you're not locked into CopilotKit — any AG-UI consumer works
+- Strong corporate backing (Google, AWS, Microsoft endorsements)
+- Open source core
+
+**Cons:**
+- More opinionated — you use their component structure or fight it
+- Freemium model (cloud features have paid tiers)
+- Smaller community than Vercel AI SDK (~15k vs ~60k stars)
+- Heavier dependency footprint
+
+### assistant-ui — Headless chat components
+
+assistant-ui is a headless React component library specifically for AI chat interfaces. It's lighter than CopilotKit and gives more control over the UI.
+
+**Key features:**
+- **LangGraphMessageAccumulator**: Efficient streaming handler for LangGraph events
+- **Headless components**: You control every visual detail (unstyled by default)
+- **LangGraph Cloud adapter**: Direct connection to LangGraph Cloud/Studio API
+- **Rich content**: Markdown, code highlighting, attachments, voice input
+- **Production UX**: Auto-scroll, retry, abort, reconnection
+
+**Pros:**
+- Maximum visual customization — headless means your design system, your rules
+- Lighter than CopilotKit (focused on chat, not a platform)
+- Good LangGraph integration via native adapter
+- Fully open source, no paid tiers
+
+**Cons:**
+- No state synchronization (no STATE_SNAPSHOT/DELTA support)
+- No built-in human-in-the-loop workflows
+- No generative UI (you build custom tool renderers yourself)
+- Smaller community (~5k stars)
+- Less documentation for non-LangGraph-Cloud backends
+
+### Vercel AI SDK — Lightweight streaming hooks
+
+Already covered in [Deep Dive: Vercel AI SDK](#3-deep-dive-vercel-ai-sdk). Key additions for this comparison:
+
+**Limitations with LangGraph backend:**
+- The `@ai-sdk/langchain` adapter converts LangGraph's rich event stream into the simpler Data Stream Protocol. This conversion is **lossy** — STATE events, lifecycle events, and detailed tool progress are dropped.
+- `useChat` manages messages as a flat list. LangGraph manages state as a graph with checkpoints. The mismatch means `useChat` can't expose LangGraph's most valuable features (time-travel, branching, state inspection).
+- For simple chat (text + basic tool calls), this loss doesn't matter. For agent UX (status indicators, approval workflows, state sync), it does.
+
+### Comparison table: All four options
+
+| Dimension | CopilotKit + AG-UI | assistant-ui | Vercel AI SDK | AG-UI direct (no lib) |
+|---|---|---|---|---|
+| **Protocol** | AG-UI (rich events) | Custom adapters | Data Stream Protocol | AG-UI (raw) |
+| **Events supported** | TEXT, TOOL_CALL, STATE, HUMAN_APPROVAL, lifecycle | TEXT, TOOL_CALL (via adapters) | Text + basic tool calls | All AG-UI events |
+| **State sync** | Yes (snapshots + deltas) | No | No | Yes (manual handling) |
+| **Human-in-the-loop** | Native | No | No | Yes (manual) |
+| **LangGraph fit** | Native 1:1 mapping | Via LangGraphMessageAccumulator | Adapter with information loss | 1:1 (manual) |
+| **Community** | ~15k stars + Google/AWS/MS | ~5k stars | ~60k stars | Open standard, emerging |
+| **Complexity** | Opinionated (platform) | Headless (flexible) | Light (just hooks) | DIY (max control) |
+| **UI customization** | Medium (pre-built components) | High (headless, unstyled) | Medium (hooks + custom) | Total |
+| **Python backend** | Native via AG-UI Python SDK | Via LangGraph Cloud adapter | Via fastapi-ai-sdk | Native |
+| **TypeScript backend** | Supported | Supported | Native | Supported |
+| **Elixir backend** | Via SSE endpoint | Via SSE endpoint | Via SSE endpoint | Via SSE endpoint |
+| **Pricing** | Open source + paid cloud | Open source | Open source | Open source |
+| **Best for** | Complex agents, rich UX | Customizable chat | Simple chat, any backend | Full control, experienced team |
+
+### When to use each — Application examples
+
+**CopilotKit + AG-UI** — Best for complex agent interactions:
+- Education platform where AI creates lessons and the teacher approves before saving
+- CRM agent that fills forms, suggests actions, and waits for user confirmation
+- Multi-agent system where the UI shows which agent is active and its current step
+- IDE assistant that edits code and shows diffs inline for approval
+
+**assistant-ui** — Best for customizable chat interfaces:
+- Chat with attachments, voice input, and rich markdown rendering
+- Project with an existing design system that must be applied to the chat UI
+- Integration with LangGraph Cloud where the adapter handles the backend
+- Chat-centric app where visual customization is more important than agent state features
+
+**Vercel AI SDK** — Best for simple, fast-to-build chat:
+- Customer support chatbot with text Q&A
+- Content generation tool (write emails, summarize documents)
+- Autocompletion / suggestion features
+- Any chat that doesn't need rich tool call UI or agent state awareness
+
+**AG-UI direct (no library)** — Best for maximum control:
+- Team with strong React expertise that wants to consume AG-UI events directly
+- Integration with non-React frameworks (Vue, Svelte, Angular)
+- Edge cases where no existing library fits
+
+### Analysis for Lanttern's requirements
+
+| Lanttern requirement | CopilotKit | assistant-ui | Vercel AI SDK | Winner |
+|---|---|---|---|---|
+| Lesson card inline in chat | Native tool rendering | Custom (headless) | Custom renderer | **CopilotKit** |
+| Teacher approves before lesson creation | Human-in-the-loop native | Not supported | Not supported | **CopilotKit** |
+| Token streaming | Yes | Yes | Yes | Tie |
+| Agent status ("creating lesson...") | STATE_DELTA events | Not supported | Not supported | **CopilotKit** |
+| LangGraph backend (if Python sidecar) | Native mapping | Via adapter | Adapter with loss | **CopilotKit** |
+| LiveView backend (if Elixir monolith) | SSE endpoint needed | SSE endpoint needed | SSE endpoint needed | Tie |
+| Visual customization (match Lanttern design) | Medium | **High** | Medium | **assistant-ui** |
+| Community & longevity | Smaller + corporate backing | Small | Large | Vercel (slight edge) |
+| Setup simplicity | Medium | Simple | Simplest | Vercel |
+
+### Recommendation for Lanttern (conditional)
+
+**If Python sidecar is adopted (LangGraph backend):**
+→ **CopilotKit + AG-UI** — The agent UX features (human-in-the-loop, state sync, tool rendering) map directly to Lanttern's requirements. The lesson approval workflow alone justifies this choice. LangGraph events flow natively through AG-UI without conversion.
+
+**If Elixir monolith continues (no LangGraph):**
+→ **Vercel AI SDK** — Lighter, simpler, sufficient for basic chat with tool calls. The agent doesn't have LangGraph's rich state events, so AG-UI's advanced features would be unused overhead.
+
+**If still on LiveView (Phases 1-3):**
+→ **Neither** — Use LiveView PubSub for streaming and Phoenix function components for rich UI. All three React options require the React islands setup. Build the backend now, choose the frontend when React is ready.
+
+**Regardless of choice**, the backend architecture (`AgentChat.LLM`, `AgentChat.Tools`, `AgentChat.ContextResolver`) remains the same. The frontend decision is independent and reversible.
+
+---
+
+## 7. Target Architecture
+
+### Architecture diagram
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         UI LAYER                                  │
+│                                                                   │
+│  Phase 1-3: LiveView                                              │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │ StrandChatLive / LessonChatLive / UniversalChatLive        │  │
+│  │   └── ConversationComponent (LiveComponent)                │  │
+│  │         - Message stream rendering                         │  │
+│  │         - Rich inline components (lesson cards, etc.)      │  │
+│  │         - Prompt form, agent/template selectors            │  │
+│  │         - Handles PubSub push updates                      │  │
+│  └────────────────────────────────────────────────────────────┘  │
+│                                                                   │
+│  Phase 5+: React island (additive, not replacing)                 │
+│  ┌────────────────────────────────────────────────────────────┐  │
+│  │ ChatIsland (React + Vercel AI SDK)                         │  │
+│  │   - useChat() connected to /api/chat SSE endpoint          │  │
+│  │   - Custom tool call renderers (LessonCard, etc.)          │  │
+│  │   - Auto-scroll, abort, retry                              │  │
+│  └────────────────────────────────────────────────────────────┘  │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │
+          ┌────────────────────┼─────────────────────┐
+          │ 1. User submits    │ 6. PubSub broadcast  │ (or SSE for React)
+          │    prompt          │    {:message_added}   │
+          ▼                    │                       │
+┌──────────────────────────────┴───────────────────────────────────┐
+│                      CONTEXT LAYER                                │
+│                                                                   │
+│  Lanttern.AgentChat (context module)                              │
+│    - create_conversation_with_message/3                           │
+│    - add_user_message/3                                           │
+│    - add_assistant_message/3                                      │
+│    - list_conversation_messages/2                                 │
+│    - subscribe/broadcast PubSub                                   │
+│                                                                   │
+│  Lanttern.AgentChat.LLM (NEW — LLM abstraction)                  │
+│    - run_completion/4  (replaces run_llm_chain)                   │
+│    - stream_completion/4  (Phase 4)                               │
+│    - build_messages/3                                             │
+│    - tool_call_loop/3  (replaces LangChain while_needs_response)  │
+│    - extract_response/1                                           │
+│    → Uses ReqLLM internally. NO LLM types leak outside.          │
+│                                                                   │
+│  Lanttern.AgentChat.Tools (NEW — tool registry)                   │
+│    - define_tools/2  (returns tool specs for LLM)                 │
+│    - execute_tool/3  (dispatches to business context functions)    │
+│    - Tools: create_lesson, update_lesson, set_conversation_title  │
+│                                                                   │
+│  Lanttern.AgentChat.Memory (NEW — Phase 3)                        │
+│    - list_user_memories/2                                         │
+│    - create_memory/2                                              │
+│    - summarize_conversation/2                                     │
+│    - inject_memory_messages/2                                     │
+│                                                                   │
+│  Lanttern.AgentChat.ContextResolver (NEW — Phase 2)               │
+│    - resolve/1  (conversation_id -> system messages)              │
+│    - register_context/3                                           │
+│    - context_to_system_messages/1  (per context_type)             │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │
+          ┌────────────────────┼─────────────────────┐
+          │ 2. Oban.insert()   │ 5. AgentChat         │
+          │                    │    .add_assistant_msg  │
+          ▼                    │    .broadcast          │
+┌──────────────────────────────┴───────────────────────────────────┐
+│                      WORKER LAYER                                 │
+│                                                                   │
+│  Lanttern.ChatResponseWorker (Oban, queue: :ai)                   │
+│    1. Resolve scope from user_id                                  │
+│    2. Resolve model (args → school config → app default)          │
+│    3. Fetch conversation + messages                               │
+│    4. Inject memory  (AgentChat.Memory — Phase 3)                 │
+│    5. Resolve context (AgentChat.ContextResolver — Phase 2)       │
+│    6. Call AgentChat.LLM.run_completion/4                         │
+│    7. Handle tool calls via AgentChat.Tools                       │
+│    8. Persist response + model call                               │
+│    9. Broadcast via PubSub                                        │
+│   10. Trigger memory update (Phase 3)                             │
+│                                                                   │
+│  Lanttern.MemorySummaryWorker (NEW — Phase 3, Oban, queue: :ai)   │
+│    - Triggered after conversation ends                            │
+│    - Summarizes conversation into memory entries                  │
+│                                                                   │
+│  Lanttern.CostAggregationWorker (NEW — Phase 4, Oban cron)        │
+│    - Periodic aggregation of llm_calls for cost reporting         │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │
+                               │ 3. ReqLLM.generate_text/3
+                               │    (or stream_text/3 in Phase 4)
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                      LLM CLIENT LAYER                            │
+│                                                                   │
+│  ReqLLM (unified, Req-based)                                      │
+│    - OpenAI, Anthropic, Google, Mistral, Groq, AWS Bedrock...     │
+│    - Tool calling support                                         │
+│    - Streaming SSE support                                        │
+│    - Req middleware for retries, logging, telemetry                │
+│                                                                   │
+│  LLMDB (model validation catalog)                                 │
+│    - LLMDB.allowed?/1                                             │
+└──────────────────────────────┬───────────────────────────────────┘
+                               │
+                               │ 4. Telemetry events
+                               │    [:lanttern, :llm, :call, ...]
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    OBSERVABILITY LAYER                            │
+│                                                                   │
+│  Phase 1-2: Telemetry + llm_calls table + LiveDashboard           │
+│  Phase 3+:  OpenTelemetry → Langfuse (Cloud or self-hosted)       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Module boundary rules
+
+| Module | Responsibility | Depends On | Does NOT depend on |
+|---|---|---|---|
+| `AgentChat` | Data access (CRUD), PubSub | Ecto, PubSub | ReqLLM, any LLM library |
+| `AgentChat.LLM` | LLM interaction: prompts, completion, tool loop | ReqLLM, LLMDB | Ecto, PubSub, Oban |
+| `AgentChat.Tools` | Tool definitions and execution dispatch | Business contexts (Lessons, etc.) | ReqLLM, Ecto |
+| `AgentChat.Memory` | Memory CRUD, summarization, injection | Ecto, AgentChat.LLM (for summarization) | PubSub, Oban |
+| `AgentChat.ContextResolver` | Polymorphic context resolution | Ecto, business contexts | LLM, PubSub |
+| `ChatResponseWorker` | Orchestration: ties all modules together | All AgentChat modules | LiveView |
+| `ConversationComponent` | UI rendering, user interaction | AgentChat (context only) | LLM, Tools, Memory, Worker |
+
+**Critical boundary**: No LLM library types leak outside `AgentChat.LLM`. The context module works with plain Elixir strings and maps. If ReqLLM is replaced later, only `AgentChat.LLM` changes.
+
+---
+
+## 8. Database Schema Evolution
+
+### Phase 1: Polymorphic conversation contexts
+
+```sql
+-- Replace strand_agent_conversations with polymorphic context links
+CREATE TABLE conversation_contexts (
+  id BIGSERIAL PRIMARY KEY,
+  conversation_id BIGINT NOT NULL REFERENCES agent_conversations(id) ON DELETE CASCADE,
+  context_type VARCHAR(50) NOT NULL,
+  context_id BIGINT NOT NULL,
+  context_metadata JSONB DEFAULT '{}',
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_conversation_contexts_unique
+  ON conversation_contexts(conversation_id, context_type, context_id);
+
+CREATE INDEX idx_conversation_contexts_type_id
+  ON conversation_contexts(context_type, context_id);
+```
+
+**Data migration**: Migrate `strand_agent_conversations` rows into `conversation_contexts`:
+- Each row becomes 1 or 2 `conversation_contexts` rows (`context_type: "strand"` + optionally `context_type: "lesson"`)
+- Leave `strand_agent_conversations` as-is (tech debt, per CLAUDE.md rule 7)
+
+### Phase 2: Message metadata + user memory
+
+```sql
+-- Rich message metadata (tool calls, UI components)
+ALTER TABLE agent_messages ADD COLUMN metadata JSONB DEFAULT '{}';
+
+-- User AI memory
+CREATE TABLE user_ai_memories (
+  id BIGSERIAL PRIMARY KEY,
+  profile_id BIGINT NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
+  school_id BIGINT NOT NULL REFERENCES schools(id) ON DELETE CASCADE,
+  category VARCHAR(50) NOT NULL DEFAULT 'general',
+  summary TEXT NOT NULL,
+  source_type VARCHAR(50) NOT NULL DEFAULT 'conversation',
+  source_id BIGINT,
+  relevance_score FLOAT DEFAULT 1.0,
+  expires_at TIMESTAMP,
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_user_ai_memories_profile ON user_ai_memories(profile_id);
+CREATE INDEX idx_user_ai_memories_school ON user_ai_memories(school_id);
+```
+
+**Message metadata structure:**
+
+```json
+{
+  "tool_calls": [
+    {"name": "create_lesson", "args": {"moment_id": 1, "description": "..."}}
+  ],
+  "tool_results": [
+    {"name": "create_lesson", "result": {"lesson_id": 42, "status": "ok"}}
+  ],
+  "ui_component": "lesson_card",
+  "ui_data": {"lesson_id": 42, "lesson_name": "Introduction to Fractions"}
+}
+```
+
+### Phase 3: Cost tracking aggregation
+
+```sql
+CREATE TABLE ai_usage_reports (
+  id BIGSERIAL PRIMARY KEY,
+  school_id BIGINT NOT NULL REFERENCES schools(id),
+  period_start DATE NOT NULL,
+  period_end DATE NOT NULL,
+  total_prompt_tokens BIGINT DEFAULT 0,
+  total_completion_tokens BIGINT DEFAULT 0,
+  total_estimated_cost_cents INTEGER DEFAULT 0,
+  model_breakdown JSONB DEFAULT '{}',
+  inserted_at TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX idx_ai_usage_reports_school_period
+  ON ai_usage_reports(school_id, period_start, period_end);
+```
+
+### Phase 4: Token budget configuration
+
+```sql
+-- Add to existing school_ai_configs table
+ALTER TABLE school_ai_configs ADD COLUMN monthly_token_budget BIGINT;
+ALTER TABLE school_ai_configs ADD COLUMN budget_alert_threshold FLOAT DEFAULT 0.8;
+```
+
+---
+
+## 9. Implementation Roadmap
+
+### Phase 1: Library Consolidation + LLM Abstraction (~2 weeks)
+
+**Goal**: Remove LangChain dependency; establish clean module boundaries.
+
+| Step | Task | Files affected | Risk |
+|---|---|---|---|
+| 1.1 | Create `Lanttern.AgentChat.LLM` module with `run_completion/4` wrapping ReqLLM | New: `lib/lanttern/agent_chat/llm.ex` | Low |
+| 1.2 | Create `Lanttern.AgentChat.Tools` module; extract tool definitions from `agent_chat.ex` | New: `lib/lanttern/agent_chat/tools.ex`; Modified: `agent_chat.ex` | Low |
+| 1.3 | Implement tool call loop in `AgentChat.LLM` (replaces `while_needs_response`) | `agent_chat/llm.ex` | **Medium** — must handle multi-turn tool calls correctly |
+| 1.4 | Rewrite `run_llm_chain/4` to use `AgentChat.LLM.run_completion/4` | `agent_chat.ex` | Medium |
+| 1.5 | Rewrite `ChatResponseWorker` to use `AgentChat.LLM` instead of `ChatOpenAI` | `workers/chat_response_worker.ex` | Medium |
+| 1.6 | Rewrite `rename_conversation_based_on_chain/3` to use `AgentChat.LLM` | `agent_chat.ex` | Low |
+| 1.7 | Update tests: replace LangChain Mimic mocks with ReqLLM stubs | Test files | Medium |
+| 1.8 | Remove `{:langchain, "0.4.0"}` from `mix.exs`; remove LangChain config | `mix.exs`, `config/*.exs` | Low |
+| 1.9 | Add `:telemetry` events for LLM calls | `agent_chat/llm.ex` | Low |
+
+**Deliverable**: All AI features work identically to today, but backed by ReqLLM through the `AgentChat.LLM` abstraction. LangChain removed from deps.
+
+**Verification**:
+- All existing tests pass
+- Manual test: create a conversation, send a message, verify response
+- Manual test: use create_lesson tool, verify lesson is created
+- Manual test: verify auto-rename works
+- `mix deps` shows no LangChain dependency
+
+### Phase 2: Universal Context + Rich Messages (~2 weeks)
+
+**Goal**: Polymorphic context system; message metadata for rich UI.
+
+| Step | Task |
+|---|---|
+| 2.1 | Create `conversation_contexts` migration and Ecto schema |
+| 2.2 | Create `Lanttern.AgentChat.ContextResolver` module |
+| 2.3 | Write data migration from `strand_agent_conversations` to `conversation_contexts` |
+| 2.4 | Add `metadata` JSONB column to `agent_messages` |
+| 2.5 | Modify `ChatResponseWorker` to use `ContextResolver` for system prompt building |
+| 2.6 | When tools execute (e.g., `create_lesson`), store entity reference in message metadata |
+| 2.7 | Modify `ConversationComponent` to render rich inline components based on `message.metadata` |
+| 2.8 | Create lesson card inline component for conversation stream |
+
+**Deliverable**: Conversations can be linked to any entity type. Tool call results render as rich UI components (lesson cards) instead of plain text.
+
+**Verification**:
+- Existing strand conversations continue to work (data migration verified)
+- New conversations create `conversation_contexts` rows
+- When AI creates a lesson, a lesson card appears inline in the chat
+- Context resolver loads correct system messages per entity type
+
+### Phase 3: Memory System (~2 weeks)
+
+**Goal**: Cross-conversation user memory.
+
+| Step | Task |
+|---|---|
+| 3.1 | Create `user_ai_memories` migration and Ecto schema |
+| 3.2 | Create `Lanttern.AgentChat.Memory` module |
+| 3.3 | Create `Lanttern.MemorySummaryWorker` Oban job |
+| 3.4 | Add Layer 0 memory injection to prompt construction |
+| 3.5 | Add conversation close/checkpoint logic that triggers memory summarization |
+| 3.6 | Add memory management page (staff can view/delete own memories) |
+| 3.7 | Integrate Langfuse Cloud (OpenTelemetry or REST API) |
+
+**Deliverable**: The agent remembers user preferences and past interactions across conversations. Langfuse provides tracing and cost dashboards.
+
+**Verification**:
+- Complete a conversation, then start a new one — agent references information from the previous conversation
+- Memory entries visible in staff settings
+- Deleting a memory removes it from future prompts
+- Langfuse dashboard shows traces with token counts
+
+### Phase 4: Streaming + Cost Controls (~2 weeks)
+
+**Goal**: Real-time token streaming; usage limits.
+
+| Step | Task |
+|---|---|
+| 4.1 | Add streaming path to `AgentChat.LLM` using ReqLLM streaming |
+| 4.2 | Add PubSub chunk events (`{:chunk, text}`) |
+| 4.3 | Update `ConversationComponent` for incremental message rendering |
+| 4.4 | Create `ai_usage_reports` table and `CostAggregationWorker` |
+| 4.5 | Add `monthly_token_budget` to `school_ai_configs` |
+| 4.6 | Add budget enforcement check before LLM calls |
+| 4.7 | Add usage dashboard for school admins |
+
+**Deliverable**: Streaming AI responses. Schools can set token budgets. Usage reporting.
+
+**Verification**:
+- Tokens appear as they are generated (no more waiting for full response)
+- Budget enforcement prevents calls when budget is exceeded
+- Usage dashboard shows per-school, per-model cost breakdown
+
+### Phase 5: File Uploads + React Evaluation (Sprint 5+)
+
+**Goal**: Support file-based context; evaluate React for chat UI.
+
+| Step | Task |
+|---|---|
+| 5.1 | Add file upload support to conversation (LiveView uploads) |
+| 5.2 | PDF/document text extraction for context injection |
+| 5.3 | Create Phoenix SSE controller for Vercel AI SDK Data Stream Protocol |
+| 5.4 | Create chat React island with Vercel AI SDK `useChat` hook |
+| 5.5 | Evaluate Langfuse self-hosted deployment |
+| 5.6 | Implement ILP cooldown enforcement server-side |
+
+**Deliverable**: File uploads work. React chat island available alongside LiveView version.
+
+---
+
+## 10. Risk Assessment
+
+| Risk | Probability | Impact | Mitigation |
+|---|---|---|---|
+| ReqLLM tool call API does not support multi-turn loop | Medium | **High** | Verify ReqLLM tool calling API in Phase 1 Step 1.3 before committing. Fallback: implement raw HTTP tool call loop (ReqLLM is just Req under the hood). |
+| Token extraction from ReqLLM differs from LangChain metadata format | Medium | Low | Write adapter in `AgentChat.LLM` that normalizes response format. Isolated by design. |
+| Memory summarization produces low-quality summaries | Medium | Medium | Start with simple extractive summaries. Iterate on prompt quality. Cap memory size. Allow users to delete bad memories. |
+| Polymorphic context table causes query complexity | Low | Low | Index on `(context_type, context_id)`. Queries are always scoped by `conversation_id` (indexed FK). |
+| LiveView streaming has perceptible latency vs SSE | Low | Low | PubSub broadcast is sub-millisecond within the same node. Acceptable UX. |
+| ReqLLM library becomes unmaintained | Low | **High** | The abstraction layer (`AgentChat.LLM`) isolates the app — replacement affects exactly one module. |
+| React islands setup takes longer than expected | Medium | Low | Architecture is UI-agnostic by design. LiveView path continues to work regardless of React timeline. |
+| Langfuse integration complexity with Elixir | Medium | Medium | Start with REST API (simpler). Graduate to OpenTelemetry when comfortable. Community SDK as bridge option. |
+| Breaking changes when migrating away from LangChain | Low | Medium | Migration is a rewrite of 2 files, not a refactor of the whole app. Comprehensive tests validate behavior. |
+| Tool call loop has edge cases (timeout, partial execution) | Medium | Medium | Copy LangChain's battle-tested timeout pattern (5 min). Add structured error handling. Test with simulated slow tool calls. |

--- a/exploration/ai-oriented-features/ai-agent-feature-qa-pt.md
+++ b/exploration/ai-oriented-features/ai-agent-feature-qa-pt.md
@@ -1,0 +1,1094 @@
+# Arquitetura AI Agent — Perguntas e Respostas
+
+> Documento complementar ao `ai-agent-feature-plan-pt.md`
+>
+> Perguntas antecipadas do time de desenvolvimento sobre decisões arquiteturais, trade-offs e detalhes de implementação.
+
+---
+
+## Sumário
+
+1. [Camada de Client LLM (LangChain → ReqLLM)](#1-camada-de-client-llm)
+2. [Orquestração de Agents (Oban)](#2-orquestração-de-agents)
+3. [Chat UI e Frontend (LiveView → React)](#3-chat-ui-e-frontend)
+4. [Streaming](#4-streaming)
+5. [Memória do Usuário](#5-memória-do-usuário)
+6. [Contexto Universal de Conversas](#6-contexto-universal-de-conversas)
+7. [Observabilidade (Langfuse)](#7-observabilidade)
+8. [Migração e Rollback](#8-migração-e-rollback)
+9. [Testes](#9-testes)
+10. [Performance e Custos](#10-performance-e-custos)
+11. [Segurança e Propriedade de Dados](#11-segurança-e-propriedade-de-dados)
+12. [Timeline e Priorização](#12-timeline-e-priorização)
+13. [Detalhes do Vercel AI SDK](#13-detalhes-do-vercel-ai-sdk)
+14. [Detalhes do Langfuse](#14-detalhes-do-langfuse)
+15. [Ecossistema Jido](#15-ecossistema-jido)
+16. [Monolith vs Microservice](#16-monolith-vs-microservice)
+17. [CopilotKit vs Vercel AI SDK vs assistant-ui](#17-copilotkit-vs-vercel-ai-sdk-vs-assistant-ui)
+
+---
+
+## 1. Camada de Client LLM
+
+### P: Por que remover LangChain ao invés de remover ReqLLM? LangChain tem mais features.
+
+LangChain tem mais features, mas a maioria não é usada pelo Lanttern. As únicas features do LangChain que realmente usamos são:
+
+1. `LLMChain` com `while_needs_response` — um loop de tool-call (~25 linhas de código customizado para substituir)
+2. `ChatOpenAI` — instanciação de modelo (uma linha com ReqLLM)
+3. `Function`/`FunctionParam` — definições de tools (mais simples no ReqLLM com `ReqLLM.Tool`)
+4. Construtores de `Message` — construção de mensagens (equivalente direto no `ReqLLM.Context`)
+
+Estamos pagando por um framework inteiro mas usando ~5% dele. ReqLLM é mais enxuto, já está no projeto, já testado, suporta nativamente 10+ provedores, e segue convenções Elixir mais de perto. O custo de manter LangChain (overhead cognitivo de duas bibliotecas, dois padrões de teste, duas configs) supera o custo de reescrever 25 linhas de código de orquestração.
+
+### P: O que exatamente é o "tool call loop" que precisamos construir? Não é complexo?
+
+O tool call loop substitui o `mode: :while_needs_response` do LangChain. Aqui está o que ele faz:
+
+1. Enviar mensagens + definições de tools para o LLM
+2. Se a resposta do LLM contém um tool call → executar a tool → appendar o resultado às mensagens → voltar ao passo 1
+3. Se a resposta do LLM é texto puro → retorná-la
+
+Em pseudocódigo:
+
+```elixir
+def tool_call_loop(model, messages, tools, opts, max_iterations \\ 10) do
+  case call_llm(model, messages, tools, opts) do
+    {:ok, %{tool_calls: []}} = result ->
+      result
+
+    {:ok, %{tool_calls: tool_calls} = response} when max_iterations > 0 ->
+      results = Enum.map(tool_calls, &execute_tool/1)
+      updated_messages = messages ++ [assistant_msg(response)] ++ tool_result_msgs(results)
+      tool_call_loop(model, updated_messages, tools, opts, max_iterations - 1)
+
+    {:ok, _} ->
+      {:error, :max_iterations_exceeded}
+
+    error ->
+      error
+  end
+end
+```
+
+São aproximadamente 25-30 linhas. O guarda `max_iterations` previne loops infinitos. O timeout de 5 minutos do LangChain é substituído por um timeout na própria função `call_llm`.
+
+### P: E se o ReqLLM não suportar tool calling da forma que precisamos?
+
+ReqLLM v1.6+ suporta tool calling via `ReqLLM.Tool`. A API é:
+
+```elixir
+tools = [
+  ReqLLM.Tool.function("create_lesson", "Creates a lesson plan", %{
+    type: "object",
+    properties: %{
+      description: %{type: "string", description: "Lesson description"},
+      moment_id: %{type: "integer", description: "The moment ID"}
+    },
+    required: ["description", "moment_id"]
+  })
+]
+
+{:ok, response} = ReqLLM.generate_text(model, context, tools: tools)
+```
+
+Se o tool calling do ReqLLM não lidar com algum edge case específico, ReqLLM é construído sobre Req (um client HTTP composável). Podemos sempre descer para a camada HTTP raw e enviar os parâmetros de tool call diretamente para a API do provedor. Isso é uma rede de segurança, não um caminho esperado.
+
+**Passo de verificação**: Phase 1 Passo 1.3 inclui explicitamente a verificação da API de tool calling do ReqLLM antes de comprometer com a migração. Se não funcionar, construímos um wrapper fino sobre Req que lida com o protocolo de tool calling da OpenAI diretamente.
+
+### P: ReqLLM suporta 10+ provedores, mas precisamos disso de verdade? Só usamos OpenAI.
+
+Hoje, sim. Mas o plano identifica explicitamente **lock-in em provedor único** como uma lacuna atual. Escolas podem querer usar diferentes modelos (Anthropic para tarefas criativas, Google para multilíngue, modelos locais para escolas com dados sensíveis). A camada de abstração (`AgentChat.LLM`) combinada com o suporte multi-provider do ReqLLM significa que trocar provedores é uma mudança de configuração, não uma mudança de código.
+
+Mesmo se ficarmos na OpenAI pelos próximos 6 meses, o custo do suporte multi-provider é zero — o ReqLLM já fornece isso. Não é algo que estamos construindo; é algo que ganhamos de graça.
+
+### P: Remover LangChain não vai quebrar os testes existentes?
+
+Sim, os testes existentes que mockam LangChain (via `Mimic.copy(LangChain.Chains.LLMChain)`) precisarão ser reescritos. Isso é Phase 1 Passo 1.7. Os novos testes usarão o mesmo padrão de `ReqLLMStub` já estabelecido para a feature de ILP — injeção de dependência do módulo LLM, não mocks específicos de biblioteca.
+
+A reescrita dos testes é na verdade uma melhoria: injeção de dependência é mais confiável e simples que mocking baseado em Mimic. A superfície de testes é contida em `agent_chat_test.exs` e `chat_response_worker_test.exs`.
+
+### P: E se o ecossistema do LangChain Elixir evoluir? E se ficar muito melhor?
+
+LangChain para Elixir (v0.4.0) é uma porta da comunidade do ecossistema LangChain Python/JS. Sua cadência de updates é incerta e não segue idiomas Elixir de perto. Mesmo que melhore, nossa arquitetura isola o client LLM dentro de `AgentChat.LLM` — se uma biblioteca melhor surgir (LangChain, Jido, ou algo novo), mudamos um módulo, não o app inteiro.
+
+A decisão arquitetural não é "ReqLLM para sempre" — é "uma biblioteca agora, atrás de uma abstração que torna a troca barata."
+
+---
+
+## 2. Orquestração de Agents
+
+### P: Por que não usar Jido agents ao invés de Oban? Jido é projetado especificamente para AI agents.
+
+Jido v2.0 introduz agents baseados em GenServer com gestão de estado, directives e execução em runtime. São features poderosas — para o problema certo. Nosso problema atual não precisa delas.
+
+O agent chat do Lanttern é stateless entre requests: o usuário envia uma mensagem, o sistema processa, armazena o resultado e faz broadcast. Todo o estado vive no PostgreSQL. Não há necessidade de estado in-memory de agente, coordenação multi-agent, ou state machines complexas.
+
+Jido adicionaria:
+- Nova supervision tree para gerenciar
+- Novas considerações de deploy (lifecycle do processo do agente)
+- Novos padrões de teste (teste de GenServer vs teste de job Oban)
+- Novos conceitos para o time aprender (directives, signals, command function)
+
+Para zero benefício sobre o que o Oban já fornece (retries, unique constraints, pruning, dashboard, isolamento de testes).
+
+**Quando Jido faz sentido**: Se algum dia precisarmos de agentes que coordenam entre si, mantêm estado long-running, ou executam workflows multi-step complexos onde a state machine não é trivialmente representável em banco de dados. Esse dia pode chegar — mas não é hoje.
+
+### P: Se adicionarmos streaming com Task.Supervisor (Phase 4), não vamos ter dois paths de execução? Não fica bagunçado?
+
+Sim, haverá dois paths. Mas servem propósitos diferentes:
+
+1. **Path Oban** (não-streaming): Confiável, retryable, baseado em jobs. Usado para a chamada LLM principal. Sobrevive a restarts do servidor. Tem unique constraints. Registra no dashboard Oban.
+2. **Path Task** (streaming): Fire-and-forget dentro do lifecycle de um request. Faz stream de chunks via PubSub. Não sobrevive a restarts (mas streaming é inerentemente atrelado a uma conexão ativa).
+
+O worker decide qual path usar:
+
+```elixir
+def perform(%Oban.Job{args: %{"streaming" => true} = args}) do
+  Task.Supervisor.start_child(Lanttern.TaskSupervisor, fn ->
+    stream_response(args)
+  end)
+end
+
+def perform(%Oban.Job{args: args}) do
+  batch_response(args)
+end
+```
+
+Não são duas arquiteturas competindo — é um orquestrador (Oban) com duas estratégias de execução. A complexidade fica contida no módulo do worker.
+
+### P: O que acontece se o job Oban falhar durante um tool call?
+
+O comportamento atual é preservado: Oban faz retry do job (até `max_attempts: 3`). O tool call é idempotente por design — se `create_lesson` for chamado duas vezes com os mesmos parâmetros, a segunda chamada ou cria uma duplicata (que o usuário pode deletar) ou falha se houver constraint de unicidade.
+
+Para operações não-idempotentes, o resultado do tool call deve ser armazenado no banco de dados antes do broadcast. No retry, o worker verifica se o tool call já foi executado (checando message metadata) e pula a re-execução.
+
+---
+
+## 3. Chat UI e Frontend
+
+### P: O setup React já está em progresso. Por que não esperar e ir direto para React + Vercel AI SDK?
+
+Três razões:
+
+1. **Risco de timeline**: O timeline do setup React é incerto. Bloquear arquitetura AI backend em infraestrutura frontend atrasaria o projeto inteiro.
+2. **Arquitetura backend-first**: O backend (abstração LLM, resolução de contexto, memória, tools) é o mesmo independente da tecnologia frontend. Construí-lo agora com LiveView significa que está pronto para React quando React estiver pronto.
+3. **LiveView é suficiente para v0**: O chat precisa exibir mensagens, mostrar estados de loading, renderizar resultados de tool call como componentes inline, e (depois) fazer stream de tokens. LiveView lida com tudo isso nativamente. O valor do Vercel AI SDK está na conveniência (auto-scroll, abort, reconnect) — bom ter, não bloqueante.
+
+O plano de transição é explícito: **Phase 1-3 = LiveView; Phase 4-5 = React island adicionado junto com LiveView**. Ambos os paths coexistem. Sem rip-and-replace.
+
+### P: Se usarmos LiveView agora, não vamos ter que reescrever toda a UI do chat quando migrarmos para React?
+
+Não. A reescrita é apenas da **camada de template** (HTML/HEEx → JSX). O contrato do backend não muda:
+
+- Funções de contexto `AgentChat`: mesma API independente do consumidor
+- Eventos PubSub: mesmos eventos se consumidos por LiveView ou encaminhados para SSE
+- Schema de mensagem: mesmo `metadata` JSONB independente de como é renderizado
+- Definições de tools: mesmo módulo `AgentChat.Tools`
+
+O que muda ao adicionar React:
+1. Um novo controller Phoenix (`AiStreamController`) que converte eventos PubSub em SSE
+2. Um componente React que usa `useChat` para consumir o stream SSE
+3. Um LiveView hook que monta o React island
+
+O que NÃO muda: `AgentChat`, `AgentChat.LLM`, `AgentChat.Tools`, `AgentChat.Memory`, `AgentChat.ContextResolver`, `ChatResponseWorker`, `MemorySummaryWorker`, todos os schemas Ecto, todas as migrations.
+
+### P: Por que Vercel AI SDK ao invés de CopilotKit? CopilotKit parece mais completo.
+
+CopilotKit é uma **plataforma completa** — inclui SDK backend, sua própria orquestração de agentes (AG-UI Protocol) e oferta cloud. Adotar CopilotKit significa:
+
+1. **Conflito de backend**: CopilotKit espera que você use seu SDK backend para comunicação com agentes. A lógica de agente do Lanttern vive em Elixir (Oban workers, ReqLLM, Phoenix PubSub). O SDK backend Node.js do CopilotKit não integra com isso.
+2. **Vendor lock-in**: CopilotKit tem modelo freemium com tiers enterprise pagos. O AI SDK é totalmente open source.
+3. **Over-engineering**: Não precisamos de uma plataforma. Precisamos de um hook de streaming de chat. Vercel AI SDK é exatamente isso — `useChat()` e nada mais.
+
+CopilotKit faz sentido para times construindo um app novo com AI no core e sem backend existente. Lanttern tem um backend Elixir maduro. Adicionar o backend do CopilotKit por cima criaria um sistema paralelo que luta com Oban/PubSub.
+
+### P: E o assistant-ui? Parece mais customizável que o Vercel AI SDK.
+
+assistant-ui é uma biblioteca de componentes React headless especificamente para UIs de chat AI. É uma boa biblioteca com controle granular sobre cada elemento de UI. Os trade-offs vs Vercel AI SDK:
+
+| Aspecto | Vercel AI SDK | assistant-ui |
+|---|---|---|
+| **Comunidade** | ~60k stars no GitHub, adoção massiva | ~5k stars, crescendo |
+| **Documentação** | Extensiva, cobre backends não-Next.js | Boa, menos cobertura para backends customizados |
+| **Protocolo backend** | Data Stream Protocol bem definido | Adapters customizados (mais flexível, mais trabalho) |
+| **Streaming** | Nativo via useChat | Requer configuração de adapter |
+| **Risco** | Muito baixo (backing da Vercel, padrão da indústria) | Baixo-médio (comunidade menor) |
+
+Ambos são viáveis. A recomendação é Vercel AI SDK porque seu Data Stream Protocol é bem documentado para backends customizados (que é o nosso caso — Phoenix, não Next.js), e o tamanho da comunidade dá confiança na manutenção a longo prazo.
+
+Se o time avaliar ambos durante Phase 5 e preferir a flexibilidade do assistant-ui, o backend não muda. O endpoint SSE serve o mesmo protocolo de qualquer forma.
+
+### P: Poderíamos usar LiveView para tudo incluindo streaming e pular React inteiramente?
+
+Sim, tecnicamente. LiveView pode fazer stream de tokens via PubSub, renderizar componentes ricos, e lidar com todas as interações do chat. A questão é se o time quer investir em construir:
+
+- Lógica de auto-scroll (scroll para baixo conforme tokens chegam, mas não se o usuário scrollou para cima)
+- Tratamento de abort (cancelar uma chamada LLM em progresso)
+- Lógica de reconexão (o que acontece quando o WebSocket cai no meio do stream?)
+- Display otimista de mensagem (mostrar mensagem do usuário imediatamente antes da confirmação do servidor)
+- Atalhos de teclado (enviar no Enter, nova linha no Shift+Enter com tratamento adequado de cursor)
+
+Esses são todos problemas resolvidos no Vercel AI SDK. Construí-los em LiveView é possível mas consome tempo. A recomendação é: **LiveView por enquanto, React para quando o investimento em UX justificar.**
+
+---
+
+## 4. Streaming
+
+### P: PubSub streaming não vai adicionar latência comparado a SSE direto?
+
+Broadcast PubSub dentro do mesmo node Erlang é sub-milissegundo. O caminho é:
+
+```
+Chunk ReqLLM → Processo Worker → PubSub.broadcast → Parent LiveView → send_update → Re-render do Component
+```
+
+Latência adicional total vs SSE direto: ~1-5ms. Imperceptível para o usuário. O gargalo é sempre o tempo de resposta da API LLM (tipicamente 50-500ms por chunk), não o broadcast interno.
+
+Se Lanttern escalar para múltiplos nodes, PubSub funciona entre nodes via `Phoenix.PubSub` com adapter distribuído (ex: `Phoenix.PubSub.PG2`, já configurado). Sem mudanças de código.
+
+### P: Como lidamos com tool calls durante streaming? O LLM pausa, chama uma tool e retoma.
+
+Durante streaming, o fluxo é:
+
+1. LLM faz stream de tokens de texto → broadcast como eventos `:chunk`
+2. LLM emite um tool call → broadcast como `:tool_call_start`
+3. Worker pausa o stream, executa a tool
+4. Broadcast `:tool_call_result` com o resultado
+5. Alimenta o resultado de volta ao LLM → streaming retoma do passo 1
+
+O ConversationComponent lida com isso mostrando:
+- Texto em streaming conforme chega (`:chunk`)
+- Um indicador "chamando tool..." quando `:tool_call_start` é recebido
+- O resultado da tool (ex: card de aula) quando `:tool_call_result` é recebido
+- Texto em streaming continuando após o tool call completar
+
+É um processo sequencial — o worker gerencia o lifecycle do stream. O component apenas reage aos eventos.
+
+### P: E se o usuário navegar para fora durante streaming? Tokens são perdidos?
+
+Quando o usuário navega para fora, o processo LiveView termina e se desinscreve do PubSub. O worker (Oban job ou Task) continua até completar independentemente — ele não sabe nem se importa com o subscriber.
+
+A mensagem completa é persistida no banco de dados quando o stream termina (evento `:message_complete`). Quando o usuário volta para a conversa, todas as mensagens (incluindo a que estava em streaming) são carregadas do banco. Nenhum dado é perdido.
+
+Mensagens parciais (o buffer de streaming) são perdidas da UI mas não da conversa. O banco de dados é a fonte de verdade, não o estado do LiveView.
+
+---
+
+## 5. Memória do Usuário
+
+### P: Como prevenimos o sistema de memória de injetar informações obsoletas ou erradas?
+
+Três salvaguardas:
+
+1. **Score de relevância**: Memórias têm um `relevance_score` (0.0-1.0). O prompt de sumarização instrui o LLM a atribuir scores mais baixos a informações sensíveis ao tempo. Apenas as top N memórias (por score) são injetadas.
+
+2. **Expiração**: Memórias com tempo limitado têm campo `expires_at`. Um cron job faz prune de entradas expiradas. Exemplo: "O usuário está trabalhando em uma unidade de frações" expira após 30 dias.
+
+3. **Controle manual**: Staff pode visualizar e deletar suas próprias memórias via página de configurações. Se o agente disser algo errado baseado em uma memória, o usuário pode corrigir diretamente.
+
+Adicionalmente, memórias são injetadas como contexto, não como fatos. O wrapper do system prompt deixa isso claro:
+
+```xml
+<user_memory>
+  <note>O seguinte é um resumo de interações anteriores. Pode estar desatualizado.
+  Use como contexto, não como verdade absoluta. Se o usuário contradisser uma memória,
+  confie no usuário.</note>
+  <preferences>Usuário prefere planos de aula detalhados com notas de diferenciação</preferences>
+</user_memory>
+```
+
+### P: A chamada LLM de sumarização não vai adicionar custo para cada conversa?
+
+Sim, mas é uma única e pequena chamada LLM por encerramento de conversa — não por mensagem. A entrada é a transcrição da conversa (tipicamente 5-20 mensagens), e a saída são 2-3 frases de resumo compactas. Estimativa de custo:
+
+- Entrada: ~2.000 tokens (transcrição da conversa)
+- Saída: ~200 tokens (resumo)
+- Modelo: Pode usar um modelo mais barato/menor (ex: GPT-4o-mini)
+- Custo por sumarização: ~$0,001
+
+Para uma escola com 50 professores ativos, cada um tendo 5 conversas por semana: 250 sumarizações × $0,001 = **$0,25/semana**. Insignificante.
+
+### P: Qual a diferença entre memória do usuário e contexto de conversa?
+
+| Aspecto | Memória do Usuário | Contexto de Conversa |
+|---|---|---|
+| **Escopo** | Entre conversas, por-usuário | Conversa única, por-entidade |
+| **Persistência** | Sobrevive após fim da conversa | Atrelado ao lifecycle da conversa |
+| **Conteúdo** | Resumos de interações passadas, preferências | Dados curriculares (detalhes de strand, lesson, ILP) |
+| **Fonte** | Gerado por AI a partir de conversas | Carregado de entidades no banco |
+| **Layer** | Layer 0 (antes de config da escola) | Layer 5 (contexto curricular) |
+| **Exemplo** | "Usuário prefere atividades práticas" | "Strand: Introdução a Frações, Ano 4" |
+
+Memória diz ao agente **quem** o usuário é. Contexto diz ao agente **sobre o que** a conversa trata.
+
+### P: Memórias podem ser compartilhadas entre escolas se um professor trabalha em múltiplas escolas?
+
+Não. Memórias são scoped para `(profile_id, school_id)`. Um professor na Escola A e Escola B tem conjuntos de memória separados. Isso é intencional:
+
+1. **Isolamento de dados**: Escolas são donas dos seus dados. Uma memória gerada do currículo da Escola A não deve vazar para a Escola B.
+2. **Relevância**: O contexto de ensino varia por escola. "Prefere planos de aula em português" pode ser relevante em uma escola mas não em outra.
+3. **Padrão de Scope**: Isso segue o padrão `Scope` de autorização existente no Lanttern — todos os dados school-scoped são isolados por `school_id`.
+
+---
+
+## 6. Contexto Universal de Conversas
+
+### P: Por que uma tabela polimórfica ao invés de uma tabela de junção separada por tipo de contexto?
+
+Uma tabela de junção separada por tipo (como a atual `strand_agent_conversations`) requer:
+- Uma nova migration para cada novo tipo de contexto
+- Um novo schema Ecto para cada tabela de junção
+- Novas funções de query no módulo de contexto
+- Lógica condicional para checar múltiplas tabelas ao carregar contextos de conversa
+
+A tabela polimórfica requer:
+- Uma migration (feita uma vez)
+- Um schema Ecto
+- Uma query para carregar todos os contextos de uma conversa
+- Uma nova cláusula de função por tipo de contexto (no `ContextResolver`)
+
+A abordagem polimórfica escala com o número de tipos de entidade sem mudanças de schema. Adicionar contexto de "assessment" ou "student" é uma mudança de código, não de banco.
+
+**Trade-off**: Perdemos integridade referencial de foreign key no nível do banco para `context_id`. Isso é aceitável porque:
+1. Context links são criados programaticamente (não via input do usuário), então referências inválidas são erros de programador, não erros de usuário
+2. O `ContextResolver` valida que a entidade existe ao resolver — uma referência pendente produz um soft error (contexto não carregado), não um crash
+3. Esse padrão é bem estabelecido em Elixir/Ecto (ex: embeds polimórficos, Activity streams)
+
+### P: O que acontece com a tabela antiga `strand_agent_conversations`?
+
+Conforme regra 7 do CLAUDE.md (padrão é dívida técnica, não refatoração):
+
+1. Os dados são **migrados** para `conversation_contexts` (uma linha por strand, opcionalmente uma por lesson)
+2. A tabela antiga é **deixada como está** — não é dropada, não é modificada
+3. Código novo usa `conversation_contexts` exclusivamente
+4. Código antigo que lê `strand_agent_conversations` continua funcionando (até eventualmente ser limpo)
+
+Não há breaking change. A tabela antiga se torna dívida técnica não utilizada, limpa em um sprint futuro.
+
+### P: Como funciona o `context_metadata` JSONB? Quando é útil?
+
+`context_metadata` armazena um **snapshot** dos dados relevantes da entidade no momento em que a conversa foi criada. Dois casos de uso:
+
+1. **Auditoria**: Após a conversa, podemos ver exatamente o que o agente sabia. Se os itens curriculares de um strand mudaram, o metadata mostra a versão que o agente viu.
+
+2. **Deleção de entidade**: Se uma lesson é deletada após uma conversa sobre ela, o metadata preserva o nome e detalhes da lesson para contexto histórico.
+
+O metadata é opcional. Na maioria dos casos, o `ContextResolver` carrega a entidade ao vivo do banco. O metadata é uma rede de segurança, não uma fonte primária de dados.
+
+### P: Uma única conversa pode ter contextos de escolas diferentes?
+
+Não. Conversas são scoped para `school_id` (via `agent_conversations.school_id`). Todas as entidades de contexto devem pertencer à mesma escola. O `ContextResolver` garante isso:
+
+```elixir
+def register_context(%Scope{school_id: school_id}, conversation, context_type, context_id) do
+  entity = load_entity(context_type, context_id)
+  true = entity.school_id == school_id
+  # ... criar conversation_context
+end
+```
+
+Isso segue o padrão `Scope` — isolamento de escola é garantido em cada fronteira.
+
+---
+
+## 7. Observabilidade
+
+### P: Por que não começar com Langfuse desde o dia um? Por que a abordagem faseada?
+
+Três razões:
+
+1. **Otimização prematura**: Nas Phases 1-2, estamos consolidando bibliotecas e construindo abstrações. O volume de chamadas LLM é baixo (POC com usuários limitados). A tabela `llm_calls` existente + eventos `:telemetry` são suficientes. Adicionar infraestrutura Langfuse antes de precisar é overhead.
+
+2. **Clareza de integração**: Na Phase 3, o módulo `AgentChat.LLM` está estável e sabemos exatamente o que instrumentar. Integrar Langfuse com um módulo que ainda está sendo refatorado (Phase 1) significaria atualizar a integração conforme o código muda.
+
+3. **Validação de custo**: Começar com Langfuse Cloud (tier gratuito) nos permite validar o valor antes de comprometer com infraestrutura self-hosted. Se o time não olha os dashboards, sabemos para não investir em self-hosting.
+
+### P: Podemos pular Langfuse Cloud e ir direto para self-hosted?
+
+Sim, mas não é recomendado. Langfuse self-hosted requer:
+
+- Cluster Kubernetes (ou Docker Compose, mas sem HA)
+- Instância ClickHouse (o maior peso operacional)
+- Instância PostgreSQL (pode reutilizar existente)
+- Instância Redis
+- Storage compatível com S3
+- Tempo de DevOps para setup, manutenção, upgrades
+
+O tier Cloud começa em **$0/mês** (50k traces). Para um time validando a ferramenta, o tier gratuito elimina todo overhead de infraestrutura. Graduem para self-hosted quando:
+
+- Volume de traces exceder 5M/mês (Cloud Pro a $199/mês começa a ficar caro)
+- Requisitos de residência de dados mandarem on-premises
+- O time estiver confiante que Langfuse é a ferramenta certa (validado no Cloud)
+
+### P: E usar o dashboard nativo da OpenAI para observabilidade?
+
+O dashboard da OpenAI mostra uso de API e custos, que é útil mas limitado:
+
+1. **Sem tracing**: Você não vê o lifecycle completo da conversa (construção de prompt → chamada LLM → execução de tool → resposta)
+2. **Sem avaliação**: Sem LLM-as-judge, sem labeling manual, sem testes de regressão
+3. **Sem gestão de prompts**: Prompts vivem no seu código, não na plataforma da OpenAI
+4. **Vendor lock-in**: Se trocar para Anthropic ou Google, perde toda observabilidade
+5. **Sem views por-escola**: OpenAI mostra uso agregado, não breakdowns por-escola
+
+O dashboard da OpenAI é um complemento, não um substituto, para observabilidade LLM adequada.
+
+---
+
+## 8. Migração e Rollback
+
+### P: Qual é o plano de rollback se a migração para ReqLLM quebrar algo em produção?
+
+A migração está atrás de fronteiras de módulos limpas. Opções de rollback:
+
+1. **Git revert**: As mudanças estão em 2 arquivos (`agent_chat.ex`, `chat_response_worker.ex`) + 1 novo módulo (`agent_chat/llm.ex`). Reverter para a versão LangChain é um `git revert` do commit de migração.
+
+2. **Feature flag**: Podemos introduzir uma feature flag temporária que alterna entre o path antigo LangChain e o novo path ReqLLM. Isso é overkill para uma mudança de 2 arquivos mas disponível se o time quiser.
+
+3. **LangChain permanece no mix.exs até Phase 1 ser verificada**: Podemos manter `{:langchain, "0.4.0"}` nas deps até verificarmos o path ReqLLM em staging. Remover apenas após confiança.
+
+O ponto chave: o schema do banco de dados não muda na Phase 1. Todas as mensagens, conversas e model calls são armazenadas no mesmo formato. A migração é puramente na camada de código — totalmente reversível.
+
+### P: Como migramos os dados de `strand_agent_conversations` sem downtime?
+
+A migração é aditiva:
+
+1. Deploy da tabela `conversation_contexts` (nova tabela, sem impacto no existente)
+2. Executar migração de dados que copia linhas de `strand_agent_conversations` para `conversation_contexts`
+3. Deploy do código que lê de `conversation_contexts`
+4. Código antigo que lê `strand_agent_conversations` continua funcionando (os dados ainda estão lá)
+
+Não há downtime porque:
+- Passo 1 é uma nova tabela (zero impacto)
+- Passo 2 é uma migração background (pode rodar em horários de baixo tráfego)
+- Passo 3 deploya código novo que lê a nova tabela
+- A tabela antiga nunca é dropada ou modificada
+
+Se o código novo tiver bug, revertemos o deploy. O código antigo ainda lê a tabela antiga. Sem perda de dados.
+
+### P: E se uma migração entre fases falhar? Podemos rodar Phase 3 sem Phase 2?
+
+Não. As fases são dependências sequenciais:
+
+- **Phase 1** (abstração LLM) é necessária por todas as fases subsequentes — todas usam `AgentChat.LLM`
+- **Phase 2** (contexto + mensagens ricas) é necessária pela Phase 3 — injeção de memória usa o pipeline de resolução de contexto
+- **Phase 3** (memória) é independente da Phase 4 — streaming não precisa de memória
+- **Phase 4** (streaming) é independente da Phase 5 — file uploads não precisam de streaming
+
+Então a cadeia de dependências é: 1 → 2 → 3, e 1 → 4, e 1 → 5. Phases 3, 4 e 5 são independentes entre si (após Phase 2 para 3, após Phase 1 para 4 e 5).
+
+---
+
+## 9. Testes
+
+### P: Como testamos o módulo `AgentChat.LLM` sem fazer chamadas reais à API?
+
+O mesmo padrão já usado para revisões de ILP — injeção de dependência:
+
+```elixir
+# Produção: usa ReqLLM
+AgentChat.LLM.run_completion(model, messages, tools)
+
+# Teste: injeta módulo stub
+AgentChat.LLM.run_completion(model, messages, tools, llm_module: Lanttern.ReqLLMStub)
+```
+
+O `ReqLLMStub` já existe em `test/support/stubs/req_llm.ex`. Estendemos para lidar com tool calling:
+
+```elixir
+defmodule Lanttern.ReqLLMStub do
+  def generate_text(_model, _context, opts \\ []) do
+    case Keyword.get(opts, :stub_response, :text) do
+      :text ->
+        {:ok, %ReqLLM.Response{message: text_message("Resposta stub")}}
+      :tool_call ->
+        {:ok, %ReqLLM.Response{message: tool_call_message("create_lesson", %{...})}}
+    end
+  end
+end
+```
+
+Isso permite testar o pipeline completo (construção de mensagem → chamada LLM → extração de resposta → execução de tool) sem chamadas reais à API.
+
+### P: Como testamos streaming?
+
+Testes de streaming usam um stub que emite chunks:
+
+```elixir
+defmodule Lanttern.ReqLLMStreamStub do
+  def stream_text(_model, _context, callback, _opts \\ []) do
+    callback.({:chunk, "Olá "})
+    callback.({:chunk, "mundo"})
+    callback.({:done, %{usage: %{input: 10, output: 5}}})
+    :ok
+  end
+end
+```
+
+O teste se inscreve no PubSub, envia uma mensagem, e asserta que eventos `:chunk` chegam em ordem, seguidos por `:message_complete`.
+
+### P: Como testamos a sumarização de memória? Ela chama o LLM.
+
+O `MemorySummaryWorker` aceita um módulo LLM via injeção de dependência (mesmo padrão). O stub de teste retorna um resumo predeterminado:
+
+```elixir
+test "resume conversa em entradas de memória" do
+  conversation = insert(:agent_conversation, ...)
+  insert(:agent_message, conversation: conversation, role: "user", content: "Prefiro atividades práticas")
+  insert(:agent_message, conversation: conversation, role: "assistant", content: "Anotado! Vou sugerir...")
+
+  perform_job(MemorySummaryWorker, %{conversation_id: conversation.id}, llm_module: SummaryStub)
+
+  memories = AgentChat.Memory.list_user_memories(scope, profile)
+  assert length(memories) == 1
+  assert hd(memories).summary =~ "práticas"
+end
+```
+
+---
+
+## 10. Performance e Custos
+
+### P: Quanto esta arquitetura vai custar em taxas de API LLM?
+
+Custo depende do volume de uso. Estimativas para uma escola com 50 professores ativos:
+
+| Operação | Tokens/chamada | Chamadas/semana | Custo/semana (GPT-4o) | Custo/semana (GPT-4o-mini) |
+|---|---|---|---|---|
+| Mensagem chat (com contexto) | ~3.000 in + ~1.000 out | 500 | ~$5,00 | ~$0,15 |
+| Sumarização de memória | ~2.000 in + ~200 out | 50 | ~$0,50 | ~$0,02 |
+| Renomeação de conversa | ~500 in + ~50 out | 50 | ~$0,05 | ~$0,002 |
+| **Total** | | | **~$5,55/semana** | **~$0,17/semana** |
+
+Usar GPT-4o-mini para sumarização e rename (não visível ao usuário) reduz custos significativamente. O `base_model` da escola controla o modelo principal do chat.
+
+Phase 4 adiciona **enforcement de orçamento**: escolas podem definir `monthly_token_budget` em `school_ai_configs`. O worker verifica o orçamento antes de fazer uma chamada LLM e retorna erro se exceder.
+
+### P: A injeção de memória vai aumentar custos de token significativamente?
+
+Injeção de memória adiciona ~200-500 tokens por conversa (a camada de resumo). Para uma conversa com 3.000 tokens de contexto já (strand + lesson + config escola), memórias adicionam ~10-15% de overhead. Isso é insignificante comparado ao valor de respostas personalizadas.
+
+O cap (top 10 memórias) previne crescimento ilimitado. Se um usuário tem 100 memórias, apenas as 10 mais relevantes são injetadas.
+
+### P: Qual o impacto de performance da tabela polimórfica de contexto?
+
+A tabela `conversation_contexts` tem:
+- Um índice único em `(conversation_id, context_type, context_id)`
+- Um índice em `(context_type, context_id)`
+
+Carregar contextos para uma conversa é uma única query:
+
+```sql
+SELECT * FROM conversation_contexts WHERE conversation_id = $1;
+```
+
+Isso retorna 1-3 linhas (strand, lesson, talvez ILP). A query bate no índice diretamente. Performance é idêntica à query atual de `strand_agent_conversations` — um lookup indexado retornando um punhado de linhas.
+
+---
+
+## 11. Segurança e Propriedade de Dados
+
+### P: Se adotarmos Langfuse Cloud, estamos enviando dados de conversa para terceiros?
+
+Sim. Langfuse Cloud recebe traces, que podem incluir conteúdo de prompt, conteúdo de completion e contagem de tokens. Porém:
+
+1. **GDPR compliant**: Langfuse oferece residência de dados na EU e DPA (Data Processing Agreement)
+2. **SOC 2 Type II certificado**: Compliance de segurança padrão
+3. **Mascaramento de dados**: Você pode mascarar campos sensíveis antes de enviar traces
+4. **Conteúdo opt-in**: Você controla quais dados são incluídos nos traces. Pode enviar apenas metadata (modelo, tokens, latência) sem conteúdo real de mensagem.
+
+Para máximo controle de dados, Langfuse self-hosted mantém tudo na sua infraestrutura. A abordagem faseada (Cloud → self-hosted) permite começar com conveniência e migrar para controle quando necessário.
+
+### P: Como protegemos o endpoint SSE (Phase 5) para o Vercel AI SDK?
+
+O endpoint SSE precisa de segurança separada porque não é uma rota LiveView (sem WebSocket, sem CSRF token):
+
+1. **Autenticação por sessão**: O React island compartilha a mesma sessão de browser que a página LiveView. O endpoint SSE valida o cookie de sessão.
+2. **Proteção CSRF**: Usar um token CSRF passado do LiveView para o React island como prop. O componente React inclui no header do request SSE.
+3. **Rate limiting**: Aplicar middleware de rate limiting por-usuário (plug) no endpoint SSE.
+4. **Autorização por Scope**: O endpoint verifica `Scope.has_permission?(scope, "agents_management")` antes de processar.
+
+```elixir
+# router.ex
+pipeline :api_auth do
+  plug :fetch_session
+  plug :verify_session_user
+  plug :verify_csrf_header  # Plug customizado: verifica header X-CSRF-Token
+  plug :rate_limit, max: 10, window: 60_000  # 10 requests/minuto
+end
+
+scope "/api" do
+  pipe_through [:api_auth]
+  post "/chat", AiStreamController, :stream
+end
+```
+
+### P: E a propriedade de dados com ReqLLM? Chamadas de API são logadas pelos provedores?
+
+Quando ReqLLM chama a API da OpenAI, a OpenAI processa o request conforme seus termos de API. Especificamente:
+
+1. **OpenAI não treina com dados de API** (conforme política atual)
+2. **OpenAI retém dados de API por 30 dias** para monitoramento de abuso (a menos que você opte por sair via configurações de retenção de dados da API)
+3. **Lanttern armazena todos os dados de conversa** em seu próprio banco — temos uma cópia local completa
+
+O mesmo se aplica a qualquer provedor (Anthropic, Google, etc.). A arquitetura armazena todos os dados localmente; o provedor recebe uma cópia durante a chamada de API. Para máximo controle, escolas podem configurar modelos locais/privados (via suporte de provedores do ReqLLM) quando estiverem disponíveis.
+
+---
+
+## 12. Timeline e Priorização
+
+### P: Podemos pular fases ou fazê-las em paralelo?
+
+**Oportunidades de paralelismo:**
+- Phase 3 (Memória) e Phase 4 (Streaming) são independentes após Phase 2. Podem rodar em paralelo se o time tiver capacidade.
+- Phase 5 (File uploads + React) é independente após Phase 1.
+
+**Não podem ser puladas:**
+- Phase 1 (abstração LLM) é fundamental — tudo depende dela
+- Phase 2 (Contexto) é necessária pela Phase 3 (Memória usa o pipeline de contexto)
+
+**Podem ser adiadas:**
+- Phase 4 (Streaming) — melhoria de UX legal mas não bloqueante
+- Phase 5 (React + File uploads) — depende do progresso do setup React
+
+### P: E se o setup React estiver pronto antes da Phase 5? Podemos antecipar?
+
+Sim. O React island de chat (Phase 5, Passos 5.3-5.4) pode ser movido para Phase 4 ou até Phase 3 se:
+
+1. Infraestrutura de React islands estiver funcionando
+2. A abstração `AgentChat.LLM` estiver estável (Phase 1 completa)
+3. O endpoint SSE puder ser construído rapidamente (é uma camada fina de tradução sobre PubSub)
+
+O backend não muda — apenas o path frontend é adicionado. Este é o benefício da arquitetura UI-agnostic.
+
+### P: 2 semanas por fase é realista?
+
+Cada fase é scoped para um conjunto específico e delimitado de mudanças:
+
+- **Phase 1**: 2 arquivos reescritos + 1 novo módulo + updates de testes. 2 semanas é confortável.
+- **Phase 2**: 1 migration + 1 novo módulo + mudanças de componente. 2 semanas é apertado mas factível.
+- **Phase 3**: 1 migration + 1 novo módulo + 1 Oban worker + página UI. 2 semanas é apertado. Pode estender para 3.
+- **Phase 4**: Streaming (novo path no worker + componente) + tracking de custo. 2 semanas é apertado. Pode estender para 3.
+- **Phase 5**: Múltiplas features independentes. Esperado levar 3-4 semanas.
+
+As estimativas são otimistas-mas-alcançáveis. Buffer deve ser adicionado para testes de integração e problemas inesperados.
+
+---
+
+## 13. Detalhes do Vercel AI SDK
+
+### P: Como o Vercel Data Stream Protocol realmente funciona?
+
+É um protocolo SSE (Server-Sent Events) onde cada evento é uma linha única com prefixo de tipo:
+
+```
+0:"Hello "          → chunk de texto "Hello "
+0:"world"           → chunk de texto "world"
+9:{"toolCallId":"1","toolName":"create_lesson","args":{"description":"..."}}
+a:{"toolCallId":"1","result":{"lesson_id":42}}
+e:{"finishReason":"stop","usage":{"promptTokens":150,"completionTokens":50}}
+d:{"finishReason":"stop"}
+```
+
+Códigos de tipo:
+- `0` = token de texto
+- `9` = tool call
+- `a` = resultado de tool
+- `e` = finish com metadata
+- `d` = sinal de done
+
+O controller Phoenix precisa produzir exatamente este formato. É um exercício de concatenação de strings — não complexo, apenas preciso.
+
+### P: useChat funciona com respostas não-streaming (batch)?
+
+Sim. `useChat` também suporta respostas não-streaming. Se o backend retorna a mensagem completa de uma vez (ao invés de streaming), `useChat` ainda lida corretamente — simplesmente aparece tudo de uma vez ao invés de token-by-token.
+
+Isso significa que podemos adotar o React island antes de implementar streaming. O endpoint SSE pode retornar uma única mensagem completa (como nosso fluxo batch atual), e `useChat` vai exibi-la.
+
+### P: O que acontece se a conexão SSE cair no meio do stream?
+
+`useChat` lida com reconexão automaticamente. Quando a conexão cai:
+
+1. A mensagem parcial atual é preservada no estado do componente
+2. O hook tenta reconectar (comportamento de retry configurável)
+3. Se a reconexão falhar, a mensagem é marcada como incompleta
+
+O backend lida com isso verificando se o job Oban já completou. Se o worker terminou e persistiu a mensagem, o client reconectado carrega a mensagem completa do banco (via chamada API ou bridge LiveView).
+
+---
+
+## 14. Detalhes do Langfuse
+
+### P: Como a integração OpenTelemetry funciona com Elixir especificamente?
+
+O ecossistema Elixir/BEAM tem forte suporte a OpenTelemetry via pacotes hex `opentelemetry`:
+
+```elixir
+# mix.exs
+{:opentelemetry, "~> 1.4"},
+{:opentelemetry_api, "~> 1.3"},
+{:opentelemetry_exporter, "~> 1.7"}
+```
+
+Configuração para exportar para Langfuse:
+
+```elixir
+# config/runtime.exs
+config :opentelemetry, :resource, service: %{name: "lanttern"}
+config :opentelemetry,
+  span_processor: :batch,
+  exporter: {:opentelemetry_exporter, %{
+    endpoints: ["https://seu-langfuse.com/api/public/otel"],
+    headers: [{"Authorization", "Bearer #{langfuse_api_key}"}]
+  }}
+```
+
+Então no código:
+
+```elixir
+require OpenTelemetry.Tracer, as: Tracer
+
+def run_completion(model, messages, tools, opts) do
+  Tracer.with_span "llm.completion" do
+    Tracer.set_attributes([
+      {"llm.model", model},
+      {"llm.provider", "openai"},
+      {"llm.messages_count", length(messages)}
+    ])
+
+    result = do_llm_call(model, messages, tools, opts)
+
+    case result do
+      {:ok, response} ->
+        Tracer.set_attributes([
+          {"llm.tokens.input", response.usage.input},
+          {"llm.tokens.output", response.usage.output}
+        ])
+      _ -> :ok
+    end
+
+    result
+  end
+end
+```
+
+O endpoint OTLP do Langfuse recebe esses spans e os exibe no visualizador de traces.
+
+### P: Podemos usar Langfuse para gestão de prompts ao invés de manter prompts no código?
+
+Sim, mas é uma consideração Phase 5+. A gestão de prompts do Langfuse permite:
+
+1. **Versionamento**: Manter múltiplas versões de um prompt, deployar versões específicas
+2. **Playground**: Testar prompts contra diferentes modelos diretamente na UI do Langfuse
+3. **Caching**: Caching server-side + client-side para evitar carregar prompts em cada chamada
+4. **Iteração não-developer**: Educadores ou product managers podem ajustar prompts sem mudanças de código
+
+O trade-off é que prompts saem de código versionado para um serviço externo. Isso adiciona uma dependência runtime (Langfuse precisa estar disponível para carregar prompts) e reduz visibilidade no nível de código.
+
+A recomendação é: manter prompts no código por enquanto (Phase 1-3). Avaliar gestão de prompts do Langfuse na Phase 5 quando a infraestrutura de observabilidade estiver madura e o time tiver experiência com a plataforma.
+
+### P: E as features de avaliação do Langfuse? Como usaríamos?
+
+A avaliação do Langfuse permite verificações automatizadas de qualidade nos outputs de AI. Exemplos práticos para o Lanttern:
+
+1. **LLM-as-judge**: Após um plano de aula ser gerado, uma chamada LLM separada o avalia contra rubricas (ex: "O plano inclui diferenciação?", "É apropriado para a faixa etária?"). O score é armazenado no Langfuse.
+
+2. **Feedback de usuário**: Quando um professor marca um plano de aula como "útil" ou "não útil", esse feedback é enviado ao Langfuse como score atrelado ao trace. Com o tempo, isso constrói um dataset para medir tendências de qualidade.
+
+3. **Testes de regressão**: Quando prompts mudam, executar o mesmo conjunto de conversas de teste pelo novo prompt e comparar scores contra o prompt antigo. Isso previne regressões de qualidade.
+
+Essas são features Phase 3+. Requerem que a infraestrutura de tracing esteja em funcionamento primeiro.
+
+---
+
+## 15. Ecossistema Jido
+
+### P: Você mencionou que Jido pode ser reconsiderado no futuro. Quando especificamente?
+
+Jido se torna relevante quando o Lanttern precisar de:
+
+1. **Múltiplos agentes independentes** que coordenam entre si (ex: um agente "planejador de aulas" que delega para um agente "pesquisador de currículo" e um agente "designer de avaliações")
+2. **State machines complexas** onde o comportamento do agente muda baseado em estado acumulado (além do que um banco de dados pode representar eficientemente)
+3. **Colaboração de agentes em tempo real** onde múltiplos agentes trabalham na mesma tarefa concorrentemente e precisam compartilhar resultados intermediários
+
+Atualmente, Lanttern tem um tipo de agente (planejador de aulas) com um lifecycle simples (receber mensagem → pensar → responder/agir). Oban lida com isso perfeitamente.
+
+Se o roadmap de 2026 evoluir para sistemas multi-agent, revisitar Jido nesse ponto. A abstração `AgentChat.LLM` torna isso possível — Jido substituiria a camada de worker, não a camada de client LLM.
+
+### P: E o `jido_action` para tools tipadas? Parece melhor que o que estamos propondo.
+
+`jido_action` fornece validação de schema em tempo de compilação para definições de tools e conversão automática para o formato de tool do LLM. É genuinamente melhor que specs de tool escritas à mão.
+
+Porém, Lanttern atualmente tem exatamente **2 tools** (create_lesson, update_lesson) com uma terceira planejada (set_conversation_title). O overhead de um framework para 3 tools não se justifica.
+
+Quando a contagem de tools crescer (10+), a validação em tempo de compilação e auto-conversão se tornam valiosas. Nesse ponto, `jido_action` pode ser adotado dentro de `AgentChat.Tools` sem mudar nada fora desse módulo.
+
+### P: Existe risco de o ecossistema Jido se tornar o padrão Elixir e nós ficarmos de fora?
+
+Jido é promissor mas novo (v2.0 lançada recentemente). O ecossistema de AI em Elixir não tem um "padrão" ainda — é cedo demais. Ao escolher ReqLLM (parte do ecossistema Jido) para o client LLM, já estamos nos beneficiando do melhor componente do ecossistema.
+
+Se Jido se tornar o padrão, adotá-lo depois é direto porque:
+1. ReqLLM (já adotado) é a fundação da camada LLM do Jido
+2. `AgentChat.LLM` abstrai a orquestração — substituí-la pela orquestração do Jido é uma mudança delimitada
+3. O schema de banco de dados, padrões PubSub e camada UI são Jido-agnostic
+
+Estamos fazendo uma aposta pragmática: adotar as partes comprovadas (ReqLLM) e adiar as partes não comprovadas (Jido agents) até estarem battle-tested e precisarmos delas.
+
+---
+
+## 16. Monolith vs Microservice
+
+### P: Vamos ser honestos — Python não tem ferramentas de AI muito melhores? Por que estamos nos limitando a Elixir?
+
+Sim, o ecossistema de AI do Python é objetivamente mais rico. Aqui está o que perdemos ficando em Elixir:
+
+| Categoria | O que Python tem | O que Elixir tem | Severidade do gap |
+|---|---|---|---|
+| **Orquestração de agents** | LangGraph (stateful, checkpointing, time-travel, 5 modos de streaming) | Custom tool_call_loop (~25 linhas) | **Grande** |
+| **Multi-agent** | CrewAI, AG2/AutoGen, Swarm | Nada production-ready | **Grande** |
+| **RAG/Documentos** | LlamaIndex (loaders, chunking, retrieval pipelines) | Implementação manual | **Grande** |
+| **Avaliação** | DeepEval, RAGAS, PromptFoo | Nada | **Grande** |
+| **Structured output** | Instructor (3M+ downloads), Pydantic AI | Validação Ecto (manual) | **Médio** |
+| **SDKs de provedores** | Oficial de OpenAI, Anthropic, Google | ReqLLM (community, bom mas não oficial) | **Pequeno-Médio** |
+| **Memória** | mem0, MemGPT/Letta | Implementação custom | **Médio** |
+| **Observabilidade** | SDKs nativos Langfuse/LangSmith | OpenTelemetry (funciona, não nativo) | **Pequeno-Médio** |
+
+Os gaps são reais. A questão é: **precisamos dessas capabilities hoje, e o custo de um microserviço vale o acesso?**
+
+Para as necessidades atuais do Lanttern (client LLM, tool calling, memória básica, streaming), Elixir + ReqLLM é suficiente. Os gaps que mais importam (orquestração LangGraph, avaliação DeepEval) são necessidades futuras, não bloqueantes.
+
+### P: Como seria a arquitetura de um sidecar Python na prática?
+
+Um serviço FastAPI co-deployed junto com Phoenix, compartilhando PostgreSQL e Redis:
+
+```
+Prompt do usuário → Phoenix LiveView → POST http://localhost:8000/chat
+                                              │
+                                              ▼
+                                        FastAPI (Python)
+                                        │ 1. GET contexto do Phoenix
+                                        │ 2. Rodar agente LangGraph
+                                        │ 3. Em tool call → POST para API interna do Phoenix
+                                        │ 4. Em chunk → publicar no Redis
+                                        │ 5. Ao completar → POST mensagem para Phoenix
+                                              │
+                                              ▼
+                                        Redis (bridge PubSub)
+                                              │
+                                              ▼
+                                        Phoenix PubSub → LiveView update
+```
+
+O sidecar cuida da orquestração LLM. Phoenix mantém toda lógica de domínio (Scope, Ecto, regras de negócio, execução de tools). Comunicação é HTTP localhost (~5-10ms de overhead).
+
+### P: Se contratarmos um engenheiro Python de AI, como ele trabalharia com o codebase Elixir?
+
+Ele não precisaria tocar em Elixir. O padrão sidecar cria uma fronteira limpa:
+
+- **Engenheiro Python cuida de**: Serviço FastAPI, agentes LangGraph, pipelines de avaliação, otimização de memória, RAG se necessário
+- **Time Elixir cuida de**: Phoenix, LiveView, lógica de negócio, Scope/auth, banco, endpoints de execução de tools
+- **Contrato compartilhado**: API HTTP interna entre os dois serviços (documentada, versionada)
+
+O engenheiro Python deploya seu serviço junto com Phoenix. Ele consome APIs internas que o time Elixir expõe. Sem necessidade de code reviews cross-language.
+
+### P: Como tool calls (create_lesson) funcionariam cruzando a fronteira de serviço?
+
+Quando o agente LangGraph decide chamar `create_lesson`, o fluxo é:
+
+1. LangGraph emite um tool call: `{"name": "create_lesson", "args": {"description": "...", "moment_id": 1}}`
+2. FastAPI recebe o tool call e encaminha para Phoenix: `POST http://localhost:4000/internal/tools/create_lesson`
+3. Phoenix recebe o request, valida o scope token, chama `Lessons.create_lesson/3` com autorização e audit logging adequados
+4. Phoenix retorna o resultado: `{"lesson_id": 42, "status": "ok"}`
+5. FastAPI alimenta o resultado de volta ao LangGraph, que continua a conversa
+
+O ponto crítico: **Phoenix continua dono da execução de tools**. O microserviço nunca toca lógica de negócio diretamente. Isso preserva autorização Scope, audit logging e integridade de dados.
+
+### P: Qual o impacto real de latência?
+
+| Arquitetura | Prompt até primeiro token | Round-trip de tool call | Total para troca típica |
+|---|---|---|---|
+| **Monolith Elixir** | Apenas latência da API LLM (~500ms) | 0ms (in-process) | ~2-5 segundos |
+| **Sidecar Python** | +5-10ms (hop localhost) | +10-20ms (dois hops localhost) | ~2-5,1 segundos |
+| **Microserviço completo** | +25-50ms (hop de rede) | +50-100ms (dois hops de rede) | ~2-5,3 segundos |
+
+Para uma interface de chat onde a própria API LLM leva 2-5 segundos por resposta, o overhead do sidecar (5-10ms) é imperceptível. O overhead do microserviço completo (25-50ms) é perceptível apenas durante streaming (entrega de tokens irregular).
+
+### P: TypeScript não seria mais natural já que vamos adicionar React?
+
+TypeScript tem vantagens para a camada frontend (Vercel AI SDK é nativo), mas para o backend de AI:
+
+- O ecossistema AI do TypeScript é um **subconjunto do Python**. LangChain.js e LangGraph.js existem mas têm comunidades menores. CrewAI, LlamaIndex, DeepEval, RAGAS, Instructor — todos exclusivos Python.
+- A força do TypeScript é frontend, não orquestração de AI.
+- Se estamos adicionando um serviço para orquestração AI, Python dá acesso a 10x mais ferramentas.
+
+Se contratarmos um engenheiro de AI, quase certamente saberá Python, não TypeScript. TypeScript é a escolha certa para a UI de chat (React + Vercel AI SDK). Python é a escolha certa para orquestração AI (se precisarmos de serviço separado).
+
+### P: Qual o custo operacional real de manter dois serviços?
+
+| Dimensão | Monolith | Sidecar | Microserviço completo |
+|---|---|---|---|
+| **Infra mensal** | ~$5K | ~$5,5-6,5K | ~$18-30K |
+| **Pipelines CI/CD** | 1 | 1 (co-deployed) | 2 (separados) |
+| **Complexidade on-call** | Baixa | Baixa (mesmo host) | Média (debug cross-service) |
+| **Testes integração** | Padrão | Precisam testes cross-service | Precisam contract tests + E2E |
+| **Gestão de config** | 1 set de env vars | 2 sets, secrets compartilhados | 2 sets, auth de rede, service discovery |
+
+O sidecar é o sweet spot: 90% dos benefícios do ecossistema Python com apenas 10% do custo operacional de microserviço. Mesmo deployment unit, mesmo host, banco compartilhado.
+
+### P: E se precisarmos de RAG para documentos curriculares (PDFs, livros)?
+
+Este é um dos argumentos mais fortes para um sidecar Python. LlamaIndex fornece:
+
+- **Document loaders**: PDF, DOCX, HTML, Google Docs — 100+ formatos
+- **Estratégias de chunking**: Semântico, baseado em sentenças, recursivo — otimizado para conteúdo educacional
+- **Modelos de embedding**: OpenAI, Cohere, modelos locais
+- **Vector stores**: pgvector, Pinecone, Qdrant — integrações first-class
+- **Pipelines de retrieval**: Busca híbrida, re-ranking, transformação de query
+
+Construir funcionalidade equivalente em Elixir exigiria escrever parsers de documentos customizados, algoritmos de chunking e integrações de busca vetorial — semanas de trabalho que LlamaIndex fornece pronto.
+
+Se RAG sobre documentos curriculares se tornar um requisito, isso sozinho justifica um sidecar Python.
+
+### P: LangGraph é realmente muito melhor que nosso tool_call_loop customizado?
+
+Para o que Lanttern faz hoje (request simples → tool call → resposta), nosso loop de 25 linhas é ok. Mas LangGraph fornece capabilities que não conseguimos replicar facilmente:
+
+| Feature | Nosso tool_call_loop | LangGraph |
+|---|---|---|
+| Tool calling básico | Sim | Sim |
+| Tool calls multi-turn | Sim (com max_iterations) | Sim (built-in) |
+| **Checkpointing** | Não | Sim — salvar/retomar estado do agente em qualquer ponto |
+| **Time-travel debugging** | Não | Sim — reproduzir conversas de qualquer checkpoint |
+| **Human-in-the-loop** | Não | Sim — pausar agente, perguntar ao humano, retomar |
+| **Tool calls paralelos** | Não | Sim — chamar múltiplas tools simultaneamente |
+| **Modos de streaming** | 1 (token) | 5 (tokens, events, updates, messages, custom) |
+| **Branching** | Não | Sim — explorar caminhos alternativos de conversa |
+| **Execução durável** | Retries Oban (grosseiro) | Recuperação de estado granular mid-conversa |
+
+Para um agente de tutoria que precisa pausar para input do professor, retomar de um estado salvo, ou explorar diferentes estratégias de explicação — LangGraph está muito à frente. Para um chatbot de planejamento de aulas, nosso loop é suficiente.
+
+### P: O que os dados da indústria dizem sobre microserviços para AI?
+
+Pontos-chave:
+
+- **42% de reversão**: Uma pesquisa CNCF de 2025 encontrou que 42% das organizações que adotaram microserviços consolidaram serviços de volta em unidades maiores. Splitting prematuro é o erro mais comum.
+- **Amazon Prime Video**: Migrou análise de qualidade de vídeo de microserviços para monolith de processo único, alcançando **90% de redução de custos de infraestrutura**.
+- **Vercel, Notion, Stripe**: Usam AI gateways (camadas de tradução) ao invés de microserviços completos. Mantêm orquestração AI próxima da aplicação principal.
+- **Tendência modular monolith**: A indústria está convergindo em monolitos modulares com fronteiras internas limpas que PODEM ser extraídas depois — exatamente o que nossa abstração `AgentChat.LLM` fornece.
+
+O padrão que funciona: **começar monolith, extrair apenas quando houver necessidade comprovada** (escala, independência de time, ou acesso a ecossistema). Não extrair prematuramente.
+
+### P: Qual o caminho de migração de monolith para sidecar?
+
+O módulo `AgentChat.LLM` é o ponto de extração. Hoje ele wrappa ReqLLM. Amanhã pode wrappar uma chamada HTTP para um serviço Python:
+
+```elixir
+# Hoje (Phase 1): chamada direta ReqLLM
+defp do_llm_call(model, messages, tools, opts) do
+  ReqLLM.generate_text(model, context, tools: tools)
+end
+
+# Futuro (quando sidecar adotado): chamada HTTP para FastAPI
+defp do_llm_call(model, messages, tools, opts) do
+  Req.post!("http://localhost:8000/chat", json: %{
+    model: model,
+    messages: messages,
+    tools: tools,
+    scope_token: opts[:scope_token]
+  })
+  |> parse_response()
+end
+```
+
+Nada fora de `AgentChat.LLM` muda. O módulo de contexto, workers, PubSub, UI — tudo inalterado. A extração é uma mudança de corpo de função em um módulo.
+
+### P: Deveríamos começar com sidecar agora ao invés de ReqLLM, para evitar migração depois?
+
+Não. Razões:
+
+1. **Você não sabe o que precisa até construir.** Usar ReqLLM diretamente nos ensina o que a abstração LLM precisa. Extração prematura significa construir um contrato de API antes de entender os requisitos.
+2. **O custo de migração é minúsculo.** Mudar um corpo de função em `AgentChat.LLM` é uma tarefa de 30 minutos. Compare com semanas de setup de sidecar antecipado.
+3. **O sidecar adiciona complexidade operacional desde o dia 1.** Dois codebases, dois test suites, uma camada de bridge — tudo antes de saber se precisamos.
+
+Construir o monolith. Aprender o que o agente realmente precisa. Extrair quando uma capability específica (LangGraph, DeepEval, RAG) exigir.
+
+### P: DeepEval / RAGAS podem ser usados sem microserviço?
+
+Parcialmente. Duas opções:
+
+1. **Avaliação offline** (sem microserviço): Rodar DeepEval/RAGAS como script Python que lê dados de conversa do banco, avalia, e escreve resultados de volta. É um processo batch, não uma dependência runtime. Pode usar CI/CD ou cron job.
+
+2. **Avaliação runtime** (precisa sidecar): Se quiser avaliação em tempo real (pontuar cada resposta AI antes de mostrar ao usuário), o framework de avaliação precisa estar no path do request — o que significa um sidecar Python.
+
+Para o estágio atual do Lanttern, **avaliação offline é suficiente**. Rodar um batch semanal que avalia conversas recentes por qualidade, segurança e relevância. Isso requer apenas um script Python, não um sidecar completo.
+
+---
+
+## 17. CopilotKit vs Vercel AI SDK vs assistant-ui
+
+### P: O que é o AG-UI Protocol e por que importa?
+
+AG-UI (Agent-User Interaction Protocol) é um padrão aberto para comunicação agent↔frontend, adotado por Google, AWS, LangChain, Microsoft, Mastra e PydanticAI. Define tipos de evento SSE ricos (streaming de texto, tool calls, state snapshots, state deltas, eventos de lifecycle, aprovação humana) projetados especificamente para AI agents.
+
+Importa porque o Vercel Data Stream Protocol só suporta chunks de texto e tool calls básicos. AG-UI suporta tudo que LangGraph pode emitir — state updates, workflows multi-step, aprovações human-in-the-loop. Ao usar LangGraph como backend, AG-UI é um encaixe nativo enquanto o protocolo Vercel requer uma conversão com perda.
+
+### P: Por que CopilotKit seria melhor que Vercel AI SDK para o Lanttern?
+
+Três features específicas do Lanttern que CopilotKit lida nativamente e Vercel AI SDK não:
+
+1. **Aprovação do professor antes de criar aula**: O human-in-the-loop do CopilotKit pausa o agente, mostra UI de aprovação, e retoma na ação do professor. Com Vercel AI SDK, você construiria isso do zero.
+
+2. **Indicadores de status do agente** ("Carregando contexto...", "Criando aula...", "Aguardando aprovação..."): Eventos STATE_DELTA do CopilotKit atualizam a UI em tempo real. Vercel AI SDK não tem equivalente.
+
+3. **Rendering de lesson card**: Ambos suportam renderers customizados, mas o sistema de generative UI do CopilotKit é mais natural — o agente decide dinamicamente qual componente renderizar.
+
+### P: Quando Vercel AI SDK ainda seria a escolha certa?
+
+Se o Lanttern ficar no monolith Elixir (sem sidecar Python), Vercel AI SDK é mais simples:
+- Sem backend LangGraph, os eventos ricos do AG-UI são irrelevantes
+- O hook `useChat` é mais leve e fácil de configurar
+- A comunidade é 4x maior
+- Para chat básico com tool calls, Vercel AI SDK é suficiente
+
+A regra: **Use CopilotKit se tiver LangGraph. Use Vercel AI SDK se não tiver.**
+
+### P: E o assistant-ui? Quando é melhor que ambos?
+
+assistant-ui é a escolha quando **customização visual importa mais que features de agent**. É headless — sem estilos default, total controle visual.
+
+Para o Lanttern: se o time quer que o chat combine com o design existente (tema amber AI, classes `ltrn-ai-*`, componentes customizados), assistant-ui dá mais controle. Componentes do CopilotKit precisariam ser estilizados para combinar.
+
+Porém, assistant-ui não tem state sync nem human-in-the-loop. Trade-off: **máximo controle visual** (assistant-ui) vs **máximo UX de agent** (CopilotKit).
+
+### P: Podemos trocar entre eles depois? Quão preso ficamos?
+
+Trocar é esforço moderado (~1-2 semanas cada direção). A arquitetura backend (`AgentChat.LLM`, `AgentChat.Tools`, Oban, PubSub) não muda em nenhum cenário. A escolha de frontend é uma decisão de camada UI, não de arquitetura.
+
+### P: CopilotKit funciona com backend Elixir/Phoenix?
+
+Sim, mas indiretamente. Phoenix precisaria de um controller que produz eventos SSE no formato AG-UI. Se o backend Elixir não produz state snapshots ou human-in-the-loop (porque não é LangGraph), CopilotKit funciona mas a maioria das features avançadas fica sem uso. **CopilotKit + Elixir não é recomendado** — você usaria 30% do framework.
+
+### P: Como funciona o fluxo LangGraph → AG-UI → CopilotKit na prática?
+
+1. Usuário digita no `<CopilotChat>`
+2. CopilotKit envia via AG-UI (SSE POST) para FastAPI
+3. FastAPI cria invocação LangGraph
+4. LangGraph roda o grafo:
+   - `RUN_STARTED` → indicador "pensando..."
+   - `TEXT_MESSAGE_CONTENT` → streaming token por token
+   - `TOOL_CALL_START` → UI de tool call com spinner
+   - FastAPI chama Phoenix para executar tool
+   - `TOOL_CALL_END` → renderiza lesson card
+   - `STATE_DELTA` → atualiza status
+   - `RUN_FINISHED` → estado final
+5. Zero camadas de conversão — AG-UI mapeia 1:1 com eventos LangGraph
+
+### P: AG-UI Protocol é maduro o suficiente para produção?
+
+Introduzido em 2025, adotado por Google, AWS, Microsoft, LangChain. Spec pública em docs.ag-ui.com.
+
+**Riscos:** Mais novo que Vercel Data Stream Protocol. CopilotKit é o implementador principal. Spec pode evoluir.
+
+**Mitigações:** Adoção corporativa major sugere estabilidade. Padrão aberto permite implementações alternativas. CopilotKit é open source.
+
+Para o timeline do Lanttern (Phase 4-5, vários meses à frente), AG-UI estará mais maduro quando precisarmos.

--- a/exploration/ai-oriented-features/ai-agent-feature-qa.md
+++ b/exploration/ai-oriented-features/ai-agent-feature-qa.md
@@ -1,0 +1,1114 @@
+# AI Agent Architecture — Questions & Answers
+
+> Companion document to `ai-agent-feature-plan.md`
+>
+> Anticipated questions from the development team about the architectural decisions, trade-offs, and implementation details.
+
+---
+
+## Table of Contents
+
+1. [LLM Client Layer (LangChain → ReqLLM)](#1-llm-client-layer)
+2. [Agent Orchestration (Oban)](#2-agent-orchestration)
+3. [Chat UI & Frontend (LiveView → React)](#3-chat-ui--frontend)
+4. [Streaming](#4-streaming)
+5. [User Memory](#5-user-memory)
+6. [Universal Conversation Context](#6-universal-conversation-context)
+7. [Observability (Langfuse)](#7-observability)
+8. [Migration & Rollback](#8-migration--rollback)
+9. [Testing](#9-testing)
+10. [Performance & Cost](#10-performance--cost)
+11. [Security & Data Ownership](#11-security--data-ownership)
+12. [Timeline & Prioritization](#12-timeline--prioritization)
+13. [Vercel AI SDK Specifics](#13-vercel-ai-sdk-specifics)
+14. [Langfuse Specifics](#14-langfuse-specifics)
+15. [Jido Ecosystem](#15-jido-ecosystem)
+16. [Monolith vs Microservice](#16-monolith-vs-microservice)
+17. [CopilotKit vs Vercel AI SDK vs assistant-ui](#17-copilotkit-vs-vercel-ai-sdk-vs-assistant-ui)
+
+---
+
+## 1. LLM Client Layer
+
+### Q: Why remove LangChain instead of removing ReqLLM? LangChain has more features.
+
+LangChain has more features, but most of them are not used by Lanttern. The only LangChain features we actually use are:
+
+1. `LLMChain` with `while_needs_response` — a tool-call loop (~25 lines of custom code to replace)
+2. `ChatOpenAI` — model instantiation (one line with ReqLLM)
+3. `Function`/`FunctionParam` — tool definitions (simpler in ReqLLM with `ReqLLM.Tool`)
+4. `Message` constructors — message building (direct equivalent in `ReqLLM.Context`)
+
+We're paying for an entire framework but using ~5% of it. ReqLLM is leaner, already in the project, already tested, natively supports 10+ providers, and follows Elixir conventions more closely. The cost of keeping LangChain (cognitive overhead of two libraries, two test patterns, two configs) outweighs the cost of rewriting 25 lines of orchestration code.
+
+### Q: What exactly is the "tool call loop" we need to build ourselves? Isn't that complex?
+
+The tool call loop replaces LangChain's `mode: :while_needs_response`. Here's what it does:
+
+1. Send messages + tool definitions to the LLM
+2. If the LLM response contains a tool call → execute the tool → append the result to messages → go back to step 1
+3. If the LLM response is plain text → return it
+
+In pseudocode:
+
+```elixir
+def tool_call_loop(model, messages, tools, opts, max_iterations \\ 10) do
+  case call_llm(model, messages, tools, opts) do
+    {:ok, %{tool_calls: []}} = result ->
+      result
+
+    {:ok, %{tool_calls: tool_calls} = response} when max_iterations > 0 ->
+      results = Enum.map(tool_calls, &execute_tool/1)
+      updated_messages = messages ++ [assistant_msg(response)] ++ tool_result_msgs(results)
+      tool_call_loop(model, updated_messages, tools, opts, max_iterations - 1)
+
+    {:ok, _} ->
+      {:error, :max_iterations_exceeded}
+
+    error ->
+      error
+  end
+end
+```
+
+It's roughly 25-30 lines. The `max_iterations` guard prevents infinite loops. The 5-minute timeout from LangChain is replaced by a timeout on the `call_llm` function itself.
+
+### Q: What if ReqLLM doesn't support tool calling the way we need?
+
+ReqLLM v1.6+ supports tool calling via `ReqLLM.Tool`. The API is:
+
+```elixir
+tools = [
+  ReqLLM.Tool.function("create_lesson", "Creates a lesson plan", %{
+    type: "object",
+    properties: %{
+      description: %{type: "string", description: "Lesson description"},
+      moment_id: %{type: "integer", description: "The moment ID"}
+    },
+    required: ["description", "moment_id"]
+  })
+]
+
+{:ok, response} = ReqLLM.generate_text(model, context, tools: tools)
+```
+
+If ReqLLM's tool calling doesn't handle a specific edge case, ReqLLM is built on Req (a composable HTTP client). We can always drop to the raw HTTP layer and send the tool call parameters directly to the provider's API. This is a safety net, not an expected path.
+
+**Verification step**: Phase 1 Step 1.3 explicitly includes verifying ReqLLM's tool calling API before committing to the migration. If it doesn't work, we build a thin wrapper around Req that handles the OpenAI tool calling protocol directly.
+
+### Q: ReqLLM supports 10+ providers, but do we actually need that? We only use OpenAI.
+
+Today, yes. But the plan explicitly identifies **single provider lock-in** as a current gap. Schools may want to use different models (Anthropic for creative tasks, Google for multilingual, local models for data-sensitive schools). The abstraction layer (`AgentChat.LLM`) combined with ReqLLM's multi-provider support means switching providers is a configuration change, not a code change.
+
+Even if we stay on OpenAI for the next 6 months, the cost of multi-provider support is zero — ReqLLM already provides it. It's not something we're building; it's something we get for free.
+
+### Q: Won't removing LangChain break the existing tests?
+
+Yes, existing tests that mock LangChain (via `Mimic.copy(LangChain.Chains.LLMChain)`) will need to be rewritten. This is Phase 1 Step 1.7. The new tests will use the same `ReqLLMStub` pattern already established for the ILP feature — dependency injection of the LLM module, not library-specific mocks.
+
+The test rewrite is actually an improvement: dependency injection is more reliable and simpler than Mimic-based mocking. The test surface is contained to `agent_chat_test.exs` and `chat_response_worker_test.exs`.
+
+### Q: What about the LangChain Elixir ecosystem evolving? What if it gets much better?
+
+LangChain for Elixir (v0.4.0) is a community port of the Python/JS LangChain ecosystem. Its update cadence is unclear and it doesn't follow Elixir idioms closely. Even if it improves, our architecture isolates the LLM client inside `AgentChat.LLM` — if a better library emerges (LangChain, Jido, or something new), we change one module, not the entire app.
+
+The architectural decision is not "ReqLLM forever" — it's "one library now, behind an abstraction that makes switching cheap."
+
+---
+
+## 2. Agent Orchestration
+
+### Q: Why not use Jido agents instead of Oban? Jido is designed specifically for AI agents.
+
+Jido v2.0 introduces GenServer-based agents with state management, directives, and runtime execution. These are powerful features — for the right problem. Our current problem doesn't need them.
+
+Lanttern's agent chat is stateless between requests: the user sends a message, the system processes it, stores the result, and broadcasts it. All state lives in PostgreSQL. There's no need for in-memory agent state, multi-agent coordination, or complex state machines.
+
+Jido would add:
+- New supervision tree to manage
+- New deployment considerations (agent process lifecycle)
+- New testing patterns (GenServer testing vs Oban job testing)
+- New concepts for the team to learn (directives, signals, command function)
+
+For zero benefit over what Oban already provides (retries, unique constraints, pruning, dashboard, test isolation).
+
+**When Jido makes sense**: If we ever need agents that coordinate with each other, hold long-running state, or execute complex multi-step workflows where the state machine is not trivially representable in a database. That day may come — but it's not today.
+
+### Q: If we add streaming with Task.Supervisor (Phase 4), won't we have two execution paths? Isn't that messy?
+
+Yes, there will be two paths. But they serve different purposes:
+
+1. **Oban path** (non-streaming): Reliable, retryable, job-based. Used for the main LLM call. Survives server restarts. Has unique constraints. Records in Oban dashboard.
+2. **Task path** (streaming): Fire-and-forget within a request lifecycle. Streams chunks via PubSub. Does not survive restarts (but streaming is inherently tied to an active connection).
+
+The worker decides which path to use:
+
+```elixir
+def perform(%Oban.Job{args: %{"streaming" => true} = args}) do
+  # Spawn a supervised Task that streams chunks via PubSub
+  Task.Supervisor.start_child(Lanttern.TaskSupervisor, fn ->
+    stream_response(args)
+  end)
+end
+
+def perform(%Oban.Job{args: args}) do
+  # Regular batch processing (current behavior)
+  batch_response(args)
+end
+```
+
+This is not two competing architectures — it's one orchestrator (Oban) with two execution strategies. The complexity is contained in the worker module.
+
+### Q: What happens if the Oban job fails during a tool call?
+
+The current behavior is preserved: Oban retries the job (up to `max_attempts: 3`). The tool call is idempotent by design — if `create_lesson` is called twice with the same parameters, the second call either creates a duplicate (which the user can delete) or fails if there's a uniqueness constraint.
+
+For non-idempotent operations, the tool call result should be stored in the database before broadcasting. On retry, the worker checks if the tool call was already executed (by checking message metadata) and skips re-execution.
+
+---
+
+## 3. Chat UI & Frontend
+
+### Q: The React setup is already in progress. Why not wait and go directly to React + Vercel AI SDK?
+
+Three reasons:
+
+1. **Timeline risk**: The React setup timeline is uncertain. Blocking AI backend architecture on frontend infrastructure would delay the entire project.
+2. **Backend-first architecture**: The backend (LLM abstraction, context resolution, memory, tools) is the same regardless of frontend technology. Building it now with LiveView means it's ready for React when React is ready.
+3. **LiveView is sufficient for v0**: The chat needs to display messages, show loading states, render tool call results as inline components, and (later) stream tokens. LiveView handles all of this natively. The value of Vercel AI SDK is in convenience (auto-scroll, abort, reconnect) — nice to have, not blocking.
+
+The transition plan is explicit: **Phase 1-3 = LiveView; Phase 4-5 = React island added alongside LiveView**. Both paths coexist. No rip-and-replace.
+
+### Q: If we go with LiveView now, won't we have to rewrite the entire chat UI when we move to React?
+
+No. The rewrite is only the **template layer** (HTML/HEEx → JSX). The backend contract doesn't change:
+
+- `AgentChat` context functions: same API regardless of consumer
+- PubSub events: same events whether consumed by LiveView or forwarded to SSE
+- Message schema: same `metadata` JSONB regardless of how it's rendered
+- Tool definitions: same `AgentChat.Tools` module
+
+What changes when adding React:
+1. A new Phoenix controller (`AiStreamController`) that converts PubSub events to SSE
+2. A React component that uses `useChat` to consume the SSE stream
+3. A LiveView hook that mounts the React island
+
+What does NOT change: `AgentChat`, `AgentChat.LLM`, `AgentChat.Tools`, `AgentChat.Memory`, `AgentChat.ContextResolver`, `ChatResponseWorker`, `MemorySummaryWorker`, all Ecto schemas, all migrations.
+
+### Q: Why Vercel AI SDK over CopilotKit? CopilotKit seems more feature-complete.
+
+CopilotKit is a **full platform** — it includes a backend SDK, its own agent orchestration (AG-UI Protocol), and a cloud offering. Adopting CopilotKit means:
+
+1. **Backend conflict**: CopilotKit expects you to use its backend SDK for agent communication. Lanttern's agent logic lives in Elixir (Oban workers, ReqLLM, Phoenix PubSub). CopilotKit's Node.js backend SDK doesn't integrate with this.
+2. **Vendor lock-in**: CopilotKit has a freemium model with paid enterprise tiers. The AI SDK is fully open source.
+3. **Over-engineering**: We don't need a platform. We need a streaming chat hook. Vercel AI SDK is exactly that — `useChat()` and nothing more.
+
+CopilotKit makes sense for teams building a new app with AI at the core and no existing backend. Lanttern has a mature Elixir backend. Adding CopilotKit's backend on top would create a parallel system that fights with Oban/PubSub.
+
+### Q: What about assistant-ui? It seems more customizable than Vercel AI SDK.
+
+assistant-ui is a headless React component library specifically for AI chat UIs. It's a good library with fine-grained control over every UI element. The trade-offs vs Vercel AI SDK:
+
+| Aspect | Vercel AI SDK | assistant-ui |
+|---|---|---|
+| **Community** | ~60k GitHub stars, massive adoption | ~5k stars, growing |
+| **Documentation** | Extensive, covers non-Next.js backends | Good, but less coverage for custom backends |
+| **Backend protocol** | Well-defined Data Stream Protocol | Custom adapters (more flexible, more work) |
+| **Streaming** | Built-in via useChat | Requires adapter configuration |
+| **Risk** | Very low (Vercel backing, industry standard) | Low-medium (smaller community) |
+
+Both are viable. The recommendation is Vercel AI SDK because its Data Stream Protocol is well-documented for custom backends (which is our case — Phoenix, not Next.js), and the community size provides confidence in long-term maintenance.
+
+If the team evaluates both during Phase 5 and prefers assistant-ui's flexibility, the backend doesn't change. The SSE endpoint serves the same protocol either way.
+
+### Q: Could we use LiveView for everything including streaming and skip React entirely?
+
+Yes, technically. LiveView can stream tokens via PubSub, render rich components, and handle all chat interactions. The question is whether the team wants to invest in building:
+
+- Auto-scroll logic (scroll to bottom as tokens arrive, but not if user scrolled up)
+- Abort handling (cancel an in-progress LLM call)
+- Reconnection logic (what happens when the WebSocket drops mid-stream?)
+- Optimistic message display (show user message immediately before server confirmation)
+- Keyboard shortcuts (submit on Enter, newline on Shift+Enter with proper cursor handling)
+
+These are all solved problems in Vercel AI SDK. Building them in LiveView is possible but time-consuming. The recommendation is: **LiveView for now, React for when the UX investment justifies it.**
+
+---
+
+## 4. Streaming
+
+### Q: Won't PubSub streaming add latency compared to direct SSE?
+
+PubSub broadcast within the same Erlang node is sub-millisecond. The path is:
+
+```
+ReqLLM chunk → Worker process → PubSub.broadcast → Parent LiveView → send_update → Component re-render
+```
+
+Total additional latency vs direct SSE: ~1-5ms. Imperceptible to the user. The bottleneck is always the LLM API response time (typically 50-500ms per chunk), not the internal broadcast.
+
+If Lanttern scales to multiple nodes, PubSub works across nodes via `Phoenix.PubSub` with a distributed adapter (e.g., `Phoenix.PubSub.PG2`, already configured). No code changes needed.
+
+### Q: How do we handle tool calls during streaming? The LLM pauses, calls a tool, and resumes.
+
+During streaming, the flow is:
+
+1. LLM streams text tokens → broadcast as `:chunk` events
+2. LLM emits a tool call → broadcast as `:tool_call_start`
+3. Worker pauses the stream, executes the tool
+4. Broadcast `:tool_call_result` with the result
+5. Feed the result back to the LLM → streaming resumes from step 1
+
+The ConversationComponent handles this by showing:
+- Streaming text as it arrives (`:chunk`)
+- A "calling tool..." indicator when `:tool_call_start` is received
+- The tool result (e.g., a lesson card) when `:tool_call_result` is received
+- Continued streaming text after the tool call completes
+
+This is a sequential process — the worker manages the stream lifecycle. The component just reacts to events.
+
+### Q: What if the user navigates away during streaming? Are tokens lost?
+
+When the user navigates away, the LiveView process terminates and unsubscribes from PubSub. The worker (Oban job or Task) continues to completion regardless — it doesn't know or care about the subscriber.
+
+The complete message is persisted to the database when the stream finishes (`:message_complete` event). When the user returns to the conversation, all messages (including the one that was streaming) are loaded from the database. No data is lost.
+
+Partial messages (the streaming buffer) are lost from the UI but not from the conversation. The database is the source of truth, not the LiveView state.
+
+---
+
+## 5. User Memory
+
+### Q: How do we prevent the memory system from injecting stale or wrong information?
+
+Three safeguards:
+
+1. **Relevance scoring**: Memories have a `relevance_score` (0.0-1.0). The summarization prompt instructs the LLM to assign lower scores to time-sensitive information. Only the top N memories (by score) are injected.
+
+2. **Expiration**: Time-bounded memories have an `expires_at` field. A cron job prunes expired entries. Example: "The user is working on a fractions unit" expires after 30 days.
+
+3. **Manual control**: Staff can view and delete their own memories via a settings page. If the agent says something wrong based on a memory, the user can fix it directly.
+
+Additionally, memories are injected as context, not as facts. The system prompt wrapper makes this clear:
+
+```xml
+<user_memory>
+  <note>The following is a summary of previous interactions. It may be outdated.
+  Use as context, not as ground truth. If the user contradicts a memory,
+  trust the user.</note>
+  <preferences>User prefers detailed lesson plans with differentiation notes</preferences>
+</user_memory>
+```
+
+### Q: Won't the summarization LLM call add cost for every conversation?
+
+Yes, but it's a single, small LLM call per conversation close — not per message. The input is the conversation transcript (typically 5-20 messages), and the output is 2-3 compact summary sentences. Cost estimate:
+
+- Input: ~2,000 tokens (conversation transcript)
+- Output: ~200 tokens (summary)
+- Model: Can use a cheaper/smaller model (e.g., GPT-4o-mini)
+- Cost per summarization: ~$0.001
+
+For a school with 50 active teachers, each having 5 conversations per week: 250 summarizations × $0.001 = **$0.25/week**. Negligible.
+
+### Q: What's the difference between user memory and conversation context?
+
+| Aspect | User Memory | Conversation Context |
+|---|---|---|
+| **Scope** | Cross-conversation, per-user | Single conversation, per-entity |
+| **Persistence** | Survives after conversation ends | Tied to conversation lifecycle |
+| **Content** | Summaries of past interactions, preferences | Curriculum data (strand, lesson, ILP details) |
+| **Source** | AI-generated from conversations | Loaded from database entities |
+| **Layer** | Layer 0 (before school config) | Layer 5 (curriculum context) |
+| **Example** | "User prefers hands-on activities" | "Strand: Introduction to Fractions, Year 4" |
+
+Memory tells the agent **who** the user is. Context tells the agent **what** the conversation is about.
+
+### Q: Can memories be shared between schools if a teacher works at multiple schools?
+
+No. Memories are scoped to `(profile_id, school_id)`. A teacher at School A and School B has separate memory sets. This is intentional:
+
+1. **Data isolation**: Schools own their data. A memory generated from School A's curriculum should not leak to School B.
+2. **Relevance**: Teaching context varies by school. "Prefers Portuguese-language lesson plans" might be relevant at one school but not another.
+3. **Scope pattern**: This follows Lanttern's existing `Scope` authorization pattern — all school-scoped data is isolated by `school_id`.
+
+---
+
+## 6. Universal Conversation Context
+
+### Q: Why a polymorphic table instead of a separate join table per context type?
+
+A separate join table per type (like the current `strand_agent_conversations`) requires:
+- A new migration for each new context type
+- A new Ecto schema for each join table
+- New query functions in the context module
+- Conditional logic to check multiple tables when loading conversation contexts
+
+The polymorphic table requires:
+- One migration (done once)
+- One Ecto schema
+- One query to load all contexts for a conversation
+- One new function clause per context type (in `ContextResolver`)
+
+The polymorphic approach scales with the number of entity types without schema changes. Adding "assessment" or "student" context is a code change, not a database change.
+
+**Trade-off**: We lose database-level foreign key integrity on `context_id`. This is acceptable because:
+1. Context links are created programmatically (not via user input), so invalid references are programmer errors, not user errors
+2. The `ContextResolver` validates the entity exists when resolving — a dangling reference produces a soft error (context not loaded), not a crash
+3. This pattern is well-established in Elixir/Ecto (e.g., polymorphic embeds, Activity streams)
+
+### Q: What happens to the old `strand_agent_conversations` table?
+
+Per CLAUDE.md rule 7 (default is tech debt, not refactoring):
+
+1. The data is **migrated** to `conversation_contexts` (one row per strand, optionally one per lesson)
+2. The old table is **left as-is** — not dropped, not modified
+3. New code uses `conversation_contexts` exclusively
+4. Old code that reads `strand_agent_conversations` continues to work (until it's eventually cleaned up)
+
+There is no breaking change. The old table becomes unused tech debt, cleaned up in a future sprint.
+
+### Q: How does `context_metadata` JSONB work? When is it useful?
+
+`context_metadata` stores a **snapshot** of the entity's relevant data at the time the conversation was created. Two use cases:
+
+1. **Audit**: After the conversation, we can see exactly what the agent knew. If a strand's curriculum items change, the metadata shows the version the agent saw.
+
+2. **Entity deletion**: If a lesson is deleted after a conversation about it, the metadata preserves the lesson's name and details for historical context.
+
+The metadata is optional. For most cases, the `ContextResolver` loads the entity live from the database. The metadata is a safety net, not a primary data source.
+
+### Q: Can a single conversation have contexts from different schools?
+
+No. Conversations are scoped to `school_id` (via `agent_conversations.school_id`). All context entities must belong to the same school. The `ContextResolver` enforces this:
+
+```elixir
+def register_context(%Scope{school_id: school_id}, conversation, context_type, context_id) do
+  # Verify the entity belongs to the same school as the conversation
+  entity = load_entity(context_type, context_id)
+  true = entity.school_id == school_id
+  # ... create conversation_context
+end
+```
+
+This follows the `Scope` pattern — school isolation is enforced at every boundary.
+
+---
+
+## 7. Observability
+
+### Q: Why not start with Langfuse from day one? Why the phased approach?
+
+Three reasons:
+
+1. **Premature optimization**: In Phase 1-2, we're consolidating libraries and building abstractions. The LLM call volume is low (POC with limited users). The existing `llm_calls` table + `:telemetry` events are sufficient. Adding Langfuse infrastructure before we need it is overhead.
+
+2. **Integration clarity**: By Phase 3, the `AgentChat.LLM` module is stable, and we know exactly what to instrument. Integrating Langfuse with a module that's still being refactored (Phase 1) would mean updating the integration as the code changes.
+
+3. **Cost validation**: Starting with Langfuse Cloud (free tier) lets us validate the value before committing to self-hosted infrastructure. If the team doesn't look at the dashboards, we know not to invest in self-hosting.
+
+### Q: Can we skip Langfuse Cloud and go directly to self-hosted?
+
+Yes, but it's not recommended. Self-hosted Langfuse requires:
+
+- Kubernetes cluster (or Docker Compose, but not HA)
+- ClickHouse instance (the biggest operational burden)
+- PostgreSQL instance (can reuse existing)
+- Redis instance
+- S3-compatible storage
+- DevOps time for setup, maintenance, upgrades
+
+The Cloud tier starts at **$0/month** (50k traces). For a team validating the tooling, the free tier eliminates all infrastructure overhead. Graduate to self-hosted when:
+
+- Trace volume exceeds 5M/month (Cloud Pro at $199/mo starts to be expensive)
+- Data residency requirements mandate on-premises
+- The team is confident Langfuse is the right tool (validated on Cloud)
+
+### Q: What about using OpenAI's built-in dashboard for observability?
+
+OpenAI's dashboard shows API usage and costs, which is useful but limited:
+
+1. **No tracing**: You can't see the full conversation lifecycle (prompt building → LLM call → tool execution → response)
+2. **No evaluation**: No LLM-as-judge, no manual labeling, no regression testing
+3. **No prompt management**: Prompts live in your code, not in OpenAI's platform
+4. **Vendor lock-in**: If you switch to Anthropic or Google, you lose all observability
+5. **No school-scoped views**: OpenAI shows aggregate usage, not per-school breakdowns
+
+OpenAI's dashboard is a complement, not a replacement, for proper LLM observability.
+
+---
+
+## 8. Migration & Rollback
+
+### Q: What's the rollback plan if the ReqLLM migration breaks something in production?
+
+The migration is behind clean module boundaries. Rollback options:
+
+1. **Git revert**: The changes are in 2 files (`agent_chat.ex`, `chat_response_worker.ex`) + 1 new module (`agent_chat/llm.ex`). Reverting to the LangChain version is a `git revert` of the migration commit.
+
+2. **Feature flag**: We can introduce a temporary feature flag that switches between the old LangChain path and the new ReqLLM path. This is overkill for a 2-file change but available if the team wants it.
+
+3. **LangChain stays in mix.exs until Phase 1 is verified**: We can keep `{:langchain, "0.4.0"}` in deps until we've verified the ReqLLM path in staging. Remove it only after confidence.
+
+The key point: the database schema doesn't change in Phase 1. All messages, conversations, and model calls are stored in the same format. The migration is purely at the code layer — fully reversible.
+
+### Q: How do we migrate the `strand_agent_conversations` data without downtime?
+
+The migration is additive:
+
+1. Deploy the `conversation_contexts` table (new table, no impact on existing)
+2. Run a data migration that copies rows from `strand_agent_conversations` to `conversation_contexts`
+3. Deploy code that reads from `conversation_contexts`
+4. Old code that reads `strand_agent_conversations` continues to work (the data is still there)
+
+There is no downtime because:
+- Step 1 is a new table (zero impact)
+- Step 2 is a background migration (can run during low-traffic hours)
+- Step 3 deploys new code that reads the new table
+- The old table is never dropped or modified
+
+If the new code has a bug, we revert the deploy. The old code still reads the old table. No data loss.
+
+### Q: What if a migration between phases fails? Can we run Phase 3 without Phase 2?
+
+No. The phases are sequential dependencies:
+
+- **Phase 1** (LLM abstraction) is required by all subsequent phases — they all use `AgentChat.LLM`
+- **Phase 2** (context + rich messages) is required by Phase 3 — memory injection uses the context resolution pipeline
+- **Phase 3** (memory) is independent of Phase 4 — streaming doesn't need memory
+- **Phase 4** (streaming) is independent of Phase 5 — file uploads don't need streaming
+
+So the dependency chain is: 1 → 2 → 3, and 1 → 4, and 1 → 5. Phase 3, 4, and 5 are independent of each other (after Phase 2 for 3, after Phase 1 for 4 and 5).
+
+---
+
+## 9. Testing
+
+### Q: How do we test the `AgentChat.LLM` module without making real API calls?
+
+The same pattern already used for ILP revisions — dependency injection:
+
+```elixir
+# Production: uses ReqLLM
+AgentChat.LLM.run_completion(model, messages, tools)
+
+# Test: inject stub module
+AgentChat.LLM.run_completion(model, messages, tools, llm_module: Lanttern.ReqLLMStub)
+```
+
+The `ReqLLMStub` already exists in `test/support/stubs/req_llm.ex`. We extend it to handle tool calling:
+
+```elixir
+defmodule Lanttern.ReqLLMStub do
+  def generate_text(_model, _context, opts \\ []) do
+    case Keyword.get(opts, :stub_response, :text) do
+      :text ->
+        {:ok, %ReqLLM.Response{message: text_message("Stub response")}}
+      :tool_call ->
+        {:ok, %ReqLLM.Response{message: tool_call_message("create_lesson", %{...})}}
+    end
+  end
+end
+```
+
+This lets us test the full pipeline (message building → LLM call → response extraction → tool execution) without real API calls.
+
+### Q: How do we test streaming?
+
+Streaming tests use a stub that emits chunks:
+
+```elixir
+defmodule Lanttern.ReqLLMStreamStub do
+  def stream_text(_model, _context, callback, _opts \\ []) do
+    callback.({:chunk, "Hello "})
+    callback.({:chunk, "world"})
+    callback.({:done, %{usage: %{input: 10, output: 5}}})
+    :ok
+  end
+end
+```
+
+The test subscribes to PubSub, sends a message, and asserts that `:chunk` events arrive in order, followed by `:message_complete`.
+
+### Q: How do we test the memory summarization? It calls the LLM.
+
+The `MemorySummaryWorker` accepts an LLM module via dependency injection (same pattern). The test stub returns a predetermined summary:
+
+```elixir
+# Test
+test "summarizes conversation into memory entries" do
+  conversation = insert(:agent_conversation, ...)
+  insert(:agent_message, conversation: conversation, role: "user", content: "I prefer hands-on activities")
+  insert(:agent_message, conversation: conversation, role: "assistant", content: "Noted! I'll suggest...")
+
+  perform_job(MemorySummaryWorker, %{conversation_id: conversation.id}, llm_module: SummaryStub)
+
+  memories = AgentChat.Memory.list_user_memories(scope, profile)
+  assert length(memories) == 1
+  assert hd(memories).summary =~ "hands-on"
+end
+```
+
+---
+
+## 10. Performance & Cost
+
+### Q: How much will this architecture cost in LLM API fees?
+
+Cost depends on usage volume. Estimates for a school with 50 active teachers:
+
+| Operation | Tokens/call | Calls/week | Cost/week (GPT-4o) | Cost/week (GPT-4o-mini) |
+|---|---|---|---|---|
+| Chat message (with context) | ~3,000 in + ~1,000 out | 500 | ~$5.00 | ~$0.15 |
+| Memory summarization | ~2,000 in + ~200 out | 50 | ~$0.50 | ~$0.02 |
+| Conversation rename | ~500 in + ~50 out | 50 | ~$0.05 | ~$0.002 |
+| **Total** | | | **~$5.55/week** | **~$0.17/week** |
+
+Using GPT-4o-mini for summarization and rename (non-user-facing) significantly reduces costs. The school's `base_model` controls the primary chat model.
+
+Phase 4 adds **budget enforcement**: schools can set `monthly_token_budget` in `school_ai_configs`. The worker checks the budget before making an LLM call and returns an error if exceeded.
+
+### Q: Will the memory injection increase token costs significantly?
+
+Memory injection adds ~200-500 tokens per conversation (the summary layer). For a conversation with 3,000 tokens of context already (strand + lesson + school config), memories add ~10-15% overhead. This is negligible compared to the value of personalized responses.
+
+The cap (top 10 memories) prevents unbounded growth. If a user has 100 memories, only the 10 most relevant are injected.
+
+### Q: What's the performance impact of the polymorphic context table?
+
+The `conversation_contexts` table has:
+- A unique index on `(conversation_id, context_type, context_id)`
+- An index on `(context_type, context_id)`
+
+Loading contexts for a conversation is a single query:
+
+```sql
+SELECT * FROM conversation_contexts WHERE conversation_id = $1;
+```
+
+This returns 1-3 rows (strand, lesson, maybe ILP). The query hits the index directly. Performance is identical to the current `strand_agent_conversations` query — one indexed lookup returning a handful of rows.
+
+---
+
+## 11. Security & Data Ownership
+
+### Q: If we adopt Langfuse Cloud, are we sending conversation data to a third party?
+
+Yes. Langfuse Cloud receives traces, which can include prompt content, completion content, and token counts. However:
+
+1. **GDPR compliant**: Langfuse offers EU data residency and a DPA (Data Processing Agreement)
+2. **SOC 2 Type II certified**: Standard security compliance
+3. **Data masking**: You can mask sensitive fields before sending traces
+4. **Opt-in content**: You control what data is included in traces. You can send only metadata (model, tokens, latency) without actual message content.
+
+For maximum data control, self-hosted Langfuse keeps everything on your infrastructure. The phased approach (Cloud → self-hosted) lets you start with convenience and move to control when needed.
+
+### Q: How do we secure the SSE endpoint (Phase 5) for Vercel AI SDK?
+
+The SSE endpoint needs separate security because it's not a LiveView route (no WebSocket, no CSRF token):
+
+1. **Session authentication**: The React island shares the same browser session as the LiveView page. The SSE endpoint validates the session cookie.
+2. **CSRF protection**: Use a CSRF token passed from LiveView to the React island as a prop. The React component includes it in the SSE request header.
+3. **Rate limiting**: Apply per-user rate limiting middleware (plug) on the SSE endpoint.
+4. **Scope authorization**: The endpoint checks `Scope.has_permission?(scope, "agents_management")` before processing.
+
+```elixir
+# router.ex
+pipeline :api_auth do
+  plug :fetch_session
+  plug :verify_session_user
+  plug :verify_csrf_header  # Custom plug: checks X-CSRF-Token header
+  plug :rate_limit, max: 10, window: 60_000  # 10 requests/minute
+end
+
+scope "/api" do
+  pipe_through [:api_auth]
+  post "/chat", AiStreamController, :stream
+end
+```
+
+### Q: What about data ownership with ReqLLM? Are API calls logged by providers?
+
+When ReqLLM calls the OpenAI API, OpenAI processes the request per their API terms. Specifically:
+
+1. **OpenAI does not train on API data** (as of their current policy)
+2. **OpenAI retains API data for 30 days** for abuse monitoring (unless you opt out via their API data retention settings)
+3. **Lanttern stores all conversation data** in its own database — we have a complete local copy
+
+The same applies to any provider (Anthropic, Google, etc.). The architecture stores all data locally; the provider gets a copy during the API call. For maximum control, schools can configure local/private models (via ReqLLM's provider support) when they become available.
+
+---
+
+## 12. Timeline & Prioritization
+
+### Q: Can we skip phases or do them in parallel?
+
+**Parallel opportunities:**
+- Phase 3 (Memory) and Phase 4 (Streaming) are independent after Phase 2. They can run in parallel if the team has capacity.
+- Phase 5 (File uploads + React) is independent after Phase 1.
+
+**Cannot be skipped:**
+- Phase 1 (LLM abstraction) is foundational — everything depends on it
+- Phase 2 (Context) is required by Phase 3 (Memory uses the context pipeline)
+
+**Can be deferred:**
+- Phase 4 (Streaming) — nice UX improvement but not blocking
+- Phase 5 (React + File uploads) — depends on React setup progress
+
+### Q: What if the React setup is ready before Phase 5? Can we bring it forward?
+
+Yes. The React chat island (Phase 5, Steps 5.3-5.4) can be moved to Phase 4 or even Phase 3 if:
+
+1. React islands infrastructure is working
+2. The `AgentChat.LLM` abstraction is stable (Phase 1 complete)
+3. The SSE endpoint can be built quickly (it's a thin translation layer over PubSub)
+
+The backend doesn't change — only the frontend path is added. This is the benefit of the UI-agnostic architecture.
+
+### Q: Is 2 weeks per phase realistic?
+
+Each phase is scoped to a specific, bounded set of changes:
+
+- **Phase 1**: 2 files rewritten + 1 new module + test updates. 2 weeks is comfortable.
+- **Phase 2**: 1 migration + 1 new module + component changes. 2 weeks is tight but doable.
+- **Phase 3**: 1 migration + 1 new module + 1 Oban worker + UI page. 2 weeks is tight. Could extend to 3.
+- **Phase 4**: Streaming (new path in worker + component) + cost tracking. 2 weeks is tight. Could extend to 3.
+- **Phase 5**: Multiple independent features. Expected to take 3-4 weeks.
+
+The estimates are optimistic-but-achievable. Buffer should be added for integration testing and unexpected issues.
+
+---
+
+## 13. Vercel AI SDK Specifics
+
+### Q: How does the Vercel Data Stream Protocol actually work?
+
+It's an SSE (Server-Sent Events) protocol where each event is a single line with a type prefix:
+
+```
+0:"Hello "          → text chunk "Hello "
+0:"world"           → text chunk "world"
+9:{"toolCallId":"1","toolName":"create_lesson","args":{"description":"..."}}
+a:{"toolCallId":"1","result":{"lesson_id":42}}
+e:{"finishReason":"stop","usage":{"promptTokens":150,"completionTokens":50}}
+d:{"finishReason":"stop"}
+```
+
+Type codes:
+- `0` = text token
+- `9` = tool call
+- `a` = tool result
+- `e` = finish with metadata
+- `d` = done signal
+
+The Phoenix controller needs to produce this exact format. It's a string concatenation exercise — not complex, just precise.
+
+### Q: Does useChat work with non-streaming (batch) responses?
+
+Yes. `useChat` also supports non-streaming responses. If the backend returns the complete message at once (instead of streaming), `useChat` still handles it correctly — it just appears all at once instead of token-by-token.
+
+This means we can adopt the React island before implementing streaming. The SSE endpoint can return a single complete message (like our current batch flow), and `useChat` will display it.
+
+### Q: What happens if the SSE connection drops mid-stream?
+
+`useChat` handles reconnection automatically. When the connection drops:
+
+1. The current partial message is preserved in the component state
+2. The hook attempts to reconnect (configurable retry behavior)
+3. If reconnection fails, the message is marked as incomplete
+
+The backend handles this by checking if the Oban job already completed. If the worker finished and persisted the message, the reconnected client loads the complete message from the database (via an API call or LiveView bridge).
+
+---
+
+## 14. Langfuse Specifics
+
+### Q: How does OpenTelemetry integration work with Elixir specifically?
+
+The Elixir/BEAM ecosystem has strong OpenTelemetry support via the `opentelemetry` hex packages:
+
+```elixir
+# mix.exs
+{:opentelemetry, "~> 1.4"},
+{:opentelemetry_api, "~> 1.3"},
+{:opentelemetry_exporter, "~> 1.7"}
+```
+
+Configuration to export to Langfuse:
+
+```elixir
+# config/runtime.exs
+config :opentelemetry, :resource, service: %{name: "lanttern"}
+config :opentelemetry,
+  span_processor: :batch,
+  exporter: {:opentelemetry_exporter, %{
+    endpoints: ["https://your-langfuse.com/api/public/otel"],
+    headers: [{"Authorization", "Bearer #{langfuse_api_key}"}]
+  }}
+```
+
+Then in the code:
+
+```elixir
+require OpenTelemetry.Tracer, as: Tracer
+
+def run_completion(model, messages, tools, opts) do
+  Tracer.with_span "llm.completion" do
+    Tracer.set_attributes([
+      {"llm.model", model},
+      {"llm.provider", "openai"},
+      {"llm.messages_count", length(messages)}
+    ])
+
+    result = do_llm_call(model, messages, tools, opts)
+
+    case result do
+      {:ok, response} ->
+        Tracer.set_attributes([
+          {"llm.tokens.input", response.usage.input},
+          {"llm.tokens.output", response.usage.output}
+        ])
+      _ -> :ok
+    end
+
+    result
+  end
+end
+```
+
+Langfuse's OTLP endpoint receives these spans and displays them in its trace viewer.
+
+### Q: Can we use Langfuse for prompt management instead of keeping prompts in code?
+
+Yes, but it's a Phase 5+ consideration. Langfuse's prompt management allows:
+
+1. **Versioning**: Keep multiple versions of a prompt, deploy specific versions
+2. **Playground**: Test prompts against different models directly in the Langfuse UI
+3. **Caching**: Server-side + client-side caching to avoid loading prompts on every call
+4. **Non-developer iteration**: Educators or product managers can tweak prompts without code changes
+
+The trade-off is that prompts move from version-controlled code to an external service. This adds a runtime dependency (Langfuse must be available to load prompts) and reduces code-level visibility.
+
+The recommendation is: keep prompts in code for now (Phase 1-3). Evaluate Langfuse prompt management in Phase 5 when the observability infrastructure is mature and the team has experience with the platform.
+
+### Q: What about Langfuse's evaluation features? How would we use them?
+
+Langfuse evaluation enables automated quality checks on AI outputs. Practical examples for Lanttern:
+
+1. **LLM-as-judge**: After a lesson plan is generated, a separate LLM call evaluates it against rubrics (e.g., "Does the plan include differentiation?", "Is it age-appropriate?"). The score is stored in Langfuse.
+
+2. **User feedback**: When a teacher marks a lesson plan as "helpful" or "not helpful", that feedback is sent to Langfuse as a score attached to the trace. Over time, this builds a dataset for measuring quality trends.
+
+3. **Regression testing**: When prompts change, run the same set of test conversations through the new prompt and compare scores against the old prompt. This prevents quality regressions.
+
+These are Phase 3+ features. They require the tracing infrastructure to be in place first.
+
+---
+
+## 15. Jido Ecosystem
+
+### Q: You mentioned Jido could be reconsidered in the future. When specifically?
+
+Jido becomes relevant when Lanttern needs:
+
+1. **Multiple independent agents** that coordinate with each other (e.g., a "lesson planner" agent that delegates to a "curriculum researcher" agent and an "assessment designer" agent)
+2. **Complex state machines** where the agent's behavior changes based on accumulated state (beyond what a database can represent efficiently)
+3. **Real-time agent collaboration** where multiple agents work on the same task concurrently and need to share intermediate results
+
+Currently, Lanttern has one agent type (lesson planner) with a simple lifecycle (receive message → think → respond/act). Oban handles this perfectly.
+
+If the 2026 roadmap evolves toward multi-agent systems, revisit Jido at that point. The `AgentChat.LLM` abstraction makes this possible — Jido would replace the worker layer, not the LLM client layer.
+
+### Q: What about `jido_action` for typed tools? That seems better than what we're proposing.
+
+`jido_action` provides compile-time schema validation for tool definitions and automatic conversion to the LLM's tool format. It's genuinely better than hand-written tool specs.
+
+However, Lanttern currently has exactly **2 tools** (create_lesson, update_lesson) with a third planned (set_conversation_title). The overhead of a framework for 3 tools is not justified.
+
+When the tool count grows (10+), the compile-time validation and auto-conversion become valuable. At that point, `jido_action` can be adopted inside `AgentChat.Tools` without changing anything outside that module.
+
+### Q: Is there a risk that the Jido ecosystem becomes the Elixir standard and we miss out?
+
+Jido is promising but new (v2.0 released recently). The Elixir AI ecosystem doesn't have a "standard" yet — it's too early. By choosing ReqLLM (part of the Jido ecosystem) for the LLM client, we're already benefiting from the ecosystem's best component.
+
+If Jido becomes the standard, adopting it later is straightforward because:
+1. ReqLLM (already adopted) is the foundation of Jido's LLM layer
+2. `AgentChat.LLM` abstracts the orchestration — replacing it with Jido's orchestration is a bounded change
+3. The database schema, PubSub patterns, and UI layer are Jido-agnostic
+
+We're making a pragmatic bet: adopt the proven parts (ReqLLM) and defer the unproven parts (Jido agents) until they're battle-tested and we need them.
+
+---
+
+## 16. Monolith vs Microservice
+
+### Q: Let's be honest — doesn't Python have much better AI tools? Why are we limiting ourselves to Elixir?
+
+Yes, Python's AI ecosystem is objectively richer. Here's what we're missing by staying in Elixir:
+
+| Category | What Python has | What Elixir has | Gap severity |
+|---|---|---|---|
+| **Agent orchestration** | LangGraph (stateful, checkpointing, time-travel, 5 streaming modes) | Custom tool_call_loop (~25 lines) | **Large** |
+| **Multi-agent** | CrewAI, AG2/AutoGen, Swarm | Nothing production-ready | **Large** |
+| **RAG/Documents** | LlamaIndex (loaders, chunking, retrieval pipelines) | Manual implementation | **Large** |
+| **Evaluation** | DeepEval, RAGAS, PromptFoo | Nothing | **Large** |
+| **Structured output** | Instructor (3M+ downloads), Pydantic AI | Ecto validation (manual) | **Medium** |
+| **Provider SDKs** | Official from OpenAI, Anthropic, Google | ReqLLM (community, good but not official) | **Small-Medium** |
+| **Memory** | mem0, MemGPT/Letta | Custom implementation | **Medium** |
+| **Observability** | Native Langfuse/LangSmith SDKs | OpenTelemetry (works, not native) | **Small-Medium** |
+
+The gaps are real. The question is: **do we need these capabilities today, and is the cost of a microservice worth the access?**
+
+For Lanttern's current needs (LLM client, tool calling, basic memory, streaming), Elixir + ReqLLM is sufficient. The gaps that matter most (LangGraph orchestration, DeepEval evaluation) are future needs, not blocking ones.
+
+### Q: What would a Python sidecar architecture actually look like?
+
+A co-deployed FastAPI service running alongside Phoenix, sharing the same PostgreSQL and Redis:
+
+```
+User prompt → Phoenix LiveView → POST http://localhost:8000/chat
+                                        │
+                                        ▼
+                                  FastAPI (Python)
+                                  │ 1. GET context from Phoenix
+                                  │ 2. Run LangGraph agent
+                                  │ 3. On tool call → POST to Phoenix internal API
+                                  │ 4. On chunk → publish to Redis
+                                  │ 5. On complete → POST message to Phoenix
+                                        │
+                                        ▼
+                                  Redis (PubSub bridge)
+                                        │
+                                        ▼
+                                  Phoenix PubSub → LiveView update
+```
+
+The sidecar handles LLM orchestration. Phoenix keeps all domain logic (Scope, Ecto, business rules, tool execution). Communication is localhost HTTP (~5-10ms overhead).
+
+### Q: If we hire a Python AI engineer, how would they work with the Elixir codebase?
+
+They wouldn't need to touch Elixir. The sidecar pattern creates a clean boundary:
+
+- **Python engineer owns**: FastAPI service, LangGraph agents, evaluation pipelines, memory optimization, RAG if needed
+- **Elixir team owns**: Phoenix, LiveView, business logic, Scope/auth, database, tool execution endpoints
+- **Shared contract**: Internal HTTP API between the two services (documented, versioned)
+
+The Python engineer deploys their service alongside Phoenix. They consume internal APIs that the Elixir team exposes. No cross-language code reviews needed.
+
+### Q: How would tool calls (create_lesson) work across the service boundary?
+
+When the LangGraph agent decides to call `create_lesson`, the flow is:
+
+1. LangGraph emits a tool call: `{"name": "create_lesson", "args": {"description": "...", "moment_id": 1}}`
+2. FastAPI receives the tool call and forwards it to Phoenix: `POST http://localhost:4000/internal/tools/create_lesson`
+3. Phoenix receives the request, validates the scope token, calls `Lessons.create_lesson/3` with proper authorization and audit logging
+4. Phoenix returns the result: `{"lesson_id": 42, "status": "ok"}`
+5. FastAPI feeds the result back to LangGraph, which continues the conversation
+
+The critical point: **Phoenix still owns tool execution**. The microservice never touches business logic directly. This preserves Scope authorization, audit logging, and data integrity.
+
+### Q: What's the real latency impact?
+
+| Architecture | Prompt-to-first-token | Tool call round-trip | Total for typical exchange |
+|---|---|---|---|
+| **Elixir monolith** | LLM API latency only (~500ms) | 0ms (in-process) | ~2-5 seconds |
+| **Python sidecar** | +5-10ms (localhost hop) | +10-20ms (two localhost hops) | ~2-5.1 seconds |
+| **Full microservice** | +25-50ms (network hop) | +50-100ms (two network hops) | ~2-5.3 seconds |
+
+For a chat interface where the LLM API itself takes 2-5 seconds per response, the sidecar overhead (5-10ms) is imperceptible. The full microservice overhead (25-50ms) is noticeable only during streaming (choppy token delivery).
+
+### Q: Wouldn't TypeScript be more natural since we're adding React anyway?
+
+TypeScript has advantages for the frontend layer (Vercel AI SDK is native), but for the AI backend:
+
+- TypeScript's AI ecosystem is a **subset of Python's**. LangChain.js and LangGraph.js exist but have smaller communities. CrewAI, LlamaIndex, DeepEval, RAGAS, Instructor — all Python-only.
+- TypeScript's strength is frontend, not AI orchestration.
+- If we're adding a service for AI orchestration, Python gives us access to 10x more tools.
+
+If we hire an AI engineer, they will almost certainly know Python, not TypeScript. TypeScript is the right choice for the chat UI (React + Vercel AI SDK). Python is the right choice for AI orchestration (if we need a separate service).
+
+### Q: What's the real operational cost of running two services?
+
+| Dimension | Monolith | Sidecar | Full microservice |
+|---|---|---|---|
+| **Monthly infra** | ~$5K | ~$5.5-6.5K | ~$18-30K |
+| **CI/CD pipelines** | 1 | 1 (co-deployed) | 2 (separate) |
+| **On-call complexity** | Low | Low (same host) | Medium (cross-service debugging) |
+| **Integration tests** | Standard | Need cross-service tests | Need contract tests + E2E |
+| **Config management** | 1 set of env vars | 2 sets, shared secrets | 2 sets, network auth, service discovery |
+
+The sidecar is the sweet spot: 90% of the Python ecosystem benefits with only 10% of the microservice operational cost. Same deployment unit, same host, shared database.
+
+### Q: What if we need RAG for curriculum documents (PDFs, textbooks)?
+
+This is one of the strongest arguments for a Python sidecar. LlamaIndex provides:
+
+- **Document loaders**: PDF, DOCX, HTML, Google Docs — 100+ formats
+- **Chunking strategies**: Semantic, sentence-based, recursive — optimized for education content
+- **Embedding models**: OpenAI, Cohere, local models
+- **Vector stores**: pgvector, Pinecone, Qdrant — first-class integrations
+- **Retrieval pipelines**: Hybrid search, re-ranking, query transformation
+
+Building equivalent functionality in Elixir would require writing custom document parsers, chunking algorithms, and vector search integrations — weeks of work that LlamaIndex provides out of the box.
+
+If RAG over curriculum documents becomes a requirement, this alone justifies a Python sidecar.
+
+### Q: Is LangGraph really that much better than our custom tool_call_loop?
+
+For what Lanttern does today (simple request → tool call → response), our 25-line loop is fine. But LangGraph provides capabilities we can't easily replicate:
+
+| Feature | Our tool_call_loop | LangGraph |
+|---|---|---|
+| Basic tool calling | Yes | Yes |
+| Multi-turn tool calls | Yes (with max_iterations) | Yes (built-in) |
+| **Checkpointing** | No | Yes — save/resume agent state at any point |
+| **Time-travel debugging** | No | Yes — replay conversations from any checkpoint |
+| **Human-in-the-loop** | No | Yes — pause agent, ask human, resume |
+| **Parallel tool calls** | No | Yes — call multiple tools simultaneously |
+| **Streaming modes** | 1 (token) | 5 (tokens, events, updates, messages, custom) |
+| **Branching** | No | Yes — explore alternative conversation paths |
+| **Durable execution** | Oban retries (coarse) | Fine-grained state recovery mid-conversation |
+
+For a tutoring agent that needs to pause for teacher input, resume from a saved state, or explore different explanation strategies — LangGraph is far ahead. For a lesson planning chatbot, our loop suffices.
+
+### Q: What does the industry data say about microservices for AI?
+
+Key data points:
+
+- **42% reversal**: A 2025 CNCF survey found 42% of organizations that adopted microservices have consolidated services back into larger units. Premature splitting is the most common mistake.
+- **Amazon Prime Video**: Migrated their video quality analysis from microservices to a single-process monolith, achieving **90% infrastructure cost reduction**.
+- **Vercel, Notion, Stripe**: Use AI gateways (translation layers) rather than full microservices. They keep AI orchestration close to the main application.
+- **Modular monolith trend**: The industry is converging on modular monoliths with clean internal boundaries that CAN be extracted later — exactly what our `AgentChat.LLM` abstraction provides.
+
+The pattern that works: **start monolith, extract only when you have a proven need** (scale, team independence, or ecosystem access). Don't extract preemptively.
+
+### Q: What's the migration path from monolith to sidecar?
+
+The `AgentChat.LLM` module is the extraction point. Today it wraps ReqLLM. Tomorrow it can wrap an HTTP call to a Python service:
+
+```elixir
+# Today (Phase 1): direct ReqLLM call
+defp do_llm_call(model, messages, tools, opts) do
+  ReqLLM.generate_text(model, context, tools: tools)
+end
+
+# Future (when sidecar adopted): HTTP call to FastAPI
+defp do_llm_call(model, messages, tools, opts) do
+  Req.post!("http://localhost:8000/chat", json: %{
+    model: model,
+    messages: messages,
+    tools: tools,
+    scope_token: opts[:scope_token]
+  })
+  |> parse_response()
+end
+```
+
+Nothing outside `AgentChat.LLM` changes. The context module, workers, PubSub, UI — all unchanged. The extraction is one function body change in one module.
+
+### Q: Should we start with a sidecar now instead of ReqLLM, to avoid migration later?
+
+No. Reasons:
+
+1. **You can't know what you need until you build it.** Using ReqLLM directly teaches us what the LLM abstraction needs. Premature extraction means building an API contract before understanding the requirements.
+2. **The migration cost is tiny.** Changing one function body in `AgentChat.LLM` is a 30-minute task. Compare that to weeks of sidecar setup upfront.
+3. **The sidecar adds operational complexity from day 1.** Two codebases, two test suites, a bridge layer — all before we know if we need it.
+
+Build the monolith. Learn what the agent actually needs. Extract when a specific capability (LangGraph, DeepEval, RAG) demands it.
+
+### Q: Can DeepEval / RAGAS evaluation be used without a microservice?
+
+Partially. You have two options:
+
+1. **Offline evaluation** (no microservice needed): Run DeepEval/RAGAS as a Python script that reads conversation data from the database, evaluates it, and writes results back. This is a batch process, not a runtime dependency. You can use CI/CD or a cron job.
+
+2. **Runtime evaluation** (sidecar needed): If you want real-time evaluation (score every AI response before showing it to the user), the evaluation framework needs to be in the request path — which means a Python sidecar.
+
+For Lanttern's current stage, **offline evaluation is sufficient**. Run a weekly batch that evaluates recent conversations for quality, safety, and relevance. This requires only a Python script, not a full sidecar.
+
+---
+
+## 17. CopilotKit vs Vercel AI SDK vs assistant-ui
+
+### Q: What is the AG-UI Protocol and why does it matter?
+
+AG-UI (Agent-User Interaction Protocol) is an open standard for agent-to-frontend communication, adopted by Google, AWS, LangChain, Microsoft, Mastra, and PydanticAI. It defines rich SSE event types (text streaming, tool calls, state snapshots, state deltas, lifecycle events, human approval) designed specifically for AI agents.
+
+It matters because the Vercel Data Stream Protocol only supports text chunks and basic tool calls. AG-UI supports everything LangGraph can emit — state updates, multi-step workflows, human-in-the-loop approvals. When using LangGraph as a backend, AG-UI is a native fit while the Vercel protocol requires a lossy conversion.
+
+### Q: Why would CopilotKit be better than Vercel AI SDK for Lanttern?
+
+Three specific Lanttern features that CopilotKit handles natively and Vercel AI SDK does not:
+
+1. **Teacher approval before lesson creation**: CopilotKit's human-in-the-loop pauses the agent, shows an approval UI, and resumes on teacher action. With Vercel AI SDK, you'd build this entirely from scratch.
+
+2. **Agent status indicators** ("Loading strand context...", "Creating lesson...", "Waiting for approval..."): CopilotKit's STATE_DELTA events update the UI in real-time as the agent progresses through steps. Vercel AI SDK has no equivalent.
+
+3. **Lesson card rendering**: Both support custom tool call renderers, but CopilotKit's generative UI system makes this more natural — the agent can dynamically decide what UI component to render.
+
+### Q: When would Vercel AI SDK still be the right choice?
+
+If Lanttern stays on the Elixir monolith (no Python sidecar), Vercel AI SDK is simpler:
+- No LangGraph backend means AG-UI's rich events are irrelevant — the Elixir backend won't produce them
+- Vercel AI SDK's `useChat` hook is lighter and easier to set up
+- The community is 4x larger, meaning more examples and better documentation
+- For basic chat with tool calls (current Lanttern feature set), Vercel AI SDK is sufficient
+
+The rule: **Use CopilotKit if you have LangGraph. Use Vercel AI SDK if you don't.**
+
+### Q: What about assistant-ui? When is it better than both?
+
+assistant-ui is the choice when **visual customization matters more than agent features**. It's headless — no pre-built styles, you apply your own design system to every element.
+
+For Lanttern specifically: if the team wants the chat UI to perfectly match Lanttern's existing design language (the amber AI theme, `ltrn-ai-*` Tailwind classes, custom components), assistant-ui gives more control. CopilotKit's pre-built components would need to be styled to match, which can fight the framework.
+
+However, assistant-ui lacks state sync and human-in-the-loop — features Lanttern will likely need. The trade-off is: **maximum visual control** (assistant-ui) vs **maximum agent UX** (CopilotKit).
+
+### Q: Can we switch between these later? How locked in are we?
+
+Switching is moderate effort, not a rewrite:
+
+- **CopilotKit → Vercel AI SDK**: Replace CopilotKit components with `useChat` hook + custom renderers. Backend SSE endpoint changes format (AG-UI → Data Stream Protocol). ~1-2 weeks.
+- **Vercel AI SDK → CopilotKit**: Replace `useChat` with CopilotKit components. Backend changes SSE format. ~1-2 weeks.
+- **Either → assistant-ui**: Replace components, adapt streaming adapter. ~1-2 weeks.
+
+The backend architecture (`AgentChat.LLM`, `AgentChat.Tools`, Oban workers, PubSub) doesn't change in any scenario. The frontend choice is a UI-layer decision, not an architecture decision.
+
+### Q: Does CopilotKit work with an Elixir/Phoenix backend?
+
+Yes, but indirectly. CopilotKit consumes AG-UI events via SSE. Phoenix would need a controller that produces AG-UI-formatted SSE events. This is the same pattern as the Vercel AI SDK integration — a Phoenix controller that speaks the right protocol.
+
+The difference: AG-UI events are richer (more event types to implement). If the Elixir backend doesn't produce state snapshots or human-in-the-loop events (because it's not LangGraph), CopilotKit still works but most of its advanced features go unused. That's why **CopilotKit + Elixir is not recommended** — you'd be using 30% of the framework.
+
+### Q: How does the LangGraph → AG-UI → CopilotKit data flow work in practice?
+
+Step by step for a user prompt:
+
+1. User types in CopilotKit `<CopilotChat>` component
+2. CopilotKit sends message to backend via AG-UI protocol (SSE POST)
+3. FastAPI receives, creates LangGraph agent invocation
+4. LangGraph runs the agent graph:
+   - Emits `RUN_STARTED` → CopilotKit shows "thinking..." indicator
+   - Emits `TEXT_MESSAGE_CONTENT` chunks → CopilotKit streams text token by token
+   - Emits `TOOL_CALL_START` (create_lesson) → CopilotKit shows tool call UI
+   - FastAPI calls Phoenix internal API to execute the tool
+   - Emits `TOOL_CALL_END` with result → CopilotKit renders lesson card
+   - Emits `STATE_DELTA` → CopilotKit updates status indicator
+   - Emits `RUN_FINISHED` → CopilotKit shows final state
+5. No conversion layer needed — AG-UI events map 1:1 to LangGraph events
+
+### Q: Is AG-UI Protocol mature enough for production?
+
+AG-UI was introduced in 2025 and has been adopted by Google, AWS, Microsoft, and LangChain. It's an open standard with a public spec (docs.ag-ui.com) and GitHub repo.
+
+Risks:
+- Newer than Vercel Data Stream Protocol (less battle-tested)
+- CopilotKit is the primary implementor — if CopilotKit pivots, AG-UI's React ecosystem shrinks
+- The spec may evolve (breaking changes in early standards)
+
+Mitigations:
+- Major corporate adoption (Google/AWS/MS) suggests stability
+- Open standard means alternative implementations can emerge
+- CopilotKit is open source — worst case, fork and maintain
+
+For Lanttern's timeline (Phase 4-5, several months away), AG-UI will be more mature by the time we need it.

--- a/exploration/ai-oriented-features/how-is-ai-in-lanttern-today.md
+++ b/exploration/ai-oriented-features/how-is-ai-in-lanttern-today.md
@@ -1,0 +1,565 @@
+# How AI Works in Lanttern Today
+
+> Technical reference document — April 2026
+>
+> Audience: developers, architects, and technical decision-makers working on Lanttern's AI roadmap.
+
+---
+
+## 1. Executive Summary
+
+Lanttern currently has **two independent AI-powered features**, built at different times and using different libraries:
+
+| Feature | Purpose | Library | LLM Provider | Async? |
+|---------|---------|---------|-------------|--------|
+| **Agent Chat** | Conversational lesson planning assistant | LangChain 0.4.0 | OpenAI (ChatOpenAI) | Yes (Oban) |
+| **ILP AI Revision** | Automated review of Individual Learning Plans | ReqLLM ~> 1.6 | OpenAI (via ReqLLM) | No (synchronous) |
+
+Both features communicate exclusively with **OpenAI's API** and share a single API key. There is no streaming — all responses are generated in full before being delivered to the user.
+
+A third dependency, **LLMDB (~> 2026.3.1)**, serves as a model validation catalog (used to verify that a configured model name is valid).
+
+---
+
+## 2. Dependency Map
+
+```
+mix.exs
+├── {:langchain, "0.4.0"}          # Agent Chat — chains, function calling, message types
+├── {:req_llm, "~> 1.6"}           # ILP Revision — simple text generation
+└── {:llm_db, "~> 2026.3.1"}       # Model name validation (LLMDB.allowed?/1)
+```
+
+### Why two LLM libraries?
+
+The ILP Revision feature was originally built (March 2025 — migrations `20250319*`) using `req_llm`, a lightweight Req-based LLM wrapper. The Agent Chat was built later (January 2026 — migrations `20260106*`) using LangChain, which provides chain orchestration and function calling.
+
+As noted in the project's planning document (`ai-agent-features-lanttern.md`), the team is considering **consolidating on `req_llm`** (part of the Jido ecosystem) and phasing out LangChain. The rationale: LangChain adds abstraction overhead that may not be needed, and `req_llm` is lighter and closer to the Elixir idiom.
+
+### Environment Variables
+
+| Variable | Used by | Required |
+|----------|---------|----------|
+| `OPENAI_API_KEY` | LangChain, ReqLLM | Yes (production) |
+| `OPENAI_ORG_ID` | LangChain | Optional |
+
+Configuration lives in `config/config.exs` (compile-time) and `config/runtime.exs` (production runtime):
+
+```elixir
+# config/config.exs:98-100 (compile-time, all environments)
+config :langchain, openai_key: System.get_env("OPENAI_API_KEY")
+config :langchain, openai_org_id: System.get_env("OPENAI_ORG_ID")
+
+# config/runtime.exs:98-99 (runtime, all environments — inside prod check is repeated)
+config :langchain, openai_key: System.get_env("OPENAI_API_KEY")
+config :langchain, openai_org_id: System.get_env("OPENAI_ORG_ID")
+
+# config/runtime.exs:196-197 (runtime, production ONLY — inside `if config_env() == :prod` block)
+config :req_llm, openai_api_key: System.get_env("OPENAI_API_KEY")
+```
+
+Note: `req_llm` is only configured in the production block of `runtime.exs`. In dev/test, it relies on the test stub (`Lanttern.ReqLLMStub`) injected via the `req_llm_module` parameter.
+
+---
+
+## 3. Feature 1: Agent Chat (Conversational Lesson Planning)
+
+### 3.1 Overview
+
+A multi-turn chat interface where teachers interact with an AI assistant to plan lessons. The AI is context-aware — it knows about the school's curriculum, the strand (unit of study), the specific lesson, and the teacher's preferences. It can also **execute actions** (create/update lessons) via LLM function calling.
+
+### 3.2 Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│  Parent LiveView (StrandChatLive / LessonChatLive)                  │
+│    • Subscribes to PubSub topic "conversation:{id}"                 │
+│    • Forwards PubSub events to ConversationComponent via            │
+│      send_update/3                                                  │
+│                                                                     │
+│  └── ConversationComponent (UI: messages, prompt, selectors)        │
+│        • Handles user prompt submission                             │
+│        • Calls AgentChat context for data operations                │
+│        • Enqueues Oban job after data is persisted                  │
+└────────────────────────┬────────────────────────────────────────────┘
+                         │ 1. User submits message
+                         ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  Step A: Data persistence (AgentChat context)                       │
+│                                                                     │
+│  create_conversation_with_message/3  or  add_user_message/3         │
+│    → Insert user message into DB (Ecto.Multi)                       │
+│    → Set conversation.status = "processing"                         │
+│                                                                     │
+│  Step B: Job enqueue (ConversationComponent)                        │
+│                                                                     │
+│  enqueue_chat_response_job/2                                        │
+│    → ChatResponseWorker.new(args) |> Oban.insert()                  │
+└────────────────────────┬────────────────────────────────────────────┘
+                         │ 2. Oban picks up the job
+                         ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│  ChatResponseWorker (lib/lanttern/workers/chat_response_worker.ex)  │
+│  Oban queue: :ai, max_attempts: 3, unique: true                     │
+│                                                                     │
+│  1. Resolve model (job arg → school config → app default)           │
+│  2. Create ChatOpenAI instance (stream: false)                      │
+│  3. Fetch conversation + all messages from DB                       │
+│  4. Call AgentChat.run_llm_chain/4                                  │
+│     → Build system messages (5-layer hierarchy)                     │
+│     → Attach tools (create_lesson, update_lesson)                   │
+│     → Run LangChain (mode: :while_needs_response)                  │
+│     → Tool timeout: 5 minutes (async_tool_timeout)                  │
+│  5. Extract response content + aggregate token usage                │
+│  6. Save assistant message + ModelCall to DB                        │
+│  7. Mark conversation idle                                          │
+│  8. Broadcast via PubSub → parent LiveView → send_update to        │
+│     ConversationComponent                                           │
+│  9. Auto-rename conversation if unnamed                             │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+Note: the Oban job is enqueued by the `ConversationComponent` (the LiveComponent), not by the `AgentChat` context module. The context is responsible only for data persistence (messages, status). This keeps the context module free of side effects beyond the database.
+
+### 3.3 System Prompt Construction (5-Layer Hierarchy)
+
+The system messages are prepended to the LangChain call in a **fixed order** to benefit from OpenAI's prompt caching. This ordering is intentional — see `agent_chat.ex:461-478`.
+
+```
+Layer 1: School Knowledge & Guardrails
+  └── Source: SchoolConfig.AiConfig (school_ai_configs table)
+  └── Tags: <school_knowledge>...</school_knowledge>
+            <school_guardrails>...</school_guardrails>
+
+Layer 2: Agent Configuration
+  └── Source: Agents.Agent (ai_agents table)
+  └── Tags: <agent_personality>...</agent_personality>
+            <agent_instructions>...</agent_instructions>
+            <agent_knowledge>...</agent_knowledge>
+            <agent_guardrails>...</agent_guardrails>
+
+Layer 3: Staff Member Context
+  └── Source: Schools.StaffMember (staff table)
+  └── Tag: <staff_member_context>
+              <name>...</name>
+              <role>...</role>
+              <about>...</about>
+              <preferences>...</preferences>
+            </staff_member_context>
+
+Layer 4: Lesson Template
+  └── Source: LessonTemplates (lesson_templates table)
+  └── Tags: <lesson_template_info>...</lesson_template_info>
+            <lesson_template>...</lesson_template>
+
+Layer 5: Curriculum Context
+  └── Strand: <strand_context> with name, subjects, years, curriculum items,
+              overview, teacher_instructions, moments
+  └── Lesson: <lesson_context> with name, moment, subjects, tags,
+              overview, teacher_notes, differentiation_notes
+  └── Tool Args: <tools_args> with moments/subjects/tags IDs
+                 (only if function calling is enabled)
+```
+
+Each layer is conditionally included — if the data doesn't exist (e.g., no agent selected, no lesson context), the corresponding system messages are simply not added.
+
+### 3.4 Function Calling (Tool Use)
+
+Two LangChain `Function` tools are available, depending on the context:
+
+**`create_lesson`** — Available in strand-level chat (`strand_id` required)
+- Parameters: `moment_id`, `subjects_ids`, `tags_ids`, `description`, `teacher_notes`, `differentiation_notes`
+- Calls `Lessons.create_lesson(scope, args, is_ai_agent: true)`
+- The `<tools_args>` system message provides the valid moment/subject/tag IDs
+
+**`update_lesson`** — Available in lesson-level chat (`lesson_id` required)
+- Same parameters as create
+- Calls `Lessons.update_lesson(scope, lesson, args, is_ai_agent: true)`
+
+**Audit Log integration:**
+When the AI creates or updates a lesson, the operation is recorded in `LessonLog` with `is_ai_agent: true` (via `AuditLog.maybe_log/5`). This allows distinguishing AI-generated lessons from human-created ones for observability and analytics.
+
+**Auto-rename via function calling:**
+When a conversation has no name, the worker triggers `rename_conversation_based_on_chain/3`, which uses a separate LLM call with a `set_conversation_title` function to generate a concise title from the first 4 messages. This is a non-critical operation — failures are silently ignored.
+
+The chain runs with `mode: :while_needs_response`, meaning LangChain will automatically handle multi-turn tool calling (LLM requests tool call → tool executes → result fed back → LLM responds). Tool execution has a 5-minute timeout (`async_tool_timeout: 5 * 60 * 1000`).
+
+### 3.5 Model Resolution
+
+The model is resolved with a 3-level fallback chain (`chat_response_worker.ex:120-131`):
+
+```
+1. Job argument (explicit override per request)      → args["model"]
+2. School configuration (admin-configured default)   → AiConfig.base_model
+3. Application default (hardcoded)                   → "gpt-5-nano"
+```
+
+### 3.6 Token Tracking
+
+Every assistant message generates a `ModelCall` record with:
+- `prompt_tokens` — total input tokens across all LLM calls in the exchange
+- `completion_tokens` — total output tokens
+- `model` — the model used
+
+Token usage is aggregated from `chain.exchanged_messages` because a single user prompt may trigger multiple LLM calls (tool calls, retries). See `chat_response_worker.ex:133-156`.
+
+**Notable gap:** There is no token-per-user limit, no budget enforcement, and no cost alerting. Token data is stored but not acted upon.
+
+### 3.7 Real-Time Updates
+
+The system uses Phoenix PubSub for real-time communication between the Oban worker and the LiveView:
+
+```
+Topic: "conversation:#{conversation_id}"
+
+Events:
+  {:conversation, {:message_added, %Message{}}}
+  {:conversation, {:failed, error}}
+  {:conversation, {:conversation_renamed, %Conversation{}}}
+```
+
+The **parent LiveView** (StrandChatLive/LessonChatLive) subscribes to the PubSub topic when a conversation is loaded (`AgentChat.subscribe_conversation/1` in `apply_action(:show)`). When events arrive, the parent forwards them to the `ConversationComponent` via `send_update/3`. The component itself does not subscribe to PubSub — it only reacts to updates from its parent. When the user navigates to a different conversation, the parent calls `unsubscribe_all()` before subscribing to the new topic.
+
+The conversation's `status` field ("idle" | "processing") prevents race conditions — the UI shows a loading state while processing.
+
+### 3.8 Database Schema
+
+```
+ai_agents
+├── id, name, knowledge, personality, guardrails, instructions
+├── school_id → schools
+└── timestamps
+
+school_ai_configs
+├── id, base_model, knowledge, guardrails
+├── school_id → schools (unique)
+└── timestamps
+
+agent_conversations
+├── id, name, status ("idle"|"processing"), last_error
+├── profile_id → profiles
+├── school_id → schools
+└── timestamps
+
+agent_messages
+├── id, role ("user"|"assistant"|"system"), content
+├── conversation_id → agent_conversations
+└── timestamps
+
+llm_calls
+├── id, prompt_tokens, completion_tokens, model
+├── message_id → agent_messages (unique)
+└── timestamps
+
+strand_agent_conversations
+├── id
+├── conversation_id → agent_conversations
+├── strand_id → strands
+├── lesson_id → lessons (nullable)
+└── timestamps
+
+staff (existing table, AI-related field)
+└── agent_conversation_preferences (text)
+```
+
+### 3.9 Routes
+
+```
+/strands/:strand_id/chat              → StrandChatLive :new
+/strands/:strand_id/chat/:conv_id     → StrandChatLive :show
+/strands/lesson/:lesson_id/chat       → LessonChatLive :new
+/strands/lesson/:lesson_id/chat/:id   → LessonChatLive :show
+/settings/agents                      → AgentsSettingsLive :index
+/settings/agents/:id                  → AgentsSettingsLive :show
+/settings/school_ai_config            → SchoolAiConfigLive :index
+```
+
+### 3.10 Permissions
+
+All Agent Chat features require the `"agents_management"` permission. The check is done in two different ways across the codebase:
+
+- **Chat pages and context modules** use `Scope.has_permission?(scope, "agents_management")` (the recommended pattern per CLAUDE.md)
+- **Settings pages** (`SchoolAiConfigLive`, `AgentsSettingsLive`) check `current_user.current_profile.permissions` directly — this is an older pattern that predates the `Scope` convention (technical debt)
+
+---
+
+## 4. Feature 2: ILP AI Revision
+
+### 4.1 Overview
+
+A simpler, synchronous AI feature that reviews a student's Individual Learning Plan (ILP) and generates a revision/feedback document. Unlike the Agent Chat, this is a **single-shot generation** — no conversation, no function calling, no async processing.
+
+### 4.2 Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Two entry points (both call ILP.revise_student_ilp/5):          │
+│                                                                  │
+│  1. ActionBarComponent — "Generate revision" button              │
+│     Shown when NO revision exists yet                            │
+│                                                                  │
+│  2. OverlayComponent — "Update revision" button                  │
+│     Shown inside the overlay that displays the current revision  │
+│                                                                  │
+│  Preconditions (both components check before showing the form):  │
+│  • All ILP entries must be filled (every entry.description ≠ nil)│
+│  • Template must have ai_layer.revision_instructions set         │
+│  • Template must have ai_layer.model set                         │
+└────────────────────────┬─────────────────────────────────────────┘
+                         │ User enters student age, submits
+                         ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  ILP.revise_student_ilp/5  (lib/lanttern/ilp.ex:743)            │
+│                                                                  │
+│  1. Convert StudentILP to text via student_ilp_to_text/3         │
+│     → Iterates template sections/components + ILP entries        │
+│     → Produces markdown: "# Section\n## Component\ncontent"     │
+│                                                                  │
+│  2. Build ReqLLM.Context                                         │
+│     → System: template.ai_layer.revision_instructions            │
+│     → User: "review the ILP for a student with age {age}\n"     │
+│             + formatted ILP text                                 │
+│                                                                  │
+│  3. ReqLLM.generate_text(model, context)  ← synchronous call    │
+│     Model comes from template.ai_layer.model (NOT school config) │
+│                                                                  │
+│  4. Save result to StudentILP via ai_changeset/2:                │
+│     → ai_revision (the generated text)                           │
+│     → last_ai_revision_input (the prompt sent)                   │
+│     → ai_revision_datetime (UTC timestamp)                       │
+│                                                                  │
+│  5. Create audit log via ILPLog.maybe_create_student_ilp_log/3   │
+│     (uses log_profile_id option to link to requesting user)      │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 4.3 Configuration
+
+Each ILP template can have an associated `ILPTemplateAILayer` (1:1 relationship via `template_id` as primary key):
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `revision_instructions` | text | System prompt for the AI revision |
+| `model` | string | LLM model (validated via `LLMDB.allowed?/1`) |
+| `cooldown_minutes` | integer (default 0) | Minimum minutes between revision requests |
+
+### 4.4 Cooldown Mechanism
+
+The `StudentILPAIRevisionOverlayComponent` checks the time elapsed since `ai_revision_datetime` against `cooldown_minutes` (using `Timex.diff/3`). If the cooldown hasn't expired, the "Update revision" form is hidden and a countdown is shown instead. The `ActionBarComponent` does not implement cooldown — it only appears when no revision exists yet, so cooldown is not applicable.
+
+This is a **UI-side enforcement** — there is no server-side cooldown validation in `revise_student_ilp/5`. A direct call to the context function would bypass the cooldown.
+
+### 4.5 Testing Strategy
+
+The function accepts `req_llm_module` as a dependency-injected parameter (defaults to `ReqLLM`). In tests, `Lanttern.ReqLLMStub` is passed instead, which returns a hardcoded stub response:
+
+```elixir
+# test/support/stubs/req_llm.ex
+def generate_text(_model, _context, _opts \\ []) do
+  {:ok, %ReqLLM.Response{
+    message: %ReqLLM.Message{
+      content: [ReqLLM.Message.ContentPart.text("This is a stub response.")]
+    }
+  }}
+end
+```
+
+### 4.6 Database Fields
+
+On `students_ilps` table (existing table, AI fields added via migration `20250319193523`):
+
+```
+ai_revision          :string    # The generated revision text
+last_ai_revision_input :string  # The prompt that was sent (audit trail)
+ai_revision_datetime :utc_datetime  # When the revision was generated
+```
+
+The same fields are mirrored in `student_ilp_logs` for the audit trail.
+
+A dedicated `ai_changeset/2` is used to separate AI-generated content from human-edited content (`student_ilp.ex:95`).
+
+---
+
+## 5. Shared Infrastructure
+
+### 5.1 Oban Job Queue
+
+```elixir
+# config/config.exs:103-114
+config :lanttern, Oban,
+  queues: [cleanup: 1, ai: 10],
+  plugins: [Oban.Plugins.Pruner, {Oban.Plugins.Cron, crontab: [...]}]
+```
+
+- The `ai` queue has **10 concurrent workers**, meaning up to 10 AI chat responses can be processed simultaneously.
+- `ChatResponseWorker` uses `unique: true` to prevent duplicate jobs for the same conversation.
+- In test environment: `config :lanttern, Oban, testing: :manual` (jobs don't execute automatically).
+- `Oban.Plugins.Pruner` cleans up completed jobs automatically.
+
+### 5.2 Audit Log — `is_ai_agent` Flag
+
+The `AuditLog` module (`lib/lanttern/audit_log.ex`) accepts an `:is_ai_agent` option on `maybe_log/5`. When the AI agent creates or updates a lesson via tool calling, `Lessons.create_lesson/3` and `Lessons.update_lesson/4` pass `is_ai_agent: true`, which is persisted in the `LessonLog` schema. This enables querying "which lessons were created by AI vs. humans."
+
+Currently, only `LessonLog` uses this flag. The ILP revision has its own separate audit trail (via `ILPLog`) that does not use `is_ai_agent` — instead, it simply records the operation linked to the requesting user's `profile_id`.
+
+### 5.3 Application Default Model
+
+```elixir
+# chat_response_worker.ex:129
+Application.get_env(:lanttern, :default_llm_model, "gpt-5-nano")
+```
+
+This is the ultimate fallback when neither the job nor the school configuration specify a model.
+
+### 5.4 UI Component Library
+
+All AI features share a consistent visual language via dedicated components:
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| `ai_panel_overlay/1` | `ai_components.ex` | Full-screen modal with AI amber theme |
+| `floating_ai_button/1` | `ai_components.ex` | Fixed FAB to open AI panels |
+| `ai_action_bar/1` | `ai_components.ex` | Horizontal bar with AI branding |
+| `ai_content_indicator/1` | `ai_components.ex` | Dot indicator for AI-generated content |
+| `ai_box/1` | `core_components.ex` | Container with AI border styling |
+| `ai_generated_content_disclaimer/1` | `core_components.ex` | "AI makes mistakes" warning |
+
+The visual theme uses custom Tailwind classes (`ltrn-ai-*`) with amber tones, animated "spectrum spots" (blur-based gradient circles), and the `hero-sparkles-mini` icon.
+
+---
+
+## 6. Complete Migration Timeline
+
+| Date | Migration | What it did |
+|------|-----------|-------------|
+| 2025-03-19 | `create_ilp_template_ai_layers` | ILP AI layer table (revision_instructions) |
+| 2025-03-19 | `add_ai_fields_to_students_ilps` | ai_revision, last_ai_revision_input, ai_revision_datetime |
+| 2025-04-03 | `add_model_and_cooldown_to_ilp_template_ai_layers` | model, cooldown_minutes fields |
+| 2026-01-06 | `create_ai_agents` | ai_agents table |
+| 2026-01-13 | `create_agent_conversations` | agent_conversations table |
+| 2026-01-13 | `create_agent_messages` | agent_messages table |
+| 2026-01-13 | `create_llm_calls` | llm_calls table (token tracking) |
+| 2026-01-14 | `add_unique_message_id_constraint_to_llm_calls` | 1:1 message-to-model_call |
+| 2026-01-14 | `add_school_id_to_agent_conversations` | school_id on conversations |
+| 2026-01-21 | `create_strand_agent_conversations` | strand/lesson conversation links |
+| 2026-02-03 | `create_school_ai_configs` | school_ai_configs table |
+| 2026-03-06 | `add_agent_conversation_preferences_to_staff` | staff preferences field |
+| 2026-03-06 | `add_status_to_agent_conversations` | status + last_error fields |
+
+The ILP feature (2025) predates the Agent Chat (2026) by ~9 months.
+
+---
+
+## 7. Configuration Hierarchy
+
+```
+Environment Variables
+  OPENAI_API_KEY ─────────────────────────────────────┐
+  OPENAI_ORG_ID ──────────────────────────────────┐   │
+                                                  │   │
+Application Config                                │   │
+  config :langchain, openai_key: ────────────────►│◄──┤
+  config :langchain, openai_org_id: ─────────────►│   │
+  config :req_llm, openai_api_key: ──────────────►────┤
+  config :lanttern, :default_llm_model ──────► "gpt-5-nano" (hardcoded fallback)
+                                                  │
+School-Level Config (per school, DB)              │
+  school_ai_configs.base_model ──────────────────►│ (overrides app default)
+  school_ai_configs.knowledge ───────────────► system prompt layer 1
+  school_ai_configs.guardrails ──────────────► system prompt layer 1
+                                                  │
+Agent-Level Config (per school, DB)               │
+  ai_agents.personality ─────────────────────► system prompt layer 2
+  ai_agents.instructions ────────────────────► system prompt layer 2
+  ai_agents.knowledge ──────────────────────► system prompt layer 2
+  ai_agents.guardrails ─────────────────────► system prompt layer 2
+                                                  │
+ILP Template Config (per template, DB)            │
+  ilp_template_ai_layers.revision_instructions ──► system prompt (ILP only)
+  ilp_template_ai_layers.model ─────────────────► model override (ILP only)
+  ilp_template_ai_layers.cooldown_minutes ──────► rate limit (ILP only)
+                                                  │
+Per-Request Override                              │
+  ChatResponseWorker job args: model ───────────►│ (highest priority for chat)
+```
+
+---
+
+## 8. Architectural Observations
+
+### What's working well
+
+1. **Clean separation of concerns.** The Oban worker pattern decouples the LiveView from LLM latency. The UI stays responsive, and PubSub provides clean real-time updates.
+
+2. **Hierarchical system prompt construction.** The 5-layer prompt hierarchy is well-organized and explicitly ordered for prompt caching. Each layer is self-contained and conditionally included.
+
+3. **Token tracking.** Every LLM call is recorded with token counts, enabling future cost analysis and budgeting.
+
+4. **School-scoped multi-tenancy.** AI configuration (model, knowledge, guardrails, agents) is fully scoped to schools. Different schools can have completely different AI setups.
+
+5. **Audit trail for ILP revisions.** The combination of `last_ai_revision_input` + `ai_revision_datetime` + ILPLog snapshots provides full traceability.
+
+### Known gaps and trade-offs
+
+1. **No streaming.** The LLM is called with `stream: false` (`chat_response_worker.ex:57`). The user sees a loading indicator until the full response is generated. For long responses, this can feel slow.
+
+2. **No token/cost limits.** Token data is stored but there's no per-user, per-school, or per-conversation budget enforcement. A single user could theoretically exhaust the API budget.
+
+3. **Dual library situation.** LangChain (Agent Chat) and ReqLLM (ILP Revision) serve overlapping purposes. This increases the cognitive load for developers and the surface area for dependency management.
+
+4. **Synchronous ILP revision.** Unlike the Agent Chat, ILP revisions block the LiveView process during the API call. If the OpenAI API is slow or down, the user's browser tab hangs.
+
+5. **Client-side only cooldown.** The ILP cooldown is enforced in the UI but not in the context function. A crafted request could bypass it.
+
+6. **No conversation memory across sessions.** Each conversation is independent. The agent has no awareness of previous conversations with the same user, previous lesson plans, or the broader history. This is explicitly called out as a future requirement in `ai-agent-features-lanttern.md`.
+
+7. **Text-only tool call results.** When the AI creates a lesson, the chat shows a text confirmation. There are no rich UI components rendered inline in the conversation (also identified as a future goal).
+
+8. **Single provider dependency.** Both libraries are configured exclusively for OpenAI. There's no abstraction layer for switching providers, though ReqLLM and LangChain both support multiple providers in theory.
+
+---
+
+## 9. File Reference Index
+
+### Core AI Modules
+| File | Purpose |
+|------|---------|
+| `lib/lanttern/agent_chat.ex` | Agent Chat context — orchestration, LLM chain, system prompts |
+| `lib/lanttern/agents.ex` | Agent CRUD context |
+| `lib/lanttern/agents/agent.ex` | Agent Ecto schema |
+| `lib/lanttern/agent_chat/conversation.ex` | Conversation schema |
+| `lib/lanttern/agent_chat/message.ex` | Message schema |
+| `lib/lanttern/agent_chat/model_call.ex` | Token tracking schema |
+| `lib/lanttern/agent_chat/strand_conversation.ex` | Strand/lesson link schema |
+| `lib/lanttern/workers/chat_response_worker.ex` | Oban worker for async LLM calls |
+| `lib/lanttern/school_config.ex` | School config context (includes AI config CRUD) |
+| `lib/lanttern/school_config/ai_config.ex` | School AI config schema |
+| `lib/lanttern/ilp.ex` | ILP context (includes `revise_student_ilp/5`) |
+| `lib/lanttern/ilp/ilp_template_ai_layer.ex` | ILP template AI layer schema |
+| `lib/lanttern/ilp/student_ilp.ex` | Student ILP schema (AI fields + ai_changeset) |
+| `lib/lanttern/audit_log.ex` | Shared audit log with `is_ai_agent` flag support |
+| `lib/lanttern/lessons/lesson_log.ex` | Lesson audit log (includes `is_ai_agent` field) |
+
+### UI Layer
+| File | Purpose |
+|------|---------|
+| `lib/lanttern_web/components/ai_components.ex` | AI panel overlay, floating button, action bar |
+| `lib/lanttern_web/components/core_components.ex` | ai_box, ai_generated_content_disclaimer |
+| `lib/lanttern_web/live/shared/agent_chat/conversation_component.ex` | Chat conversation UI |
+| `lib/lanttern_web/live/shared/agent_chat/agent_preferences_overlay_component.ex` | User AI preferences |
+| `lib/lanttern_web/live/shared/agent_chat/rename_conversation_form_component.ex` | Conversation rename |
+| `lib/lanttern_web/live/pages/strands/id/chat/strand_chat_live.ex` | Strand-level chat page |
+| `lib/lanttern_web/live/pages/strands/lesson/id/chat/lesson_chat_live.ex` | Lesson-level chat page |
+| `lib/lanttern_web/live/pages/settings/agents/agents_settings_live.ex` | Agent management settings |
+| `lib/lanttern_web/live/pages/settings/school_ai_config/school_ai_config_live.ex` | School AI config settings |
+| `lib/lanttern_web/live/shared/ilp/student_ilp_ai_revision_overlay_component.ex` | ILP revision overlay |
+| `lib/lanttern_web/live/shared/ilp/student_ilp_ai_revision_action_bar_component.ex` | ILP revision action bar |
+
+### Config & Test
+| File | Purpose |
+|------|---------|
+| `config/config.exs` | LangChain config, Oban queue setup |
+| `config/runtime.exs` | Runtime LangChain + ReqLLM API key config |
+| `config/test.exs` | Oban testing: :manual |
+| `test/support/stubs/req_llm.ex` | ReqLLM test stub |
+| `mix.exs` | Dependencies: langchain, req_llm, llm_db |

--- a/exploration/ai-oriented-features/issue.md
+++ b/exploration/ai-oriented-features/issue.md
@@ -1,0 +1,117 @@
+# What?
+
+This project is about setting up the base for the AI agent(s) structure we'll be iterating for the rest of the year. We can consider this Lanttern's 2026 core feature.
+
+## Current implementation
+
+We've recently deployed an AI lesson planner agent in Lanttern.
+
+It's a basic chat UI available in two contexts: on the strand level, and on the lesson level. The agent features can be summarized in two groups: system messages injection and tool calling.
+
+We use **system messages injection** to add context to the conversation:
+
+- **Strand and lesson information**
+- **Custom "agents" instructions**: we have a school agents management area, where users with required permissions can manage school-level AI preferences (always applied) and custom agents settings (depends on user agent selection)
+  - School settings: AI model, knowledge base, guardrails
+  - Agent settings: personality, knowledge base, instructions, guardrails
+- **Lesson templates**: it's the lesson expected output format. Two fields: "about" (add information about the pedagogical proposal of the template) and "template" (the template itself, the format definition)
+- **User information**: name (so the AI can refer to the user using their name, feeling more personalized) and preferences (a layer of user-defined AI interaction preferences)
+- **Tools args**: we add a specific system message to inform moments, subjects, and tags ids — needed on lesson creation
+
+And we currently have **two functions** supported:
+
+- Create lesson
+- Update lesson
+
+Summarized version:
+
+| System messages | Functions |
+|-----------------|-----------|
+| School settings | Create lesson |
+| Agents | Update lesson |
+| Staff member info | |
+| Lesson template | |
+| Strand info | |
+| Lesson info | |
+| Tool args | |
+
+### Oban jobs
+
+Because LLM messages may take some time to process, I also implemented a simple Oban job to help manage those.
+
+## Issues
+
+This initial implementation was designed as a proof of concept (POC), and as such there are two things we need to improve:
+
+1. **Minor adjustments before making it available to teachers**: even considering it a v0/experimental feature, there are some issues we need to address (e.g. limit tokens per user to ensure at least some level of usage control — other suggested enhancements detailed in the So What section)
+
+2. **Better architecture**: considering agentic AI is one of the main 2026 features in Lanttern, we know in advance that this is something we'll iterate a lot. To reduce the chances of this initial POC feature snowballing into a huge mess, I think it's a good idea to use this first sprint to do some refactoring and define at least an initial (and informed) architectural direction.
+
+---
+
+# So What?
+
+Considering the context and the exploratory nature of this project, we'll have one objective goal for the sprint (to avoid spending 4 weeks without a clear deliverable) but it's expected that at least part of the technical aspects will be incorporated into the deliverable.
+
+## Deliverable: AI lesson planning v0
+
+TBD
+
+## Technical aspects
+
+There are two macro definitions to focus on:
+
+1. **Libraries for LLM interaction**
+2. **System architecture**
+
+And one subject to think about (with actual development impact starting on next sprint, probably):
+
+3. **Agent observability, evaluation, etc.**
+
+---
+
+### Libraries for LLM interaction
+
+The current implementation uses an Elixir implementation of LangChain. The initial idea was to use some library to avoid creating our own modules to handle API calling, response management/formating, and etc. (i.e. to avoid reinventing the wheel), and I choose the LangChain implementation because it's one of the established ways of interacting with LLMs in other languages.
+
+On further research and study (and after having the opportunity to develop a feature using langchain), I think we can redefine the "tech stack" for Lanttern/LLM interaction. It's always hard to make this type of decision, especially when everything is new and there's no one default/standard implementation, but that being said, I suggest we look into the **Jido ecosystem**.
+
+I've already reimplemented an old AI feature using req_llm (part of the Jido ecosystem) and I think it looks promising.
+
+Considering the current implementation, my suggestion is to simply replace the langchain implementation with req_llm, while we evaluate the idea of bringing in Jido (which is more opinionated) to replace even the Oban job, serving as our core lib/tech stack to manage our agents.
+
+---
+
+### System architecture
+
+Considering the future vision for agents in Lanttern, it's important to review the current system architecture (DB, processes, etc.).
+
+The expected output is a plan: how we are thinking about the architecture taking into consideration all of the agents' requirements in terms of UX and features, at the same time we're taking care of designing a sustainable system (cost, performance).
+
+We don't need to rush with the implementation: this should be spread across this and future sprints.
+
+**Concepts we should take into consideration:**
+
+- **User memory**: it's expected that each user will have lots of conversations with agents; the idea here is that on each new conversation, the agent should be aware of previous conversations with the same user, their preferences, and etc.
+
+- **Conversation context**: instead of creating multiple conversational UIs based on the context, we want to do the opposite — a single universal conversational UI that is "context aware". In this initial iteration, we'll focus on the already existing strand and lesson context, but this scope will expand as we move forward with the development.
+
+- **Integrated UI components**: as we're aiming to have a single conversational UI, we should spend a lot of time working on UX enhancements. One of the "features" we want to implement on the AI chat is the integration with custom UI components. For example, in the current implementation, when the AI runs the "create lesson" action, it just writes in the chat "The lesson was created" (and some other details, but still just text); it would be amazing to render a lesson card preview in the chat UI, for a better user experience.
+
+- **Integration with files**: we should consider that part of the interactions will involve file uploads. Example: "Create a lesson plan based on the content from this PDF".
+
+---
+
+### Agent platform (observability, evaluation, ...)
+
+Most of the major LLM services providers have their "AI/agent platform" offering (e.g. OpenAI, Mistral's Forge and Studio, and many others).
+
+This is a hard decision, because there are many advantages and disadvantages for every option — including spinning our own solution.
+
+In the same way we won't solve the full system architecture in a single sprint, it's not expected that we'll solve this platform issue soon. But it's important to keep this in our radar.
+
+**The main aspects to take into account in this decision are:**
+
+- **Data ownership**: the main idea here is that schools using Lanttern own their data - period. That being said, there's a lot of nuances and details in this. For example: even if we keep all of the exchanged messages between the user and the LLM, on consuming an OpenAI API for example, some of the data is also registered in the OpenAI Platform. Having this being stored in the provider is ok (as long as they don't use this for model training), the question is the next step: if we use the model evaluation and fine tuning features in the OpenAI platform, this is data that will live only in the OpenAI DB, not Lanttern's. Is this an issue, or a price to pay for not having to develop our own AI management platform?
+
+- **Vendor lock-in**: continuing on the scenario above, another issue of using the OpenAI platform is that it will work only for GPT models. What if we decide to use Google, Anthropic, Kimi, or any other model in the future? What if our system architecture relies on mixing different models from different providers?

--- a/exploration/ai-oriented-features/useful-links.md
+++ b/exploration/ai-oriented-features/useful-links.md
@@ -1,0 +1,242 @@
+# Useful Links
+
+Reference links collected during the AI agent architecture research.
+
+> **Note:** All links below were found by AI via automated web searches. They have not been individually verified by a human — URLs may be outdated, moved, or contain inaccurate information. Use as starting points for further investigation.
+
+---
+
+## Links found by human (verified or shared directly)
+
+These links were provided or verified by team members during discussions.
+
+### Vercel AI SDK
+
+- [AI SDK — Official docs](https://ai-sdk.dev/docs/introduction)
+- [AI SDK UI docs](https://ai-sdk.dev/docs/ai-sdk-ui)
+- [Multi-Step & Generative UI — Vercel Academy](https://vercel.com/academy/ai-sdk/multi-step-and-generative-ui)
+- [AI SDK Python Streaming — Template](https://vercel.com/templates/next.js/ai-sdk-python-streaming)
+- [vercel-labs/ai-sdk-preview-python-streaming — GitHub](https://github.com/vercel-labs/ai-sdk-preview-python-streaming)
+- [vercel/ai — Next.js + FastAPI example](https://github.com/vercel/ai/tree/main/examples/next-fastapi)
+- [Python AI SDK — Docs](https://pythonaisdk.mintlify.app/)
+- [python-ai-sdk/sdk — GitHub](https://github.com/python-ai-sdk/sdk)
+- [LangChain vs Vercel AI SDK vs OpenAI SDK: 2026 Guide](https://strapi.io/blog/langchain-vs-vercel-ai-sdk-vs-openai-sdk-comparison-guide)
+- [Any concrete drawbacks from using Vercel’s AI SDK? — r/LocalLLaMA](https://www.reddit.com/r/LocalLLaMA/comments/1nxmfz7/any_concrete_drawbacks_from_using_vercels_ai_sdk/)
+- [Confused between AI SDK and LangChain — r/LangChain](https://www.reddit.com/r/LangChain/comments/1fie8ul/confused_between_ai_sdk_and_langchain/)
+- [Tutorials for integrating Vercel AI SDK UI with FastAPI — r/LangChain](https://www.reddit.com/r/LangChain/comments/1ii2gqz/tutorials_for_integrating_vercel_ai_sdk_ui_with/)
+
+### CopilotKit
+
+- [CopilotKit — Product](https://www.copilotkit.ai/product)
+- [CopilotKit — Examples](https://www.copilotkit.ai/examples)
+- [CopilotKit — AG-UI Protocol page](https://www.copilotkit.ai/ag-ui)
+- [Agent Streams Are Tricky, Here’s How We Got Ours to Make Sense](https://www.copilotkit.ai/blog/agent-streams-are-tricky-heres-how-we-got-ours-to-make-sense)
+- [How To Build Fullstack Agent Apps (Gemini, CopilotKit & LangGraph)](https://www.copilotkit.ai/blog/heres-how-to-build-fullstack-agent-apps-gemini-copilotkit-langgraph)
+- [AG-UI and A2UI Explained: How the Emerging Agentic Stack Fits Together](https://www.copilotkit.ai/blog/ag-ui-and-a2ui-explained-how-the-emerging-agentic-stack-fits-together)
+- [The State of Agentic UI: Comparing AG-UI, MCP-UI, and A2A Protocols](https://www.copilotkit.ai/blog/the-state-of-agentic-ui-comparing-ag-ui-mcp-ui-and-a2ui-protocols)
+
+### AG-UI Protocol
+
+- [AG-UI Overview — Official docs](https://docs.ag-ui.com/introduction)
+- [AG-UI Core Architecture](https://docs.ag-ui.com/concepts/architecture)
+- [ag-ui-protocol/ag-ui — GitHub](https://github.com/ag-ui-protocol/ag-ui)
+- [Introducing AG-UI: The Protocol Where Agents Meet Users](https://www.copilotkit.ai/blog/introducing-ag-ui-the-protocol-where-agents-meet-users)
+- [Demystifying AG-UI: What It Is and Why It Matters](https://medium.com/@amananwari/demystifying-ag-ui-what-it-is-and-why-it-matters-2518d9cdbe98)
+- [What is AG-UI? Protocol Stack Addressing Critical Gaps — Mindflow](https://mindflow.io/blog/what-is-ag-ui)
+- [AG-UI: What Backend and Frontend Developers Should Know](https://levelup.gitconnected.com/agui-agent-to-ui-protocol-what-should-backend-and-frontend-developers-know-25a7a1ddf1f8)
+
+### assistant-ui
+
+- [assistant-ui — Official site](https://www.assistant-ui.com/)
+- [AI SDK + Chat Persistence example](https://www.assistant-ui.com/examples/ai-sdk)
+
+### Comparisons & Community Discussions
+
+- [Quick evaluation of CopilotKit vs AI SDK UI — r/AI_Agents](https://www.reddit.com/r/AI_Agents/comments/1nrfm40/quick_noob_evaluation_of_copilotkit_vs_ai_sdk_ui/)
+- [Comparison between CopilotKit and assistant-ui — r/AI_Agents](https://www.reddit.com/r/AI_Agents/comments/1jh4u4m/comparison_between_copilotkit_and_assistantui/)
+- [Best UI component library for AI agents? — r/nextjs](https://www.reddit.com/r/nextjs/comments/1j8khc1/what_is_the_best_ui_component_library_for/)
+- [I Evaluated Every AI Chat UI Library in 2026 — DEV Community](https://dev.to/alexander_lukashov/i-evaluated-every-ai-chat-ui-library-in-2026-heres-what-i-found-and-what-i-built-4p10)
+- [The Complete Guide to Generative UI Frameworks in 2026](https://medium.com/@akshaychame2/the-complete-guide-to-generative-ui-frameworks-in-2026-fde71c4fa8cc)
+
+### Python Agent Frameworks
+
+- [google/adk-python — Google Agent Development Kit](https://github.com/google/adk-python)
+
+---
+
+## Links found by AI (web search during research sessions)
+
+These links were discovered by AI agents during automated web searches. They have not been individually verified by a human — URLs may be outdated, moved, or contain inaccurate information. Use as starting points for further investigation.
+
+## Elixir AI Ecosystem
+
+### ReqLLM (Recommended LLM client)
+- [GitHub](https://github.com/agentjido/req_llm)
+- [HexDocs](https://hexdocs.pm/req_llm/readme.html)
+- [Introducing ReqLLM](https://elixirmerge.com/p/introducing-reqllm-an-elixir-client-for-llm-interactions)
+
+### Jido (Agent framework — future consideration)
+- [GitHub — jido](https://github.com/agentjido/jido)
+- [GitHub — jido_ai](https://github.com/agentjido/jido_ai)
+- [Official site](https://jido.run/)
+- [Integrating AI into Elixir with Jido](https://www.appunite.com/blog/integrating-generative-ai-into-elixir-based-applications-by-using-the-jido-agentic-framework)
+- [HN: Jido 2.0](https://news.ycombinator.com/item?id=47263036)
+
+### Elixir + AI Architecture
+- [Why Elixir is Perfect for AI Agents at Scale](https://elixirator.com/blog/elixir-for-ai-agents/)
+- [Phoenix Creator: Elixir is AI's Best Language](https://thenewstack.io/phoenix-creator-argues-elixir-is-ai-best-language/)
+- [Orchestrating AI Agents with Elixir's Actor Model](https://www.freshcodeit.com/blog/why-elixir-is-the-best-runtime-for-building-agentic-workflows)
+- [Building AI Agents using Oban](https://medium.com/@adwaykasture00/building-ai-agents-using-oban-2e2643711501)
+- [Multi-Agent AI on Elixir + Bare Metal](https://openmetal.io/resources/blog/multi-agent-ai-elixir-bare-metal/)
+
+---
+
+## Frontend — Chat UI Libraries
+
+### Vercel AI SDK
+- [Official docs](https://ai-sdk.dev/docs/introduction)
+- [Stream Protocol docs](https://ai-sdk.dev/docs/ai-sdk-ui/stream-protocol)
+- [Streaming custom data](https://ai-sdk.dev/docs/ai-sdk-ui/streaming-data)
+- [LangChain adapter](https://ai-sdk.dev/providers/adapters/langchain)
+- [Python streaming template](https://vercel.com/templates/next.js/ai-sdk-python-streaming)
+- [Flask template](https://vercel.com/templates/ai/ai-sdk-with-flask)
+
+### CopilotKit + AG-UI Protocol
+- [CopilotKit — GitHub](https://github.com/CopilotKit/CopilotKit)
+- [CopilotKit — Official site](https://www.copilotkit.ai/)
+- [AG-UI Protocol — Docs](https://docs.ag-ui.com/)
+- [AG-UI Protocol — GitHub](https://github.com/ag-ui-protocol/ag-ui/)
+- [Introducing AG-UI](https://webflow.copilotkit.ai/blog/introducing-ag-ui-the-protocol-where-agents-meet-users)
+- [Frontend for LangChain Agents with CopilotKit](https://www.copilotkit.ai/blog/how-to-build-a-frontend-for-langchain-deep-agents-with-copilotkit)
+- [LangGraph Agent UI in Minutes](https://www.copilotkit.ai/blog/easily-build-a-ui-for-your-ai-agent-in-minutes-langgraph-copilotkit)
+- [Add MCP Client to React in 30 Minutes](https://www.copilotkit.ai/blog/add-an-mcp-client-to-any-react-app-in-under-30-minutes)
+- [CopilotKit vs Assistant UI comparison](https://champsignal.com/comparisons/copilotkit.ai-vs-assistant-ui.com)
+
+### assistant-ui
+- [GitHub](https://github.com/assistant-ui/assistant-ui)
+- [Docs — LangGraph integration](https://www.assistant-ui.com/docs/runtimes/langgraph)
+- [LangChain blog: assistant-ui](https://blog.langchain.com/assistant-ui/)
+- [FastAPI + LangGraph example](https://github.com/Yonom/assistant-ui-langgraph-fastapi)
+
+### Python Backend + Vercel AI SDK
+- [fastapi-ai-sdk — PyPI](https://pypi.org/project/fastapi-ai-sdk/)
+- [fastapi-ai-sdk — GitHub](https://github.com/doganarif/fastapi-ai-sdk)
+- [py-ai-datastream — GitHub](https://github.com/elementary-data/py-ai-datastream)
+- [ai-sdk-python — PyPI](https://pypi.org/project/ai-sdk-python/)
+- [Building a Python-Native Backend for AI Chat](https://www.elementary-data.com/post/building-a-python-native-backend-for-ai-chat-streaming)
+
+### Phoenix + React Integration
+- [React Islands + LiveView](https://hexshift.medium.com/integrating-tailwind-react-islands-and-elixir-phoenix-liveview-for-modern-ui-delivery-185964fe4320)
+- [phoenix-islands/react — npm](https://www.npmjs.com/package/@phoenix-islands/react)
+- [phoenix_live_react — GitHub](https://github.com/fidr/phoenix_live_react)
+- [React in LiveView: How and Why?](https://stephenbussey.com/2022/04/13/react-in-liveview-how-and-why.html)
+- [React and Phoenix LiveView in 2022](https://blog.nootch.net/post/react-and-phoenix-liveview-2022/)
+
+---
+
+## Python AI Ecosystem
+
+### Agent Frameworks
+- [LangGraph — Streaming Docs](https://docs.langchain.com/oss/python/langgraph/streaming)
+- [LangChain — Release Policy](https://docs.langchain.com/oss/python/release-policy)
+- [LangChain Tools and Agents 2026](https://langchain-tutorials.github.io/langchain-tools-agents-2026/)
+- [CrewAI — Official site](https://www.crewai.com/)
+- [LlamaIndex — Official site](https://www.llamaindex.ai/)
+- [Pydantic AI — Docs](https://docs.pydantic.dev/latest/concepts/agents/)
+- [DSPy — GitHub](https://github.com/stanfordnlp/dspy)
+- [Instructor — GitHub](https://github.com/jxnl/instructor)
+- [Best AI Agent Frameworks 2025](https://www.getmaxim.ai/articles/top-5-ai-agent-frameworks-in-2025-a-practical-guide-for-ai-builders/)
+- [LlamaIndex vs CrewAI Comparison](https://www.zenml.io/blog/llamaindex-vs-crewai)
+- [Pydantic AI vs Instructor](https://medium.com/@mahadevan.varadhan/pydanticai-vs-instructor-structured-llm-ai-outputs-with-python-tools-c7b7b202eb23)
+- [Choosing the Best AI Agent Framework 2025](https://fashn.ai/blog/choosing-the-best-ai-agent-framework-in-2025)
+
+### TypeScript Agent Frameworks
+- [Vercel AI SDK vs Mastra vs LangChain.js](https://buttondown.com/vadima/archive/vercel-ai-sdk-vs-mastra-vs-langchainjs-which/)
+- [LangGraph vs CrewAI vs OpenAI Agents — TS](https://langgraphjs.guide/comparison/)
+- [Streaming LangGraph Agent Responses in TypeScript](https://langgraphjs.guide/streaming/)
+
+### Evaluation Frameworks
+- [DeepEval — GitHub](https://github.com/confident-ai/deepeval)
+- [RAGAS — GitHub](https://github.com/explodinggradients/ragas)
+- [PromptFoo — GitHub](https://github.com/promptfoo/promptfoo)
+- [Top 5 AI Evaluation Frameworks 2025](https://www.gocodeo.com/post/top-5-ai-evaluation-frameworks-in-2025-from-ragas-to-deepeval-and-beyond)
+
+### Memory Systems
+- [mem0 — GitHub](https://github.com/mem0ai/mem0)
+- [Letta (MemGPT) — GitHub](https://github.com/letta-ai/letta)
+
+### RAG & Document Processing
+- [Building Production RAG Systems in 2026](https://brlikhon.engineer/blog/building-production-rag-systems-in-2026-complete-tutorial-with-langchain-pinecone)
+
+### LangGraph Streaming + FastAPI
+- [Streaming AI Agent with FastAPI & LangGraph](https://dev.to/kasi_viswanath/streaming-ai-agent-with-fastapi-langgraph-2025-26-guide-1nkn)
+- [SSE with FastAPI, React & LangGraph](https://www.softgrade.org/sse-with-fastapi-react-langgraph/)
+- [FastAPI for LangGraph Agents](https://mlvector.com/2025/06/30/30daysoflangchain-day-25-fastapi-for-langgraph-agents-streaming-responses/)
+- [LangGraph_Streaming — GitHub](https://github.com/sheikhhanif/LangGraph_Streaming)
+- [agent-service-toolkit — GitHub](https://github.com/JoshuaC215/agent-service-toolkit)
+- [langgraph_openai_serve — PyPI](https://pypi.org/project/langgraph_openai_serve/)
+- [FastAPI + Celery Production Guide](https://medium.com/@dewasheesh.rana/celery-redis-fastapi-the-ultimate-2025-production-guide-broker-vs-backend-explained-5b84ef508fa7)
+
+### Provider SDKs
+- [OpenAI Python SDK — GitHub](https://github.com/openai/openai-python)
+- [Anthropic Python SDK — GitHub](https://github.com/anthropics/anthropic-sdk-python)
+
+---
+
+## Observability
+
+### Langfuse
+- [Official docs](https://langfuse.com/docs)
+- [GitHub](https://github.com/langfuse/langfuse)
+- [Self-hosting guide](https://langfuse.com/self-hosting)
+- [Docker Compose deployment](https://langfuse.com/self-hosting/deployment/docker-compose)
+- [Kubernetes (Helm) deployment](https://langfuse.com/self-hosting/deployment/kubernetes-helm)
+- [OpenTelemetry integration](https://langfuse.com/integrations/native/opentelemetry)
+- [Public API reference](https://api.reference.langfuse.com/)
+- [Pricing — Cloud](https://langfuse.com/pricing)
+- [Pricing — Self-hosted](https://langfuse.com/pricing-self-host)
+- [GDPR compliance](https://langfuse.com/security/gdpr)
+- [V4 Architecture](https://langfuse.com/changelog/2026-03-10-simplify-for-scale)
+- [ClickHouse + Langfuse](https://clickhouse.com/blog/langfuse-and-clickhouse-a-new-data-stack-for-modern-llm-applications)
+- [Community Elixir SDK](https://github.com/workera-ai/langfuse_sdk)
+
+### Alternatives
+- [LangSmith — Observability](https://www.langchain.com/langsmith/observability)
+- [LangSmith vs Langfuse vs Helicone](https://getathenic.com/blog/langsmith-vs-helicone-vs-langfuse-comparison)
+- [LangSmith Agent Tracing Techniques](https://sparkco.ai/blog/advanced-langsmith-tracing-techniques-in-2025)
+- [LangSmith and AgentOps](https://www.akira.ai/blog/langsmith-and-agentops-with-ai-agents)
+
+---
+
+## Microservice Architecture
+
+### Patterns & Analysis
+- [AI Gateway as Critical Infrastructure](https://www.adwaitx.com/ai-gateway-higress-2025-infrastructure/)
+- [Microservices for AI Applications](https://medium.com/@meeran03/microservices-architecture-for-ai-applications-scalable-patterns-and-2025-trends-5ac273eac232)
+- [gRPC vs REST Benchmarks 2025](https://markaicode.com/grpc-vs-rest-benchmarks-2025/)
+- [Communication Styles for Microservices](https://medium.com/@platform.engineers/a-deep-dive-into-communication-styles-for-microservices-rest-vs-grpc-vs-message-queues-ea72011173b3)
+
+### Industry Data
+- [Microservices vs Monoliths: When Each Wins](https://www.javacodegeeks.com/2025/12/microservices-vs-monoliths-in-2026-when-each-architecture-wins.html)
+- [Monolith vs Microservices: Real Cloud Migration Costs](https://medium.com/@pawel.piwosz/monolith-vs-microservices-2025-real-cloud-migration-costs-and-hidden-challenges-8b453a3c71ec)
+- [When Amazon Cuts Costs 90%](https://byteiota.com/monolith-vs-microservices-2025-when-amazon-cuts-costs-90/)
+- [42% Ditch Microservices in 2026](https://byteiota.com/modular-monolith-42-ditch-microservices-in-2026/)
+- [How Notion Workers Run Untrusted Code at Scale](https://vercel.com/blog/notion-workers-vercel-sandbox)
+- [Notion MCP Integration with Vercel AI SDK](https://composio.dev/toolkits/notion/framework/ai-sdk)
+
+### Vector Databases
+- [Top 9 Vector Databases 2026](https://www.shakudo.io/blog/top-9-vector-databases)
+- [Pinecone vs Weaviate vs Qdrant vs pgvector](https://getathenic.com/blog/pinecone-vs-weaviate-vs-qdrant-vs-pgvector)
+- [Best Vector Databases 2025](https://www.firecrawl.dev/blog/best-vector-databases)
+
+---
+
+## Background Jobs
+- [BullMQ Elixir vs Oban Benchmark](https://bullmq.io/articles/benchmarks/bullmq-elixir-vs-oban/)
+
+---
+
+## Hiring & Community
+- [Octoverse: TypeScript Overtakes Python on GitHub](https://github.blog/news-insights/octoverse/octoverse-a-new-developer-joins-github-every-second-as-ai-leads-typescript-to-1/)
+- [TypeScript vs Python: Which to Choose 2026](https://www.leanware.co/insights/typescript-vs-python)
+- [Best AI Programming Languages 2026](https://www.solutelabs.com/blog/best-ai-programming-languages)


### PR DESCRIPTION
  Summary

  Adds the exploration/ directory — a dedicated space for exploratory research documents, architecture analysis, and design
  investigations that inform technical decisions but are not runnable code.

  This first batch contains the AI agent architecture research for Lanttern's 2026 roadmap:

  - As-is analysis of current AI features (Agent Chat with LangChain, ILP Revision with ReqLLM)
  - Architecture plan with 8 architectural decisions, 4 deep dives (Vercel AI SDK, Langfuse, microservice ecosystems, frontend stack
  comparison), target architecture, DB schema evolution, and 5-phase implementation roadmap
  - Q&A document with 17 sections anticipating developer questions across all decisions
  - Both plan and Q&A available in English and Portuguese                                                                                 
                                              
  Test plan                                                                                                                             
                                                            
  - No code changes — documentation only                                                                                                
  - Review documents for accuracy against current codebase
  - Team reads and discusses architectural decisions   