### PR TITLE
fix(assessments): order attachments by position in assessment overlays

### DIFF
--- a/lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex
@@ -13,6 +13,7 @@ defmodule LantternWeb.Assessments.StrandGoalDetailsOverlayComponent do
   use LantternWeb, :live_component
 
   alias Lanttern.Assessments
+  alias Lanttern.Attachments
   alias Lanttern.Reporting
   alias Lanttern.Rubrics
 
@@ -172,8 +173,16 @@ defmodule LantternWeb.Assessments.StrandGoalDetailsOverlayComponent do
       Assessments.get_assessment_point_student_entry(
         socket.assigns.strand_goal.id,
         socket.assigns.student_id,
-        preloads: [:scale, :ordinal_value, :student_ordinal_value, :evidences]
+        preloads: [:scale, :ordinal_value, :student_ordinal_value]
       )
+
+    entry =
+      if entry do
+        evidences = Attachments.list_attachments(assessment_point_entry_id: entry.id)
+        %{entry | evidences: evidences}
+      else
+        entry
+      end
 
     assign(socket, :entry, entry)
   end

--- a/lib/lanttern_web/live/shared/assessments/student_assessment_point_details_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/student_assessment_point_details_overlay_component.ex
@@ -13,6 +13,7 @@ defmodule LantternWeb.Assessments.StudentAssessmentPointDetailsOverlayComponent 
 
   alias Lanttern.Assessments
   alias Lanttern.Assessments.AssessmentPoint
+  alias Lanttern.Attachments
   alias Lanttern.Rubrics
 
   # shared components
@@ -139,8 +140,16 @@ defmodule LantternWeb.Assessments.StudentAssessmentPointDetailsOverlayComponent 
       Assessments.get_assessment_point_student_entry(
         socket.assigns.assessment_point.id,
         socket.assigns.student_id,
-        preloads: [:scale, :ordinal_value, :student_ordinal_value, :evidences]
+        preloads: [:scale, :ordinal_value, :student_ordinal_value]
       )
+
+    entry =
+      if entry do
+        evidences = Attachments.list_attachments(assessment_point_entry_id: entry.id)
+        %{entry | evidences: evidences}
+      else
+        entry
+      end
 
     assign(socket, :entry, entry)
   end


### PR DESCRIPTION
### Summary

Fixes attachment ordering in assessment overlays by loading evidences through `Attachments.list_attachments/1` instead of via Ecto preload, ensuring they respect the position-based sort order.

### What This PR Does

- Replaces `:evidences` Ecto preload with an explicit call to `Attachments.list_attachments/1` in both the strand goal details overlay and the student assessment point details overlay
- Ensures evidences (attachments) are returned in their defined position order, which the generic Ecto preload did not guarantee

### Impact and Scope

- Affects `StrandGoalDetailsOverlayComponent` and `StudentAssessmentPointDetailsOverlayComponent`
- No breaking changes; same data shape, correct ordering

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>