### PR TITLE
fix(rubrics): pass current_scope to RubricFormOverlayComponent

### DIFF
--- a/lib/lanttern_web/live/pages/strands/id/strand_live.html.heex
+++ b/lib/lanttern_web/live/pages/strands/id/strand_live.html.heex
@@ -110,6 +110,7 @@
       id="strand-rubrics"
       strand={@strand}
       current_user={@current_user}
+      current_scope={@current_scope}
       selected_classes_ids={@selected_classes_ids}
       selected_classes_text={
         format_action_items_text(

--- a/lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex
@@ -191,6 +191,7 @@ defmodule LantternWeb.StrandLive.StrandRubricsComponent do
         id="strand-rubric-overlay"
         rubric={@rubric}
         title={@rubric_overlay_title}
+        current_scope={@current_scope}
         on_cancel={JS.patch(~p"/strands/#{@strand}/rubrics")}
         notify_component={@myself}
       />

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2026.4.17-alpha.93",
+      version: "2026.4.20-alpha.94",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/lanttern_web/live/pages/strands/id/strand_rubrics_component_test.exs
+++ b/test/lanttern_web/live/pages/strands/id/strand_rubrics_component_test.exs
@@ -1,0 +1,39 @@
+defmodule LantternWeb.StrandLive.StrandRubricsComponentTest do
+  use LantternWeb.ConnCase
+
+  import Lanttern.Factory
+  import PhoenixTest
+
+  alias Lanttern.AssessmentsFixtures
+  alias Lanttern.RubricsFixtures
+
+  @live_view_base_path "/strands"
+
+  setup [:register_and_log_in_staff_member]
+
+  describe "rubric form overlay" do
+    test "opens edit rubric overlay without scope error", %{conn: conn, user: user} do
+      school_id = user.current_profile.school_id
+      strand = insert(:strand)
+      scale = insert(:scale)
+      curriculum_item = insert(:curriculum_item, school_id: school_id)
+
+      AssessmentsFixtures.assessment_point_fixture(%{
+        strand_id: strand.id,
+        scale_id: scale.id,
+        curriculum_item_id: curriculum_item.id
+      })
+
+      rubric =
+        RubricsFixtures.rubric_fixture(%{
+          strand_id: strand.id,
+          scale_id: scale.id,
+          curriculum_item_id: curriculum_item.id
+        })
+
+      conn
+      |> visit("#{@live_view_base_path}/#{strand.id}/rubrics?edit_rubric=#{rubric.id}")
+      |> assert_has("p", text: "Rubric for curriculum item")
+    end
+  end
+end


### PR DESCRIPTION
### Summary

Fixes a bug where the rubric form overlay in the strand rubrics view was missing the `current_scope` prop, causing a scope error when opening the overlay.

### Related Issues

N/A

### What This PR Does

- Passes `current_scope` from the strand live view down to `StrandRubricsComponent`
- Forwards `current_scope` to `RubricFormOverlayComponent` so it has the authorization context it needs
- Adds a regression test that verifies the rubric edit overlay opens without a scope error

### Impact and Scope

- Affects the strand rubrics tab (`/strands/:id/rubrics`)
- Only touches the `StrandRubricsComponent` and its template — no data model or API changes

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>