### PR TITLE
fix(grades-reports): use Decimal to floor composition normalized value

### DIFF
--- a/lib/lanttern_web/components/assessments_components.ex
+++ b/lib/lanttern_web/components/assessments_components.ex
@@ -34,7 +34,8 @@ defmodule LantternWeb.AssessmentsComponents do
       ) do
     ov_name =
       if assigns.is_short do
-        assigns.entry.ordinal_value.short_name || String.slice(assigns.entry.ordinal_value.name, 0..2)
+        assigns.entry.ordinal_value.short_name ||
+          String.slice(assigns.entry.ordinal_value.name, 0..2)
       else
         assigns.entry.ordinal_value.name
       end

--- a/lib/lanttern_web/components/grades_reports_components.ex
+++ b/lib/lanttern_web/components/grades_reports_components.ex
@@ -1104,9 +1104,9 @@ defmodule LantternWeb.GradesReportsComponents do
             </td>
             <td colspan="2" class="p-2 text-right">
               {@student_grades_report_entry.composition_normalized_value
-               |> Decimal.from_float()
-               |> Decimal.round(2, :floor)
-               |> Decimal.to_string()}
+              |> Decimal.from_float()
+              |> Decimal.round(2, :floor)
+              |> Decimal.to_string()}
             </td>
           </tr>
         </tbody>
@@ -1171,9 +1171,9 @@ defmodule LantternWeb.GradesReportsComponents do
             </td>
             <td class="p-2 text-right">
               {@student_grades_report_final_entry.composition_normalized_value
-               |> Decimal.from_float()
-               |> Decimal.round(2, :floor)
-               |> Decimal.to_string()}
+              |> Decimal.from_float()
+              |> Decimal.round(2, :floor)
+              |> Decimal.to_string()}
             </td>
           </tr>
         </tbody>

--- a/lib/lanttern_web/components/grades_reports_components.ex
+++ b/lib/lanttern_web/components/grades_reports_components.ex
@@ -1103,10 +1103,10 @@ defmodule LantternWeb.GradesReportsComponents do
               end}
             </td>
             <td colspan="2" class="p-2 text-right">
-              {:erlang.float_to_binary(
-                Float.floor(@student_grades_report_entry.composition_normalized_value, 2),
-                decimals: 2
-              )}
+              {@student_grades_report_entry.composition_normalized_value
+               |> Decimal.from_float()
+               |> Decimal.round(2, :floor)
+               |> Decimal.to_string()}
             </td>
           </tr>
         </tbody>
@@ -1170,10 +1170,10 @@ defmodule LantternWeb.GradesReportsComponents do
               end}
             </td>
             <td class="p-2 text-right">
-              {:erlang.float_to_binary(
-                Float.floor(@student_grades_report_final_entry.composition_normalized_value, 2),
-                decimals: 2
-              )}
+              {@student_grades_report_final_entry.composition_normalized_value
+               |> Decimal.from_float()
+               |> Decimal.round(2, :floor)
+               |> Decimal.to_string()}
             </td>
           </tr>
         </tbody>

--- a/mix.exs
+++ b/mix.exs
@@ -99,7 +99,8 @@ defmodule Lanttern.MixProject do
       {:llm_db, "~> 2026.3.1"},
       {:live_react, "~> 1.1.0"},
       {:floki, "~> 0.38.0", only: :test},
-      {:colorex, "~> 1.0"}
+      {:colorex, "~> 1.0"},
+      {:decimal, "~> 2.0"}
     ]
   end
 

--- a/test/lanttern_web/components/grades_reports_components_test.exs
+++ b/test/lanttern_web/components/grades_reports_components_test.exs
@@ -1,0 +1,27 @@
+defmodule LantternWeb.GradesReportsComponentsTest do
+  use Lanttern.DataCase, async: true
+  import Phoenix.LiveViewTest
+
+  alias LantternWeb.GradesReportsComponents
+  alias Lanttern.GradesReports.StudentGradesReportEntry
+
+  describe "grade_composition_table/1" do
+    test "rounds composition_normalized_value down to 2 decimal places without floating-point error" do
+      # 0.99 in IEEE 754 is ~0.98999..., so Float.floor(0.99, 2) = 0.98 (bug)
+      entry = %StudentGradesReportEntry{
+        composition: [],
+        composition_ordinal_value: nil,
+        composition_score: 10.0,
+        composition_normalized_value: 0.99
+      }
+
+      html =
+        render_component(
+          &GradesReportsComponents.grade_composition_table/1,
+          student_grades_report_entry: entry
+        )
+
+      assert html =~ "0.99"
+    end
+  end
+end

--- a/test/lanttern_web/components/grades_reports_components_test.exs
+++ b/test/lanttern_web/components/grades_reports_components_test.exs
@@ -2,8 +2,8 @@ defmodule LantternWeb.GradesReportsComponentsTest do
   use Lanttern.DataCase, async: true
   import Phoenix.LiveViewTest
 
-  alias LantternWeb.GradesReportsComponents
   alias Lanttern.GradesReports.StudentGradesReportEntry
+  alias LantternWeb.GradesReportsComponents
 
   describe "grade_composition_table/1" do
     test "rounds composition_normalized_value down to 2 decimal places without floating-point error" do


### PR DESCRIPTION
### Summary

Fixes a floating-point precision bug where `Float.floor/2` would incorrectly floor `0.99` to `0.98` due to IEEE 754 representation, by switching to `Decimal` arithmetic for rounding composition normalized values in grade report tables.

### What This PR Does

- Replaces `:erlang.float_to_binary/2` + `Float.floor/2` with `Decimal.from_float/1` → `Decimal.round/3` (`:floor`) → `Decimal.to_string/1` in both `grade_composition_table` and `grade_composition_final_table` components
- Adds the `decimal ~> 2.0` dependency to `mix.exs`
- Adds a regression test that verifies `0.99` is displayed as `"0.99"` and not `"0.98"`

### Impact and Scope

- Affects the grade composition table display in grades reports (both standard and final entry variants)
- No schema or data changes; purely a display-layer fix

### Testing Considerations

- New test `LantternWeb.GradesReportsComponentsTest` covers the specific `0.99 → 0.98` floating-point edge case that triggered this bug

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>