### PR TITLE
fix(assessments): use short_name in entry badge and fix particle width

### DIFF
--- a/lib/lanttern_web/components/assessments_components.ex
+++ b/lib/lanttern_web/components/assessments_components.ex
@@ -20,7 +20,7 @@ defmodule LantternWeb.AssessmentsComponents do
 
   attr :is_short, :boolean,
     default: false,
-    doc: "Displays only the first 3 letters of the ordinal value"
+    doc: "Displays the ordinal value short_name, falling back to first 3 chars of name"
 
   attr :show_stop, :boolean,
     default: false,
@@ -34,7 +34,7 @@ defmodule LantternWeb.AssessmentsComponents do
       ) do
     ov_name =
       if assigns.is_short do
-        String.slice(assigns.entry.ordinal_value.name, 0..2)
+        assigns.entry.ordinal_value.short_name || String.slice(assigns.entry.ordinal_value.name, 0..2)
       else
         assigns.entry.ordinal_value.name
       end

--- a/lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex
+++ b/lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex
@@ -272,7 +272,6 @@ defmodule LantternWeb.StrandReportLive.StrandReportAssessmentComponent do
                 module={EntryParticleComponent}
                 id={moment_entry.id}
                 entry={moment_entry}
-                class="flex-1"
               />
             </div>
           </div>

--- a/lib/lanttern_web/live/shared/assessments/entry_particle_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_particle_component.ex
@@ -30,8 +30,8 @@ defmodule LantternWeb.Assessments.EntryParticleComponent do
       class={[
         "flex items-center justify-center rounded-full font-sans",
         if(@size == "sm",
-          do: "min-w-4 h-4 w-auto px-1 text-xs",
-          else: "min-w-6 h-6 w-auto px-1 text-sm"
+          do: "min-w-4 h-4 px-1 text-xs",
+          else: "min-w-6 h-6 px-1 text-sm"
         ),
         @additional_classes,
         @class

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2026.4.17-alpha.91",
+      version: "2026.4.17-alpha.92",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Summary

Fixes two visual issues with assessment point entry particles: badges now use `short_name` when available for compact display, and particles no longer have `w-auto` preventing them from filling their container width in the tracking grid.

### Related Issues

- Closes #519

### What This PR Does

- **Entry badge short mode**: In compact (`is_short`) display mode, the entry badge now uses the ordinal value's `short_name` field, falling back to the first 3 characters of `name` if `short_name` is not set
- **Entry particle width fix**: Removes `w-auto` from the particle's Tailwind classes so particles can properly fill available width when placed in a flex or grid container (e.g. the strand report tracking grid)
- **Strand report cleanup**: Removes the `flex-1` override on `EntryParticleComponent` in the strand report assessment component, as the component now handles width correctly on its own

### Impact and Scope

- Affects assessment entry display across the tracking grid and strand reports
- No data model changes; purely UI/presentation fixes

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>