### PR TITLE
fix(curricula): pass current_scope to CurriculumItemSearchComponent in assessment point form

### DIFF
--- a/lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex
@@ -69,6 +69,7 @@ defmodule LantternWeb.Assessments.AssessmentPointFormOverlayComponent do
             <.live_component
               module={CurriculumItemSearchComponent}
               id="curriculum-item-search"
+              current_scope={@current_scope}
               notify_component={@myself}
               label={gettext("Curriculum")}
             />

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2026.4.17-alpha.92",
+      version: "2026.4.17-alpha.93",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
### Summary

Fixes a bug where the `CurriculumItemSearchComponent` inside the assessment point form overlay was not receiving the `current_scope`, causing curriculum search to fail or return incorrect results.

### What This PR Does

- Passes `current_scope` to `CurriculumItemSearchComponent` in `AssessmentPointFormOverlayComponent`, ensuring the curriculum search respects the current school/user scope

### Impact and Scope

- Affects the assessment point creation/editing flow
- Only touches `AssessmentPointFormOverlayComponent`

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>