### PR TITLE
Add curriculum item management to strands and lessons

### DIFF
--- a/lib/lanttern/curricula.ex
+++ b/lib/lanttern/curricula.ex
@@ -395,7 +395,12 @@ defmodule Lanttern.Curricula do
     do: apply_list_curriculum_items_opts(queryable, opts)
 
   @doc """
-  Returns the list of curriculum items linked to the given strand.
+  Returns the list of curriculum items linked to the given strand via assessment points (strand goals).
+
+  This queries curriculum items through their associated `AssessmentPoint` records where
+  `strand_id` matches. It is used to populate assessment-related UIs (e.g. the assessment
+  point form overlay). For the explicit strand curriculum tagging, see
+  `Lanttern.Strands.list_strand_curriculum_items/3`.
 
   ## Options:
 

--- a/lib/lanttern/lessons.ex
+++ b/lib/lanttern/lessons.ex
@@ -556,8 +556,13 @@ defmodule Lanttern.Lessons do
       [%LessonCurriculumItem{}, ...]
 
   """
-  def list_lesson_curriculum_items(%Scope{} = _scope) do
-    Repo.all(LessonCurriculumItem)
+  def list_lesson_curriculum_items(%Scope{} = _scope, lesson_id, opts \\ []) do
+    from(lci in LessonCurriculumItem,
+      where: lci.lesson_id == ^lesson_id,
+      order_by: [asc: lci.position]
+    )
+    |> Repo.all()
+    |> maybe_preload(opts)
   end
 
   @doc """
@@ -592,6 +597,16 @@ defmodule Lanttern.Lessons do
   """
   def create_lesson_curriculum_item(%Scope{} = scope, attrs) do
     true = Scope.profile_type?(scope, "staff")
+
+    lesson_id = Map.get(attrs, :lesson_id) || Map.get(attrs, "lesson_id")
+
+    attrs =
+      if lesson_id do
+        from(lci in LessonCurriculumItem, where: lci.lesson_id == ^lesson_id)
+        |> set_position_in_attrs(attrs)
+      else
+        attrs
+      end
 
     with {:ok, lesson_curriculum_item = %LessonCurriculumItem{}} <-
            %LessonCurriculumItem{}
@@ -670,5 +685,9 @@ defmodule Lanttern.Lessons do
         attrs \\ %{}
       ) do
     LessonCurriculumItem.changeset(lesson_curriculum_item, attrs)
+  end
+
+  def update_lesson_curriculum_items_positions(ids) do
+    update_positions(LessonCurriculumItem, ids)
   end
 end

--- a/lib/lanttern/lessons.ex
+++ b/lib/lanttern/lessons.ex
@@ -12,6 +12,7 @@ defmodule Lanttern.Lessons do
   alias Lanttern.Identity.Scope
   alias Lanttern.Lessons.Lesson
   alias Lanttern.Lessons.LessonAttachment
+  alias Lanttern.Lessons.LessonCurriculumItem
   alias Lanttern.Lessons.LessonLog
   alias Lanttern.Lessons.Tag
 
@@ -520,5 +521,154 @@ defmodule Lanttern.Lessons do
     true = Scope.has_permission?(scope, "content_management")
 
     Tag.changeset(tag, attrs, scope)
+  end
+
+  # Lesson curriculum items
+
+  @doc """
+  Subscribes to scoped notifications about any lesson_curriculum_item changes.
+
+  The broadcasted messages match the pattern:
+
+    * {:created, %LessonCurriculumItem{}}
+    * {:updated, %LessonCurriculumItem{}}
+    * {:deleted, %LessonCurriculumItem{}}
+
+  """
+  def subscribe_lesson_curriculum_items(%Scope{} = scope) do
+    key = scope.school_id
+
+    Phoenix.PubSub.subscribe(Lanttern.PubSub, "school:#{key}:lesson_curriculum_items")
+  end
+
+  defp broadcast_lesson_curriculum_item(%Scope{} = scope, message) do
+    key = scope.school_id
+
+    Phoenix.PubSub.broadcast(Lanttern.PubSub, "school:#{key}:lesson_curriculum_items", message)
+  end
+
+  @doc """
+  Returns the list of lesson_curriculum_items.
+
+  ## Examples
+
+      iex> list_lesson_curriculum_items(scope)
+      [%LessonCurriculumItem{}, ...]
+
+  """
+  def list_lesson_curriculum_items(%Scope{} = _scope) do
+    Repo.all(LessonCurriculumItem)
+  end
+
+  @doc """
+  Gets a single lesson_curriculum_item.
+
+  Raises `Ecto.NoResultsError` if the Lesson curriculum item does not exist.
+
+  ## Examples
+
+      iex> get_lesson_curriculum_item!(scope, 123)
+      %LessonCurriculumItem{}
+
+      iex> get_lesson_curriculum_item!(scope, 456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_lesson_curriculum_item!(%Scope{} = _scope, id) do
+    Repo.get!(LessonCurriculumItem, id)
+  end
+
+  @doc """
+  Creates a lesson_curriculum_item.
+
+  ## Examples
+
+      iex> create_lesson_curriculum_item(scope, %{field: value})
+      {:ok, %LessonCurriculumItem{}}
+
+      iex> create_lesson_curriculum_item(scope, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_lesson_curriculum_item(%Scope{} = scope, attrs) do
+    true = Scope.profile_type?(scope, "staff")
+
+    with {:ok, lesson_curriculum_item = %LessonCurriculumItem{}} <-
+           %LessonCurriculumItem{}
+           |> LessonCurriculumItem.changeset(attrs)
+           |> Repo.insert() do
+      broadcast_lesson_curriculum_item(scope, {:created, lesson_curriculum_item})
+      {:ok, lesson_curriculum_item}
+    end
+  end
+
+  @doc """
+  Updates a lesson_curriculum_item.
+
+  ## Examples
+
+      iex> update_lesson_curriculum_item(scope, lesson_curriculum_item, %{field: new_value})
+      {:ok, %LessonCurriculumItem{}}
+
+      iex> update_lesson_curriculum_item(scope, lesson_curriculum_item, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_lesson_curriculum_item(
+        %Scope{} = scope,
+        %LessonCurriculumItem{} = lesson_curriculum_item,
+        attrs
+      ) do
+    true = Scope.profile_type?(scope, "staff")
+
+    with {:ok, lesson_curriculum_item = %LessonCurriculumItem{}} <-
+           lesson_curriculum_item
+           |> LessonCurriculumItem.changeset(attrs)
+           |> Repo.update() do
+      broadcast_lesson_curriculum_item(scope, {:updated, lesson_curriculum_item})
+      {:ok, lesson_curriculum_item}
+    end
+  end
+
+  @doc """
+  Deletes a lesson_curriculum_item.
+
+  ## Examples
+
+      iex> delete_lesson_curriculum_item(scope, lesson_curriculum_item)
+      {:ok, %LessonCurriculumItem{}}
+
+      iex> delete_lesson_curriculum_item(scope, lesson_curriculum_item)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_lesson_curriculum_item(
+        %Scope{} = scope,
+        %LessonCurriculumItem{} = lesson_curriculum_item
+      ) do
+    true = Scope.profile_type?(scope, "staff")
+
+    with {:ok, lesson_curriculum_item = %LessonCurriculumItem{}} <-
+           Repo.delete(lesson_curriculum_item) do
+      broadcast_lesson_curriculum_item(scope, {:deleted, lesson_curriculum_item})
+      {:ok, lesson_curriculum_item}
+    end
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking lesson_curriculum_item changes.
+
+  ## Examples
+
+      iex> change_lesson_curriculum_item(scope, lesson_curriculum_item)
+      %Ecto.Changeset{data: %LessonCurriculumItem{}}
+
+  """
+  def change_lesson_curriculum_item(
+        %Scope{} = _scope,
+        %LessonCurriculumItem{} = lesson_curriculum_item,
+        attrs \\ %{}
+      ) do
+    LessonCurriculumItem.changeset(lesson_curriculum_item, attrs)
   end
 end

--- a/lib/lanttern/lessons/lesson_curriculum_item.ex
+++ b/lib/lanttern/lessons/lesson_curriculum_item.ex
@@ -1,0 +1,38 @@
+defmodule Lanttern.Lessons.LessonCurriculumItem do
+  @moduledoc """
+  The `LessonCurriculumItem` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Lanttern.Curricula.CurriculumItem
+  alias Lanttern.Lessons.Lesson
+
+  @type t :: %__MODULE__{
+          id: pos_integer(),
+          position: non_neg_integer(),
+          lesson: Lesson.t() | Ecto.Association.NotLoaded.t(),
+          lesson_id: pos_integer(),
+          curriculum_item: CurriculumItem.t() | Ecto.Association.NotLoaded.t(),
+          curriculum_item_id: pos_integer(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "lesson_curriculum_items" do
+    field :position, :integer, default: 0
+
+    belongs_to :lesson, Lesson
+    belongs_to :curriculum_item, CurriculumItem
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(lesson_curriculum_item, attrs) do
+    lesson_curriculum_item
+    |> cast(attrs, [:position, :lesson_id, :curriculum_item_id])
+    |> validate_required([:position, :lesson_id, :curriculum_item_id])
+  end
+end

--- a/lib/lanttern/lessons/lesson_curriculum_item.ex
+++ b/lib/lanttern/lessons/lesson_curriculum_item.ex
@@ -34,5 +34,6 @@ defmodule Lanttern.Lessons.LessonCurriculumItem do
     lesson_curriculum_item
     |> cast(attrs, [:position, :lesson_id, :curriculum_item_id])
     |> validate_required([:position, :lesson_id, :curriculum_item_id])
+    |> unique_constraint([:curriculum_item_id, :lesson_id])
   end
 end

--- a/lib/lanttern/lessons/lesson_curriculum_item.ex
+++ b/lib/lanttern/lessons/lesson_curriculum_item.ex
@@ -6,6 +6,8 @@ defmodule Lanttern.Lessons.LessonCurriculumItem do
   use Ecto.Schema
   import Ecto.Changeset
 
+  use Gettext, backend: Lanttern.Gettext
+
   alias Lanttern.Curricula.CurriculumItem
   alias Lanttern.Lessons.Lesson
 
@@ -34,6 +36,9 @@ defmodule Lanttern.Lessons.LessonCurriculumItem do
     lesson_curriculum_item
     |> cast(attrs, [:position, :lesson_id, :curriculum_item_id])
     |> validate_required([:position, :lesson_id, :curriculum_item_id])
-    |> unique_constraint([:curriculum_item_id, :lesson_id])
+    |> unique_constraint([:curriculum_item_id, :lesson_id],
+      name: "lesson_curriculum_items_curriculum_item_id_lesson_id_index",
+      message: gettext("Curriculum item already linked to this lesson")
+    )
   end
 end

--- a/lib/lanttern/strands.ex
+++ b/lib/lanttern/strands.ex
@@ -38,6 +38,10 @@ defmodule Lanttern.Strands do
   @doc """
   Returns the list of strand_curriculum_items for a given strand, ordered by position.
 
+  This queries the explicit `strand_curriculum_items` join table. For curriculum items
+  derived from strand assessment points (strand goals), see
+  `Lanttern.Curricula.list_strand_curriculum_items/2`.
+
   ## Options
 
   - `:preloads` - preloads to apply

--- a/lib/lanttern/strands.ex
+++ b/lib/lanttern/strands.ex
@@ -4,6 +4,10 @@ defmodule Lanttern.Strands do
   """
 
   import Ecto.Query, warn: false
+
+  import Lanttern.RepoHelpers,
+    only: [maybe_preload: 2, set_position_in_attrs: 2, update_positions: 2]
+
   alias Lanttern.Repo
 
   alias Lanttern.Identity.Scope
@@ -32,16 +36,25 @@ defmodule Lanttern.Strands do
   end
 
   @doc """
-  Returns the list of strand_curriculum_items.
+  Returns the list of strand_curriculum_items for a given strand, ordered by position.
+
+  ## Options
+
+  - `:preloads` - preloads to apply
 
   ## Examples
 
-      iex> list_strand_curriculum_items(scope)
+      iex> list_strand_curriculum_items(scope, strand_id)
       [%StrandCurriculumItem{}, ...]
 
   """
-  def list_strand_curriculum_items(%Scope{} = _scope) do
-    Repo.all(StrandCurriculumItem)
+  def list_strand_curriculum_items(%Scope{} = _scope, strand_id, opts \\ []) do
+    from(sci in StrandCurriculumItem,
+      where: sci.strand_id == ^strand_id,
+      order_by: [asc: sci.position]
+    )
+    |> Repo.all()
+    |> maybe_preload(opts)
   end
 
   @doc """
@@ -76,6 +89,16 @@ defmodule Lanttern.Strands do
   """
   def create_strand_curriculum_item(%Scope{} = scope, attrs) do
     true = Scope.profile_type?(scope, "staff")
+
+    strand_id = Map.get(attrs, :strand_id) || Map.get(attrs, "strand_id")
+
+    attrs =
+      if strand_id do
+        from(sci in StrandCurriculumItem, where: sci.strand_id == ^strand_id)
+        |> set_position_in_attrs(attrs)
+      else
+        attrs
+      end
 
     with {:ok, strand_curriculum_item = %StrandCurriculumItem{}} <-
            %StrandCurriculumItem{}
@@ -137,6 +160,13 @@ defmodule Lanttern.Strands do
       broadcast_strand_curriculum_item(scope, {:deleted, strand_curriculum_item})
       {:ok, strand_curriculum_item}
     end
+  end
+
+  @doc """
+  Updates positions for a list of strand_curriculum_item ids.
+  """
+  def update_strand_curriculum_items_positions(ids) do
+    update_positions(StrandCurriculumItem, ids)
   end
 
   @doc """

--- a/lib/lanttern/strands.ex
+++ b/lib/lanttern/strands.ex
@@ -1,0 +1,158 @@
+defmodule Lanttern.Strands do
+  @moduledoc """
+  The Strands context.
+  """
+
+  import Ecto.Query, warn: false
+  alias Lanttern.Repo
+
+  alias Lanttern.Identity.Scope
+  alias Lanttern.Strands.StrandCurriculumItem
+
+  @doc """
+  Subscribes to scoped notifications about any strand_curriculum_item changes.
+
+  The broadcasted messages match the pattern:
+
+    * {:created, %StrandCurriculumItem{}}
+    * {:updated, %StrandCurriculumItem{}}
+    * {:deleted, %StrandCurriculumItem{}}
+
+  """
+  def subscribe_strand_curriculum_items(%Scope{} = scope) do
+    key = scope.school_id
+
+    Phoenix.PubSub.subscribe(Lanttern.PubSub, "school:#{key}:strand_curriculum_items")
+  end
+
+  defp broadcast_strand_curriculum_item(%Scope{} = scope, message) do
+    key = scope.school_id
+
+    Phoenix.PubSub.broadcast(Lanttern.PubSub, "school:#{key}:strand_curriculum_items", message)
+  end
+
+  @doc """
+  Returns the list of strand_curriculum_items.
+
+  ## Examples
+
+      iex> list_strand_curriculum_items(scope)
+      [%StrandCurriculumItem{}, ...]
+
+  """
+  def list_strand_curriculum_items(%Scope{} = _scope) do
+    Repo.all(StrandCurriculumItem)
+  end
+
+  @doc """
+  Gets a single strand_curriculum_item.
+
+  Raises `Ecto.NoResultsError` if the Strand curriculum item does not exist.
+
+  ## Examples
+
+      iex> get_strand_curriculum_item!(scope, 123)
+      %StrandCurriculumItem{}
+
+      iex> get_strand_curriculum_item!(scope, 456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_strand_curriculum_item!(%Scope{} = _scope, id) do
+    Repo.get!(StrandCurriculumItem, id)
+  end
+
+  @doc """
+  Creates a strand_curriculum_item.
+
+  ## Examples
+
+      iex> create_strand_curriculum_item(scope, %{field: value})
+      {:ok, %StrandCurriculumItem{}}
+
+      iex> create_strand_curriculum_item(scope, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_strand_curriculum_item(%Scope{} = scope, attrs) do
+    true = Scope.profile_type?(scope, "staff")
+
+    with {:ok, strand_curriculum_item = %StrandCurriculumItem{}} <-
+           %StrandCurriculumItem{}
+           |> StrandCurriculumItem.changeset(attrs)
+           |> Repo.insert() do
+      broadcast_strand_curriculum_item(scope, {:created, strand_curriculum_item})
+      {:ok, strand_curriculum_item}
+    end
+  end
+
+  @doc """
+  Updates a strand_curriculum_item.
+
+  ## Examples
+
+      iex> update_strand_curriculum_item(scope, strand_curriculum_item, %{field: new_value})
+      {:ok, %StrandCurriculumItem{}}
+
+      iex> update_strand_curriculum_item(scope, strand_curriculum_item, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_strand_curriculum_item(
+        %Scope{} = scope,
+        %StrandCurriculumItem{} = strand_curriculum_item,
+        attrs
+      ) do
+    true = Scope.profile_type?(scope, "staff")
+
+    with {:ok, strand_curriculum_item = %StrandCurriculumItem{}} <-
+           strand_curriculum_item
+           |> StrandCurriculumItem.changeset(attrs)
+           |> Repo.update() do
+      broadcast_strand_curriculum_item(scope, {:updated, strand_curriculum_item})
+      {:ok, strand_curriculum_item}
+    end
+  end
+
+  @doc """
+  Deletes a strand_curriculum_item.
+
+  ## Examples
+
+      iex> delete_strand_curriculum_item(scope, strand_curriculum_item)
+      {:ok, %StrandCurriculumItem{}}
+
+      iex> delete_strand_curriculum_item(scope, strand_curriculum_item)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_strand_curriculum_item(
+        %Scope{} = scope,
+        %StrandCurriculumItem{} = strand_curriculum_item
+      ) do
+    true = Scope.profile_type?(scope, "staff")
+
+    with {:ok, strand_curriculum_item = %StrandCurriculumItem{}} <-
+           Repo.delete(strand_curriculum_item) do
+      broadcast_strand_curriculum_item(scope, {:deleted, strand_curriculum_item})
+      {:ok, strand_curriculum_item}
+    end
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking strand_curriculum_item changes.
+
+  ## Examples
+
+      iex> change_strand_curriculum_item(scope, strand_curriculum_item)
+      %Ecto.Changeset{data: %StrandCurriculumItem{}}
+
+  """
+  def change_strand_curriculum_item(
+        %Scope{} = _scope,
+        %StrandCurriculumItem{} = strand_curriculum_item,
+        attrs \\ %{}
+      ) do
+    StrandCurriculumItem.changeset(strand_curriculum_item, attrs)
+  end
+end

--- a/lib/lanttern/strands/strand_curriculum_item.ex
+++ b/lib/lanttern/strands/strand_curriculum_item.ex
@@ -6,6 +6,8 @@ defmodule Lanttern.Strands.StrandCurriculumItem do
   use Ecto.Schema
   import Ecto.Changeset
 
+  use Gettext, backend: Lanttern.Gettext
+
   alias Lanttern.Curricula.CurriculumItem
   alias Lanttern.LearningContext.Strand
 
@@ -34,5 +36,9 @@ defmodule Lanttern.Strands.StrandCurriculumItem do
     strand_curriculum_item
     |> cast(attrs, [:position, :strand_id, :curriculum_item_id])
     |> validate_required([:position, :strand_id, :curriculum_item_id])
+    |> unique_constraint([:strand_id, :curriculum_item_id],
+      name: "strand_curriculum_items_curriculum_item_id_strand_id_index",
+      message: gettext("Curriculum item already linked to this strand")
+    )
   end
 end

--- a/lib/lanttern/strands/strand_curriculum_item.ex
+++ b/lib/lanttern/strands/strand_curriculum_item.ex
@@ -1,0 +1,38 @@
+defmodule Lanttern.Strands.StrandCurriculumItem do
+  @moduledoc """
+  The `StrandCurriculumItem` schema
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  alias Lanttern.Curricula.CurriculumItem
+  alias Lanttern.LearningContext.Strand
+
+  @type t :: %__MODULE__{
+          id: pos_integer(),
+          position: non_neg_integer(),
+          strand: Strand.t() | Ecto.Association.NotLoaded.t(),
+          strand_id: pos_integer(),
+          curriculum_item: CurriculumItem.t() | Ecto.Association.NotLoaded.t(),
+          curriculum_item_id: pos_integer(),
+          inserted_at: DateTime.t(),
+          updated_at: DateTime.t()
+        }
+
+  schema "strand_curriculum_items" do
+    field :position, :integer, default: 0
+
+    belongs_to :strand, Strand
+    belongs_to :curriculum_item, CurriculumItem
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(strand_curriculum_item, attrs) do
+    strand_curriculum_item
+    |> cast(attrs, [:position, :strand_id, :curriculum_item_id])
+    |> validate_required([:position, :strand_id, :curriculum_item_id])
+  end
+end

--- a/lib/lanttern_web.ex
+++ b/lib/lanttern_web.ex
@@ -95,6 +95,7 @@ defmodule LantternWeb do
       import LiveReact
       # Core UI components and translation
       import LantternWeb.CoreComponents
+      import LantternWeb.ChangesetHelpers
       import LantternWeb.NavigationComponents
       import LantternWeb.FormComponents
       import LantternWeb.OverlayComponents

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -2362,6 +2362,17 @@ defmodule LantternWeb.CoreComponents do
   end
 
   @doc """
+  Converts all errors in a changeset to a single joined string.
+
+  Uses `translate_error/1` so gettext interpolation (e.g. `%{count}`) is handled.
+  """
+  def changeset_error_string(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+    |> Enum.flat_map(fn {_field, msgs} -> msgs end)
+    |> Enum.join(" ")
+  end
+
+  @doc """
   Renders a mouse-following tooltip (similar to native browser `title` tooltips).
 
   The tooltip appears near the mouse cursor and follows it. It automatically

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -2362,17 +2362,6 @@ defmodule LantternWeb.CoreComponents do
   end
 
   @doc """
-  Converts all errors in a changeset to a single joined string.
-
-  Uses `translate_error/1` so gettext interpolation (e.g. `%{count}`) is handled.
-  """
-  def changeset_error_string(changeset) do
-    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
-    |> Enum.flat_map(fn {_field, msgs} -> msgs end)
-    |> Enum.join(" ")
-  end
-
-  @doc """
   Renders a mouse-following tooltip (similar to native browser `title` tooltips).
 
   The tooltip appears near the mouse cursor and follows it. It automatically

--- a/lib/lanttern_web/helpers/changeset_helpers.ex
+++ b/lib/lanttern_web/helpers/changeset_helpers.ex
@@ -1,0 +1,18 @@
+defmodule LantternWeb.ChangesetHelpers do
+  @moduledoc """
+  Helper functions for working with Ecto changesets in views and live views.
+  """
+
+  import LantternWeb.CoreComponents, only: [translate_error: 1]
+
+  @doc """
+  Converts all errors in a changeset to a single joined string.
+
+  Uses `translate_error/1` so gettext interpolation (e.g. `%{count}`) is handled.
+  """
+  def changeset_error_string(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+    |> Enum.flat_map(fn {_field, msgs} -> msgs end)
+    |> Enum.join(" ")
+  end
+end

--- a/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
@@ -111,6 +111,10 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
                   }
                   text={moment.name}
                 />
+                <:item
+                  on_click={JS.push("new_strand_goal", target: @myself)}
+                  text={gettext("Strand goal")}
+                />
               </.dropdown_menu>
             </div>
             <div class="relative">
@@ -228,7 +232,10 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
         notify_component={@myself}
         title={@assessment_point_overlay_title}
         on_cancel={JS.push("close_assessment_point_form", target: @myself)}
-        curriculum_from_strand_id={@strand.id}
+        curriculum_from_strand_id={
+          # do not use curriculum from strand when creating a strand goal
+          if @assessment_point.strand_id, do: nil, else: @strand.id
+        }
       />
     </div>
     """
@@ -504,6 +511,20 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
       socket
       |> assign(:assessment_point, assessment_point)
       |> assign(:assessment_point_overlay_title, gettext("New assessment point"))
+
+    {:noreply, socket}
+  end
+
+  def handle_event("new_strand_goal", _params, socket) do
+    assessment_point = %AssessmentPoint{
+      strand_id: socket.assigns.strand.id,
+      datetime: DateTime.utc_now()
+    }
+
+    socket =
+      socket
+      |> assign(:assessment_point, assessment_point)
+      |> assign(:assessment_point_overlay_title, gettext("New strand goal"))
 
     {:noreply, socket}
   end

--- a/lib/lanttern_web/live/pages/strands/id/overview_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/overview_component.ex
@@ -1,16 +1,11 @@
 defmodule LantternWeb.StrandLive.OverviewComponent do
   use LantternWeb, :live_component
 
-  alias Lanttern.Assessments
-  alias Lanttern.Assessments.AssessmentPoint
-  alias Lanttern.Curricula
   alias Lanttern.Reporting
 
   import Lanttern.SupabaseHelpers, only: [object_url_to_render_url: 2]
-  import Lanttern.Utils, only: [reorder: 3]
 
   # shared components
-  alias LantternWeb.Assessments.AssessmentPointFormOverlayComponent
   import LantternWeb.ReportingComponents, only: [report_card_card: 1]
 
   @impl true
@@ -47,70 +42,6 @@ defmodule LantternWeb.StrandLive.OverviewComponent do
           </p>
           <.markdown text={@strand.teacher_instructions} />
         </div>
-        <div class="flex items-end justify-between gap-6" id="strand-curriculum">
-          <h3 class="mt-16 font-display font-black text-3xl">{gettext("Strand Curriculum")}</h3>
-          <.action
-            type="link"
-            icon_name="hero-plus-circle-mini"
-            patch={~p"/strands/#{@strand}/overview?goal=new"}
-          >
-            {gettext("Add curriculum item")}
-          </.action>
-        </div>
-        <div
-          phx-hook="Sortable"
-          id="sortable-curriculum-items"
-          data-sortable-handle=".sortable-handle"
-          data-sortable-event="sortable_update"
-          phx-update="ignore"
-          phx-target={@myself}
-        >
-          <.draggable_card
-            :for={{dom_id, curriculum_item} <- @streams.curriculum_items}
-            class="mt-6"
-            id={dom_id}
-          >
-            <div class="flex items-center gap-6">
-              <div class="flex-1">
-                <div class="flex items-center gap-4">
-                  <div :if={curriculum_item.has_rubric}>
-                    <.icon name="hero-view-columns" class="w-6 h-6" />
-                    <.tooltip id={"#{dom_id}-rubric-tooltip"}>
-                      {gettext("Uses rubric in final assessment")}
-                    </.tooltip>
-                  </div>
-                  <.badge :if={curriculum_item.is_differentiation} theme="diff">
-                    {gettext("Differentiation")}
-                  </.badge>
-                  <p class="flex-1 font-display font-bold text-sm">
-                    {curriculum_item.curriculum_component.name}
-                  </p>
-                </div>
-                <p class="mt-4">{curriculum_item.name}</p>
-                <div
-                  :if={hd(curriculum_item.assessment_points).report_info}
-                  class="p-4 rounded-sm mt-6 bg-ltrn-mesh-cyan"
-                >
-                  <div class="flex items-center gap-2 font-bold text-sm text-ltrn-subtle">
-                    <.icon name="hero-information-circle" class="w-6 h-6" /> {gettext("Report info")}
-                  </div>
-                  <.markdown
-                    text={hd(curriculum_item.assessment_points).report_info}
-                    class="max-w-none mt-4"
-                  />
-                </div>
-              </div>
-              <.action
-                type="link"
-                theme="subtle"
-                icon_name="hero-pencil-mini"
-                patch={~p"/strands/#{@strand}/overview?goal=#{curriculum_item.assessment_point_id}"}
-              >
-                {gettext("Edit")}
-              </.action>
-            </div>
-          </.draggable_card>
-        </div>
       </.responsive_container>
       <.responsive_container class="mt-16">
         <h3 class="font-display font-black text-3xl">{gettext("Report cards")}</h3>
@@ -132,16 +63,6 @@ defmodule LantternWeb.StrandLive.OverviewComponent do
           {gettext("No report cards linked to this strand")}
         </.empty_state>
       <% end %>
-      <.live_component
-        :if={@goal}
-        module={AssessmentPointFormOverlayComponent}
-        id={"strand-#{@strand.id}-goal-form-overlay"}
-        current_scope={@current_scope}
-        notify_component={@myself}
-        assessment_point={@goal}
-        title={gettext("Strand goal")}
-        on_cancel={JS.patch(~p"/strands/#{@strand}/overview")}
-      />
     </div>
     """
   end
@@ -154,40 +75,11 @@ defmodule LantternWeb.StrandLive.OverviewComponent do
   end
 
   @impl true
-  def update(
-        %{action: {AssessmentPointFormOverlayComponent, {action, _assessment_point}}},
-        socket
-      )
-      when action in [:created, :updated, :deleted, :deleted_with_entries] do
-    flash_message =
-      case action do
-        :created ->
-          {:info, gettext("Assessment point created successfully")}
-
-        :updated ->
-          {:info, gettext("Assessment point updated successfully")}
-
-        :deleted ->
-          {:info, gettext("Assessment point deleted successfully")}
-
-        :deleted_with_entries ->
-          {:info, gettext("Assessment point and entries deleted successfully")}
-      end
-
-    nav_opts = [
-      put_flash: flash_message,
-      push_navigate: [to: ~p"/strands/#{socket.assigns.strand}/overview"]
-    ]
-
-    {:ok, delegate_navigation(socket, nav_opts)}
-  end
-
   def update(assigns, socket) do
     socket =
       socket
       |> assign(assigns)
       |> initialize()
-      |> assign_goal()
       |> assign_cover_image_url()
 
     {:ok, socket}
@@ -195,24 +87,11 @@ defmodule LantternWeb.StrandLive.OverviewComponent do
 
   defp initialize(%{assigns: %{initialized: false}} = socket) do
     socket
-    |> stream_curriculum_items()
     |> stream_report_cards()
     |> assign(:initialized, true)
   end
 
   defp initialize(socket), do: socket
-
-  defp stream_curriculum_items(socket) do
-    curriculum_items =
-      Curricula.list_strand_curriculum_items(
-        socket.assigns.strand.id,
-        preloads: :curriculum_component
-      )
-
-    socket
-    |> stream(:curriculum_items, curriculum_items)
-    |> assign(:goals_ids, Enum.map(curriculum_items, & &1.assessment_point_id))
-  end
 
   defp stream_report_cards(socket) do
     report_cards =
@@ -227,50 +106,11 @@ defmodule LantternWeb.StrandLive.OverviewComponent do
     |> assign(:has_report_cards, report_cards != [])
   end
 
-  defp assign_goal(%{assigns: %{params: %{"goal" => "new"}}} = socket) do
-    goal =
-      %AssessmentPoint{
-        strand_id: socket.assigns.strand.id,
-        datetime: DateTime.utc_now()
-      }
-
-    assign(socket, :goal, goal)
-  end
-
-  defp assign_goal(%{assigns: %{params: %{"goal" => binary_id}}} = socket) do
-    with {id, _} <- Integer.parse(binary_id), true <- id in socket.assigns.goals_ids do
-      goal = Assessments.get_assessment_point(id)
-      assign(socket, :goal, goal)
-    else
-      _ -> assign(socket, :goal, nil)
-    end
-  end
-
-  defp assign_goal(socket), do: assign(socket, :goal, nil)
-
   defp assign_cover_image_url(socket) do
     assign(
       socket,
       :cover_image_url,
       object_url_to_render_url(socket.assigns.strand.cover_image_url, width: 1280, height: 640)
     )
-  end
-
-  # event handlers
-
-  @impl true
-  def handle_event("sortable_update", payload, socket) do
-    %{
-      "oldIndex" => old_index,
-      "newIndex" => new_index
-    } = payload
-
-    goals_ids = reorder(socket.assigns.goals_ids, old_index, new_index)
-
-    # the interface was already updated (optimistic update)
-    # just persist the new order
-    Assessments.update_assessment_points_positions(goals_ids)
-
-    {:noreply, assign(socket, :goals_ids, goals_ids)}
   end
 end

--- a/lib/lanttern_web/live/pages/strands/id/overview_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/overview_component.ex
@@ -2,10 +2,13 @@ defmodule LantternWeb.StrandLive.OverviewComponent do
   use LantternWeb, :live_component
 
   alias Lanttern.Reporting
+  alias Lanttern.Strands
 
   import Lanttern.SupabaseHelpers, only: [object_url_to_render_url: 2]
+  import Lanttern.Utils, only: [reorder: 3]
 
   # shared components
+  alias LantternWeb.Curricula.CurriculumItemSearchComponent
   import LantternWeb.ReportingComponents, only: [report_card_card: 1]
 
   @impl true
@@ -42,7 +45,88 @@ defmodule LantternWeb.StrandLive.OverviewComponent do
           </p>
           <.markdown text={@strand.teacher_instructions} />
         </div>
+        <div class="flex items-end justify-between gap-6 mt-16">
+          <h3 class="font-display font-black text-3xl">{gettext("Strand Curriculum")}</h3>
+          <.button
+            type="button"
+            id="new-curriculum-item-button"
+            phx-click={JS.push("new_curriculum_item", target: @myself)}
+          >
+            {gettext("New")}
+          </.button>
+        </div>
+        <div
+          :if={@curriculum_item_ids != []}
+          phx-hook="Sortable"
+          id="sortable-strand-curriculum-items"
+          data-sortable-handle=".sortable-handle"
+          data-sortable-event="sortable_update"
+          phx-update="stream"
+          phx-target={@myself}
+        >
+          <.draggable_card
+            :for={{dom_id, sci} <- @streams.curriculum_items}
+            class="mt-4"
+            id={dom_id}
+          >
+            <div class="flex items-center gap-4">
+              <div class="flex-1 min-w-0">
+                <p>{sci.curriculum_item.name}</p>
+                <p class="mt-2 font-sans text-sm text-ltrn-subtle truncate">
+                  {sci.curriculum_item.curriculum_component.name}
+                </p>
+              </div>
+              <div class="relative shrink-0">
+                <.button type="button" theme="ghost" size="sm" id={"#{dom_id}-edit-button"}>
+                  {gettext("Edit")}
+                </.button>
+                <.dropdown_menu
+                  id={"#{dom_id}-edit"}
+                  button_id={"#{dom_id}-edit-button"}
+                  position="right"
+                >
+                  <:item
+                    on_click={
+                      JS.push("replace_curriculum_item", value: %{id: sci.id}, target: @myself)
+                    }
+                    text={gettext("Replace")}
+                  />
+                  <:item
+                    on_click={
+                      JS.push("remove_curriculum_item", value: %{id: sci.id}, target: @myself)
+                    }
+                    text={gettext("Remove")}
+                    theme="alert"
+                    confirm_msg={gettext("Are you sure?")}
+                  />
+                </.dropdown_menu>
+              </div>
+            </div>
+          </.draggable_card>
+        </div>
+        <.empty_state :if={@curriculum_item_ids == []} class="mt-10">
+          {gettext("No curriculum items linked to this strand")}
+        </.empty_state>
       </.responsive_container>
+      <.modal
+        :if={@show_search_modal}
+        id="curriculum-item-search-modal"
+        show={true}
+        on_cancel={JS.push("close_search_modal", target: @myself)}
+      >
+        <:title>{gettext("Add curriculum item")}</:title>
+        <form>
+          <.live_component
+            module={CurriculumItemSearchComponent}
+            id="curriculum-item-search"
+            current_scope={@current_scope}
+            notify_component={@myself}
+          />
+        </form>
+        <.error_block :if={@curriculum_error} class="mt-6">
+          <p>{@curriculum_error}</p>
+        </.error_block>
+      </.modal>
       <.responsive_container class="mt-16">
         <h3 class="font-display font-black text-3xl">{gettext("Report cards")}</h3>
         <p class="flex gap-1 mt-4">
@@ -71,10 +155,63 @@ defmodule LantternWeb.StrandLive.OverviewComponent do
 
   @impl true
   def mount(socket) do
-    {:ok, assign(socket, :initialized, false)}
+    socket =
+      socket
+      |> assign(:initialized, false)
+      |> assign(:show_search_modal, false)
+      |> assign(:editing_strand_curriculum_item, nil)
+      |> assign(:curriculum_error, nil)
+
+    {:ok, socket}
   end
 
   @impl true
+  def update(
+        %{action: {CurriculumItemSearchComponent, {:selected, curriculum_item}}},
+        socket
+      ) do
+    socket = assign(socket, :curriculum_error, nil)
+
+    socket =
+      case socket.assigns.editing_strand_curriculum_item do
+        nil ->
+          attrs = %{
+            strand_id: socket.assigns.strand.id,
+            curriculum_item_id: curriculum_item.id
+          }
+
+          case Strands.create_strand_curriculum_item(socket.assigns.current_scope, attrs) do
+            {:ok, sci} ->
+              sci = Map.put(sci, :curriculum_item, curriculum_item)
+
+              socket
+              |> stream_insert(:curriculum_items, sci)
+              |> update(:curriculum_item_ids, &(&1 ++ [sci.id]))
+              |> assign(show_search_modal: false, editing_strand_curriculum_item: nil)
+
+            {:error, changeset} ->
+              assign(socket, :curriculum_error, changeset_error_string(changeset))
+          end
+
+        sci ->
+          attrs = %{curriculum_item_id: curriculum_item.id}
+
+          case Strands.update_strand_curriculum_item(socket.assigns.current_scope, sci, attrs) do
+            {:ok, updated} ->
+              updated = Map.put(updated, :curriculum_item, curriculum_item)
+
+              socket
+              |> stream_insert(:curriculum_items, updated)
+              |> assign(show_search_modal: false, editing_strand_curriculum_item: nil)
+
+            {:error, changeset} ->
+              assign(socket, :curriculum_error, changeset_error_string(changeset))
+          end
+      end
+
+    {:ok, socket}
+  end
+
   def update(assigns, socket) do
     socket =
       socket
@@ -87,11 +224,25 @@ defmodule LantternWeb.StrandLive.OverviewComponent do
 
   defp initialize(%{assigns: %{initialized: false}} = socket) do
     socket
+    |> stream_curriculum_items()
     |> stream_report_cards()
     |> assign(:initialized, true)
   end
 
   defp initialize(socket), do: socket
+
+  defp stream_curriculum_items(socket) do
+    curriculum_items =
+      Strands.list_strand_curriculum_items(
+        socket.assigns.current_scope,
+        socket.assigns.strand.id,
+        preloads: [curriculum_item: :curriculum_component]
+      )
+
+    socket
+    |> stream(:curriculum_items, curriculum_items)
+    |> assign(:curriculum_item_ids, Enum.map(curriculum_items, & &1.id))
+  end
 
   defp stream_report_cards(socket) do
     report_cards =
@@ -112,5 +263,55 @@ defmodule LantternWeb.StrandLive.OverviewComponent do
       :cover_image_url,
       object_url_to_render_url(socket.assigns.strand.cover_image_url, width: 1280, height: 640)
     )
+  end
+
+  # event handlers
+
+  @impl true
+  def handle_event("new_curriculum_item", _params, socket) do
+    socket =
+      socket
+      |> assign(:show_search_modal, true)
+      |> assign(:editing_strand_curriculum_item, nil)
+      |> assign(:curriculum_error, nil)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("replace_curriculum_item", %{"id" => id}, socket) do
+    sci = Strands.get_strand_curriculum_item!(socket.assigns.current_scope, id)
+
+    socket =
+      socket
+      |> assign(:show_search_modal, true)
+      |> assign(:editing_strand_curriculum_item, sci)
+      |> assign(:curriculum_error, nil)
+
+    {:noreply, socket}
+  end
+
+  def handle_event("remove_curriculum_item", %{"id" => id}, socket) do
+    sci = Strands.get_strand_curriculum_item!(socket.assigns.current_scope, id)
+    {:ok, _} = Strands.delete_strand_curriculum_item(socket.assigns.current_scope, sci)
+
+    socket =
+      socket
+      |> stream_delete(:curriculum_items, sci)
+      |> update(:curriculum_item_ids, &List.delete(&1, sci.id))
+
+    {:noreply, socket}
+  end
+
+  def handle_event("close_search_modal", _params, socket) do
+    {:noreply, assign(socket, show_search_modal: false, editing_strand_curriculum_item: nil)}
+  end
+
+  def handle_event("sortable_update", payload, socket) do
+    %{"oldIndex" => old_index, "newIndex" => new_index} = payload
+
+    curriculum_item_ids = reorder(socket.assigns.curriculum_item_ids, old_index, new_index)
+    Strands.update_strand_curriculum_items_positions(curriculum_item_ids)
+
+    {:noreply, assign(socket, :curriculum_item_ids, curriculum_item_ids)}
   end
 end

--- a/lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex
+++ b/lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex
@@ -6,10 +6,14 @@ defmodule LantternWeb.LessonLive do
   alias Lanttern.LearningContext
   alias Lanttern.LearningContext.Moment
   alias Lanttern.Lessons
+  alias Lanttern.Strands
+
+  import Lanttern.Utils, only: [reorder: 3]
 
   # shared components
   alias LantternWeb.Assessments.AssessmentPointFormOverlayComponent
   alias LantternWeb.Attachments.AttachmentAreaComponent
+  alias LantternWeb.Curricula.CurriculumItemSearchComponent
   alias LantternWeb.LearningContext.MomentDetailsOverlayComponent
   alias LantternWeb.Lessons.LessonFormComponent
   alias LantternWeb.Lessons.LessonsSideNavComponent
@@ -87,7 +91,13 @@ defmodule LantternWeb.LessonLive do
       |> assign(:unlinking_from_lesson, nil)
       |> assign(:assessment_point, nil)
       |> assign(:assessment_point_overlay_title, nil)
+      |> assign(:show_lesson_curriculum_modal, false)
+      |> assign(:editing_lesson_curriculum_item, nil)
+      |> assign(:lesson_curriculum_error, nil)
+      |> assign(:lesson_curriculum_initial_results, [])
       |> stream_lesson_assessment_points()
+      |> stream_lesson_curriculum_section()
+      |> assign_strand_curriculum_items()
       |> assign(
         :has_agents_management_permission,
         Scope.has_permission?(socket.assigns.current_scope, "agents_management")
@@ -127,6 +137,31 @@ defmodule LantternWeb.LessonLive do
 
     socket
     |> assign(:strand, strand)
+  end
+
+  defp stream_lesson_curriculum_section(socket) do
+    items =
+      Lessons.list_lesson_curriculum_items(
+        socket.assigns.current_scope,
+        socket.assigns.lesson.id,
+        preloads: [curriculum_item: :curriculum_component]
+      )
+
+    socket
+    |> stream(:lesson_curriculum_items, items, reset: true)
+    |> assign(:lesson_curriculum_item_ids, Enum.map(items, & &1.id))
+    |> assign(:lesson_curriculum_ids, Enum.map(items, & &1.curriculum_item_id))
+  end
+
+  defp assign_strand_curriculum_items(socket) do
+    items =
+      Strands.list_strand_curriculum_items(
+        socket.assigns.current_scope,
+        socket.assigns.strand.id,
+        preloads: [curriculum_item: :curriculum_component]
+      )
+
+    assign(socket, :strand_curriculum_items, items)
   end
 
   # event handlers
@@ -374,6 +409,76 @@ defmodule LantternWeb.LessonLive do
   def handle_event("close_moment_details", _params, socket),
     do: {:noreply, assign(socket, :moment_id, nil)}
 
+  # -- lesson curriculum items
+
+  def handle_event("new_lesson_curriculum_item", _params, socket) do
+    socket =
+      socket
+      |> assign(:show_lesson_curriculum_modal, true)
+      |> assign(:editing_lesson_curriculum_item, nil)
+      |> assign(:lesson_curriculum_error, nil)
+      |> assign(
+        :lesson_curriculum_initial_results,
+        filtered_initial_results(
+          socket.assigns.strand_curriculum_items,
+          socket.assigns.lesson_curriculum_ids
+        )
+      )
+
+    {:noreply, socket}
+  end
+
+  def handle_event("replace_lesson_curriculum_item", %{"id" => id}, socket) do
+    lci = Lessons.get_lesson_curriculum_item!(socket.assigns.current_scope, id)
+
+    excluded_ids = List.delete(socket.assigns.lesson_curriculum_ids, lci.curriculum_item_id)
+
+    socket =
+      socket
+      |> assign(:show_lesson_curriculum_modal, true)
+      |> assign(:editing_lesson_curriculum_item, lci)
+      |> assign(:lesson_curriculum_error, nil)
+      |> assign(
+        :lesson_curriculum_initial_results,
+        filtered_initial_results(socket.assigns.strand_curriculum_items, excluded_ids)
+      )
+
+    {:noreply, socket}
+  end
+
+  def handle_event("remove_lesson_curriculum_item", %{"id" => id}, socket) do
+    lci = Lessons.get_lesson_curriculum_item!(socket.assigns.current_scope, id)
+    {:ok, _} = Lessons.delete_lesson_curriculum_item(socket.assigns.current_scope, lci)
+
+    socket =
+      socket
+      |> stream_delete(:lesson_curriculum_items, lci)
+      |> update(:lesson_curriculum_item_ids, &List.delete(&1, lci.id))
+      |> update(:lesson_curriculum_ids, &List.delete(&1, lci.curriculum_item_id))
+
+    {:noreply, socket}
+  end
+
+  def handle_event("close_lesson_curriculum_modal", _params, socket) do
+    {:noreply,
+     assign(socket,
+       show_lesson_curriculum_modal: false,
+       editing_lesson_curriculum_item: nil
+     )}
+  end
+
+  def handle_event("lesson_curriculum_sortable_update", payload, socket) do
+    %{"oldIndex" => old_index, "newIndex" => new_index} = payload
+
+    curriculum_item_ids =
+      socket.assigns.lesson_curriculum_item_ids
+      |> reorder(old_index, new_index)
+
+    Lessons.update_lesson_curriculum_items_positions(curriculum_item_ids)
+
+    {:noreply, assign(socket, :lesson_curriculum_item_ids, curriculum_item_ids)}
+  end
+
   # handle_event helpers
 
   defp update_assessment_point_lesson_link(socket, ap, lesson_id) do
@@ -421,5 +526,91 @@ defmodule LantternWeb.LessonLive do
       |> put_flash(:info, gettext("Assessment point deleted"))
 
     {:noreply, socket}
+  end
+
+  def handle_info({CurriculumItemSearchComponent, {:selected, curriculum_item}}, socket) do
+    scope = socket.assigns.current_scope
+    socket = assign(socket, :lesson_curriculum_error, nil)
+
+    socket =
+      case socket.assigns.editing_lesson_curriculum_item do
+        nil ->
+          attrs = %{
+            lesson_id: socket.assigns.lesson.id,
+            curriculum_item_id: curriculum_item.id
+          }
+
+          case Lessons.create_lesson_curriculum_item(scope, attrs) do
+            {:ok, lci} ->
+              lci = Map.put(lci, :curriculum_item, curriculum_item)
+
+              socket
+              |> stream_insert(:lesson_curriculum_items, lci)
+              |> update(:lesson_curriculum_item_ids, &(&1 ++ [lci.id]))
+              |> update(:lesson_curriculum_ids, &(&1 ++ [curriculum_item.id]))
+              |> maybe_add_to_strand_curriculum(curriculum_item)
+              |> assign(
+                show_lesson_curriculum_modal: false,
+                editing_lesson_curriculum_item: nil
+              )
+
+            {:error, changeset} ->
+              assign(socket, :lesson_curriculum_error, changeset_error_string(changeset))
+          end
+
+        lci ->
+          attrs = %{curriculum_item_id: curriculum_item.id}
+
+          case Lessons.update_lesson_curriculum_item(scope, lci, attrs) do
+            {:ok, updated} ->
+              updated = Map.put(updated, :curriculum_item, curriculum_item)
+
+              replaced_ids =
+                socket.assigns.lesson_curriculum_ids
+                |> List.delete(lci.curriculum_item_id)
+                |> then(&(&1 ++ [curriculum_item.id]))
+
+              socket
+              |> stream_insert(:lesson_curriculum_items, updated)
+              |> assign(:lesson_curriculum_ids, replaced_ids)
+              |> assign(
+                show_lesson_curriculum_modal: false,
+                editing_lesson_curriculum_item: nil
+              )
+
+            {:error, changeset} ->
+              assign(socket, :lesson_curriculum_error, changeset_error_string(changeset))
+          end
+      end
+
+    {:noreply, socket}
+  end
+
+  defp filtered_initial_results(strand_curriculum_items, excluded_ids) do
+    strand_curriculum_items
+    |> Enum.map(& &1.curriculum_item)
+    |> Enum.reject(&(&1.id in excluded_ids))
+  end
+
+  defp maybe_add_to_strand_curriculum(socket, curriculum_item) do
+    strand_ci_ids = Enum.map(socket.assigns.strand_curriculum_items, & &1.curriculum_item_id)
+
+    if curriculum_item.id in strand_ci_ids do
+      socket
+    else
+      attrs = %{
+        strand_id: socket.assigns.strand.id,
+        curriculum_item_id: curriculum_item.id
+      }
+
+      case Strands.create_strand_curriculum_item(socket.assigns.current_scope, attrs) do
+        {:ok, sci} ->
+          sci = Map.put(sci, :curriculum_item, curriculum_item)
+          update(socket, :strand_curriculum_items, &(&1 ++ [sci]))
+
+        {:error, _} ->
+          socket
+      end
+    end
   end
 end

--- a/lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex
+++ b/lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex
@@ -346,6 +346,67 @@
       />
     </.responsive_container>
   </section>
+  <section id="lesson-curriculum" class="py-10">
+    <.responsive_container>
+      <div class="flex items-end justify-between gap-6">
+        <h3 class="font-display font-black text-2xl">{gettext("Lesson Curriculum")}</h3>
+        <.button
+          type="button"
+          id="new-lesson-curriculum-item-button"
+          phx-click="new_lesson_curriculum_item"
+        >
+          {gettext("New")}
+        </.button>
+      </div>
+      <div
+        :if={@lesson_curriculum_item_ids != []}
+        phx-hook="Sortable"
+        id="sortable-lesson-curriculum-items"
+        data-sortable-handle=".sortable-handle"
+        data-sortable-event="lesson_curriculum_sortable_update"
+        phx-update="stream"
+      >
+        <.draggable_card
+          :for={{dom_id, lci} <- @streams.lesson_curriculum_items}
+          class="mt-4"
+          id={dom_id}
+        >
+          <div class="flex items-center gap-4">
+            <div class="flex-1 min-w-0">
+              <p>{lci.curriculum_item.name}</p>
+              <p class="mt-2 font-sans text-sm text-ltrn-subtle truncate">
+                {lci.curriculum_item.curriculum_component.name}
+              </p>
+            </div>
+            <div class="relative shrink-0">
+              <.button type="button" theme="ghost" size="sm" id={"#{dom_id}-edit-button"}>
+                {gettext("Edit")}
+              </.button>
+              <.dropdown_menu
+                id={"#{dom_id}-edit"}
+                button_id={"#{dom_id}-edit-button"}
+                position="right"
+              >
+                <:item
+                  on_click={JS.push("replace_lesson_curriculum_item", value: %{id: lci.id})}
+                  text={gettext("Replace")}
+                />
+                <:item
+                  on_click={JS.push("remove_lesson_curriculum_item", value: %{id: lci.id})}
+                  text={gettext("Remove")}
+                  theme="alert"
+                  confirm_msg={gettext("Are you sure?")}
+                />
+              </.dropdown_menu>
+            </div>
+          </div>
+        </.draggable_card>
+      </div>
+      <.empty_state :if={@lesson_curriculum_item_ids == []} class="mt-10">
+        {gettext("No curriculum items linked to this lesson")}
+      </.empty_state>
+    </.responsive_container>
+  </section>
 </Layouts.app_with_side_nav>
 <.button
   :if={@has_agents_management_permission}
@@ -427,3 +488,23 @@
   on_cancel={JS.push("close_assessment_point_form")}
   curriculum_from_strand_id={@strand.id}
 />
+<.modal
+  :if={@show_lesson_curriculum_modal}
+  id="lesson-curriculum-item-search-modal"
+  show={true}
+  on_cancel={JS.push("close_lesson_curriculum_modal")}
+>
+  <:title>{gettext("Add curriculum item")}</:title>
+  <form>
+    <.live_component
+      module={CurriculumItemSearchComponent}
+      id="lesson-curriculum-item-search"
+      current_scope={@current_scope}
+      notify_component={self()}
+      initial_results={@lesson_curriculum_initial_results}
+    />
+  </form>
+  <.error_block :if={@lesson_curriculum_error} class="mt-6">
+    <p>{@lesson_curriculum_error}</p>
+  </.error_block>
+</.modal>

--- a/lib/lanttern_web/live/shared/curricula/curriculum_item_search_component.ex
+++ b/lib/lanttern_web/live/shared/curricula/curriculum_item_search_component.ex
@@ -99,7 +99,30 @@ defmodule LantternWeb.Curricula.CurriculumItemSearchComponent do
       |> assign(:label, nil)
       |> assign(:class, nil)
       |> assign(:refocus_on_select, "false")
+      |> assign(:initial_results, [])
+      |> assign(:results_initialized, false)
       |> stream(:results, [])
+
+    {:ok, socket}
+  end
+
+  def update(assigns, socket) do
+    socket = assign(socket, assigns)
+
+    socket =
+      if socket.assigns.results_initialized do
+        socket
+      else
+        results = socket.assigns.initial_results
+        results_simplified = Enum.map(results, fn ci -> %{id: ci.id} end)
+
+        socket
+        |> stream(:results, results, reset: true)
+        |> push_event("autocomplete_search_results:#{socket.assigns.id}", %{
+          results: results_simplified
+        })
+        |> assign(:results_initialized, true)
+      end
 
     {:ok, socket}
   end
@@ -116,6 +139,10 @@ defmodule LantternWeb.Curricula.CurriculumItemSearchComponent do
         # or when more than 3 characters were typed
         String.length(query) > 3 ->
           Curricula.search_curriculum_items(socket.assigns.current_scope, query)
+
+        # show initial results when query is empty
+        query == "" ->
+          socket.assigns.initial_results
 
         true ->
           []
@@ -139,7 +166,11 @@ defmodule LantternWeb.Curricula.CurriculumItemSearchComponent do
         preloads: :curriculum_component
       )
 
-    send_update(socket.assigns.notify_component, action: {__MODULE__, {:selected, selected}})
+    if is_pid(socket.assigns.notify_component) do
+      send(socket.assigns.notify_component, {__MODULE__, {:selected, selected}})
+    else
+      send_update(socket.assigns.notify_component, action: {__MODULE__, {:selected, selected}})
+    end
 
     socket =
       socket

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Lanttern.MixProject do
   def project do
     [
       app: :lanttern,
-      version: "2026.4.20-alpha.94",
+      version: "2026.4.29-alpha.95",
       elixir: "~> 1.18",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -122,7 +122,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:137
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:277
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:330
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:412
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:473
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:102
 #: lib/lanttern_web/live/shared/agent_chat/agent_preferences_overlay_component.ex:73
 #: lib/lanttern_web/live/shared/agent_chat/rename_conversation_form_component.ex:28
@@ -519,7 +519,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_component_form_component.ex:62
 #: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:62
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:71
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:100
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:83
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:398
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:36
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:139
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:183
@@ -557,10 +559,9 @@ msgstr ""
 msgid "Current assessment points"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:270
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:83
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:277
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:102
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:46
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:50
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:286
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:118
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:34
@@ -588,11 +589,12 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/lesson_templates/lesson_template_card_component.ex:28
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:161
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:309
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:109
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:81
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:240
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:79
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:248
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:301
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:383
 #: lib/lanttern_web/live/pages/students/settings/tags_component.ex:46
 #: lib/lanttern_web/live/pages/students_records/settings/status_component.ex:61
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:57
@@ -814,8 +816,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:261
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:297
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:330
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:157
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:175
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:192
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:210
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:575
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:776
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:777
@@ -877,7 +879,8 @@ msgid "About the curriculum component"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.ex:67
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:57
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:117
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:497
 #, elixir-autogen, elixir-format
 msgid "Add curriculum item"
 msgstr ""
@@ -1209,7 +1212,7 @@ msgstr ""
 msgid "Link strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:118
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:133
 #, elixir-autogen, elixir-format
 msgid "List of report cards linked to this strand."
 msgstr ""
@@ -1330,6 +1333,8 @@ msgstr ""
 #: lib/lanttern_web/components/core_components.ex:356
 #: lib/lanttern_web/components/core_components.ex:1649
 #: lib/lanttern_web/components/form_components.ex:1243
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:98
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:396
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:196
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:158
 #, elixir-autogen, elixir-format
@@ -1355,7 +1360,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:22
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:29
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:116
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:131
 #: lib/lanttern_web/live/pages/student_report_cards/student_report_cards_live.html.heex:3
 #: lib/lanttern_web/live/shared/menu_component.ex:459
 #: lib/lanttern_web/live/shared/menu_component.ex:478
@@ -1426,7 +1431,7 @@ msgid "Strand already linked to report card"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:96
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:142
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:116
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Strand goal"
@@ -1612,11 +1617,6 @@ msgstr ""
 msgid "About this assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:95
-#, elixir-autogen, elixir-format
-msgid "Report info"
-msgstr ""
-
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:109
 #, elixir-autogen, elixir-format
 msgid "Report information"
@@ -1700,7 +1700,7 @@ msgid_plural "%{count} changes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:132
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:147
 #, elixir-autogen, elixir-format
 msgid "No report cards linked to this strand"
 msgstr ""
@@ -2174,7 +2174,7 @@ msgid "Goal assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:76
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:183
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:187
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:305
 #, elixir-autogen, elixir-format
 msgid "Goals assessment"
@@ -2887,7 +2887,7 @@ msgid "Edit report to add a cover image"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:26
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:23
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:21
 #, elixir-autogen, elixir-format
 msgid "Edit strand to add a cover image"
 msgstr ""
@@ -2949,7 +2949,7 @@ msgstr ""
 msgid "Loading profiles"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:506
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:513
 #, elixir-autogen, elixir-format
 msgid "New assessment point"
 msgstr ""
@@ -3113,7 +3113,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/shared/strand_report/overview/strand_report_overview_live.html.heex:17
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_overview_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:25
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:22
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:20
 #, elixir-autogen, elixir-format
 msgid "Strand cover image"
 msgstr ""
@@ -3362,7 +3362,7 @@ msgstr ""
 msgid "Shared with students and guardians"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:46
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:44
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:86
 #, elixir-autogen, elixir-format
 msgid "Teacher instructions"
@@ -4471,28 +4471,24 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:132
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:132
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:174
 #, elixir-autogen, elixir-format
 msgid "Assessment point and entries deleted successfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:123
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:123
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:165
 #, elixir-autogen, elixir-format
 msgid "Assessment point created successfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:129
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:129
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:171
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted successfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:126
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:126
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:168
 #, elixir-autogen, elixir-format
 msgid "Assessment point updated successfully"
 msgstr ""
@@ -4621,11 +4617,6 @@ msgstr ""
 #: lib/lanttern_web/live/shared/rubrics/rubric_diff_info_overlay_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "There are two ways to \"connect\" students and differentiation rubrics:"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:79
-#, elixir-autogen, elixir-format
-msgid "Uses rubric in final assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/rubrics/rubric_diff_info_overlay_component.ex:34
@@ -5096,7 +5087,7 @@ msgid "Edit content"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:560
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:367
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:428
 #, elixir-autogen, elixir-format
 msgid "Edit lesson"
 msgstr ""
@@ -5152,7 +5143,7 @@ msgstr ""
 msgid "Lesson name"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:150
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Lesson published"
 msgstr ""
@@ -5162,7 +5153,7 @@ msgstr ""
 msgid "Lesson resources"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:172
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Lesson unpublished"
 msgstr ""
@@ -5210,6 +5201,8 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:95
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:85
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:55
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr ""
@@ -5304,7 +5297,7 @@ msgstr ""
 msgid "Something went wrong when trying to delete the lesson"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:51
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Strand Curriculum"
 msgstr ""
@@ -5627,12 +5620,12 @@ msgstr ""
 msgid "Chat"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:359
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:420
 #, elixir-autogen, elixir-format
 msgid "Create with AI"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:359
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:420
 #, elixir-autogen, elixir-format
 msgid "Enhance with AI"
 msgstr ""
@@ -5738,19 +5731,19 @@ msgstr ""
 msgid "Assessment information"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:332
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:339
 #, elixir-autogen, elixir-format
 msgid "Assessment point created"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:380
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:421
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:387
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:347
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:406
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:354
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Assessment point updated"
 msgstr ""
@@ -5796,8 +5789,8 @@ msgstr ""
 msgid "Edit assessment info"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:518
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:355
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:539
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Edit assessment point"
 msgstr ""
@@ -5812,7 +5805,7 @@ msgstr ""
 msgid "Edit lesson tag"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:193
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:197
 #, elixir-autogen, elixir-format
 msgid "Goals assessment are defined by the strand curriculum."
 msgstr ""
@@ -5854,9 +5847,9 @@ msgid "Manage lesson tags below"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:8
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:122
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:152
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:189
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:126
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:156
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:193
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Marking"
@@ -5882,7 +5875,7 @@ msgstr ""
 msgid "New lesson tag"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:176
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:180
 #, elixir-autogen, elixir-format
 msgid "No assessment points in this moment yet"
 msgstr ""
@@ -5956,7 +5949,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:28
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:44
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:47
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:137
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:141
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Strand goals"
@@ -5986,13 +5979,13 @@ msgstr ""
 msgid "Use this area to share assessment information with students (e.g. grade composition)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:266
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:42
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:273
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Uses rubric in assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:198
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:202
 #, elixir-autogen, elixir-format
 msgid "You can manage curriculum items in the overview section."
 msgstr ""
@@ -6235,22 +6228,22 @@ msgstr ""
 msgid "We use essential cookies to keep you logged in. We'd also like to use analytics cookies (Google Analytics) to help us improve the app."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:399
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "Assessment points can be linked to only one lesson at a time, and this one is already linked to another lesson."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:391
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Could not link assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:392
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Could not unlink assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:404
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Do you want to unlink it from \"%{linked_lesson}\" and link to \"%{this_lesson}\" (this lesson)?"
 msgstr ""
@@ -6260,7 +6253,7 @@ msgstr ""
 msgid "Lesson assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:289
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:296
 #, elixir-autogen, elixir-format
 msgid "Lesson:"
 msgstr ""
@@ -6270,7 +6263,7 @@ msgstr ""
 msgid "Link assessment point to this lesson"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:397
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Link assessment point"
 msgstr ""
@@ -6305,13 +6298,13 @@ msgstr ""
 msgid "No linked assessment points"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:67
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:71
 #: lib/lanttern_web/live/shared/schools/class_staff_member_form_overlay_component.ex:48
 #, elixir-autogen, elixir-format
 msgid "Unlink"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:415
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "Update link"
 msgstr ""
@@ -6763,4 +6756,40 @@ msgstr ""
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Here you'll find information about the strand assessments. Click the cards to view more details about it."
+msgstr ""
+
+#: lib/lanttern/lessons/lesson_curriculum_item.ex:41
+#, elixir-autogen, elixir-format
+msgid "Curriculum item already linked to this lesson"
+msgstr ""
+
+#: lib/lanttern/strands/strand_curriculum_item.ex:41
+#, elixir-autogen, elixir-format
+msgid "Curriculum item already linked to this strand"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:352
+#, elixir-autogen, elixir-format
+msgid "Lesson Curriculum"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:527
+#, elixir-autogen, elixir-format
+msgid "New strand goal"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:406
+#, elixir-autogen, elixir-format
+msgid "No curriculum items linked to this lesson"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:108
+#, elixir-autogen, elixir-format
+msgid "No curriculum items linked to this strand"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:92
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:392
+#, elixir-autogen, elixir-format
+msgid "Replace"
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -122,7 +122,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:137
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:277
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:330
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:412
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:473
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:102
 #: lib/lanttern_web/live/shared/agent_chat/agent_preferences_overlay_component.ex:73
 #: lib/lanttern_web/live/shared/agent_chat/rename_conversation_form_component.ex:28
@@ -519,7 +519,9 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_component_form_component.ex:62
 #: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:62
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:71
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:100
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:83
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:398
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:36
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:139
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:183
@@ -557,10 +559,9 @@ msgstr ""
 msgid "Current assessment points"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:270
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:83
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:277
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:102
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:46
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:50
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:286
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:118
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:34
@@ -588,11 +589,12 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/lesson_templates/lesson_template_card_component.ex:28
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:161
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:309
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:109
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:81
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:240
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:79
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:248
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:301
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:383
 #: lib/lanttern_web/live/pages/students/settings/tags_component.ex:46
 #: lib/lanttern_web/live/pages/students_records/settings/status_component.ex:61
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:57
@@ -814,8 +816,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:261
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:297
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:330
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:157
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:175
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:192
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:210
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:575
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:776
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:777
@@ -877,7 +879,8 @@ msgid "About the curriculum component"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.ex:67
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:57
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:117
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:497
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add curriculum item"
 msgstr ""
@@ -1209,7 +1212,7 @@ msgstr ""
 msgid "Link strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:118
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:133
 #, elixir-autogen, elixir-format
 msgid "List of report cards linked to this strand."
 msgstr ""
@@ -1330,6 +1333,8 @@ msgstr ""
 #: lib/lanttern_web/components/core_components.ex:356
 #: lib/lanttern_web/components/core_components.ex:1649
 #: lib/lanttern_web/components/form_components.ex:1243
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:98
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:396
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:196
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:158
 #, elixir-autogen, elixir-format
@@ -1355,7 +1360,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:22
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:29
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:116
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:131
 #: lib/lanttern_web/live/pages/student_report_cards/student_report_cards_live.html.heex:3
 #: lib/lanttern_web/live/shared/menu_component.ex:459
 #: lib/lanttern_web/live/shared/menu_component.ex:478
@@ -1426,7 +1431,7 @@ msgid "Strand already linked to report card"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:96
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:142
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:116
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strand goal"
@@ -1612,11 +1617,6 @@ msgstr ""
 msgid "About this assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:95
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Report info"
-msgstr ""
-
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:109
 #, elixir-autogen, elixir-format
 msgid "Report information"
@@ -1700,7 +1700,7 @@ msgid_plural "%{count} changes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:132
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:147
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No report cards linked to this strand"
 msgstr ""
@@ -2174,7 +2174,7 @@ msgid "Goal assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:76
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:183
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:187
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:305
 #, elixir-autogen, elixir-format
 msgid "Goals assessment"
@@ -2887,7 +2887,7 @@ msgid "Edit report to add a cover image"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:26
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:23
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:21
 #, elixir-autogen, elixir-format
 msgid "Edit strand to add a cover image"
 msgstr ""
@@ -2949,7 +2949,7 @@ msgstr ""
 msgid "Loading profiles"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:506
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:513
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New assessment point"
 msgstr ""
@@ -3113,7 +3113,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/shared/strand_report/overview/strand_report_overview_live.html.heex:17
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_overview_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:25
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:22
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:20
 #, elixir-autogen, elixir-format
 msgid "Strand cover image"
 msgstr ""
@@ -3362,7 +3362,7 @@ msgstr ""
 msgid "Shared with students and guardians"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:46
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:44
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:86
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Teacher instructions"
@@ -4471,28 +4471,24 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:132
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:132
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:174
 #, elixir-autogen, elixir-format
 msgid "Assessment point and entries deleted successfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:123
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:123
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:165
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point created successfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:129
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:129
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:171
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point deleted successfully"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:126
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:126
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:168
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point updated successfully"
 msgstr ""
@@ -4621,11 +4617,6 @@ msgstr ""
 #: lib/lanttern_web/live/shared/rubrics/rubric_diff_info_overlay_component.ex:27
 #, elixir-autogen, elixir-format
 msgid "There are two ways to \"connect\" students and differentiation rubrics:"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:79
-#, elixir-autogen, elixir-format
-msgid "Uses rubric in final assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/rubrics/rubric_diff_info_overlay_component.ex:34
@@ -5096,7 +5087,7 @@ msgid "Edit content"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:560
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:367
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:428
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit lesson"
 msgstr ""
@@ -5152,7 +5143,7 @@ msgstr ""
 msgid "Lesson name"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:150
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Lesson published"
 msgstr ""
@@ -5162,7 +5153,7 @@ msgstr ""
 msgid "Lesson resources"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:172
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Lesson unpublished"
 msgstr ""
@@ -5210,6 +5201,8 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:95
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:85
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:55
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:358
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New"
 msgstr ""
@@ -5304,7 +5297,7 @@ msgstr ""
 msgid "Something went wrong when trying to delete the lesson"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:51
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:49
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strand Curriculum"
 msgstr ""
@@ -5627,12 +5620,12 @@ msgstr ""
 msgid "Chat"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:359
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:420
 #, elixir-autogen, elixir-format
 msgid "Create with AI"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:359
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:420
 #, elixir-autogen, elixir-format
 msgid "Enhance with AI"
 msgstr ""
@@ -5738,19 +5731,19 @@ msgstr ""
 msgid "Assessment information"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:332
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:339
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point created"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:380
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:421
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:387
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:526
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:347
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:406
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:354
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:511
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point updated"
 msgstr ""
@@ -5796,8 +5789,8 @@ msgstr ""
 msgid "Edit assessment info"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:518
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:355
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:539
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:390
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit assessment point"
 msgstr ""
@@ -5812,7 +5805,7 @@ msgstr ""
 msgid "Edit lesson tag"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:193
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:197
 #, elixir-autogen, elixir-format
 msgid "Goals assessment are defined by the strand curriculum."
 msgstr ""
@@ -5854,9 +5847,9 @@ msgid "Manage lesson tags below"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:8
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:122
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:152
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:189
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:126
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:156
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:193
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:42
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marking"
@@ -5882,7 +5875,7 @@ msgstr ""
 msgid "New lesson tag"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:176
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:180
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No assessment points in this moment yet"
 msgstr ""
@@ -5956,7 +5949,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:28
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:44
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:47
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:137
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:141
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:57
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strand goals"
@@ -5986,13 +5979,13 @@ msgstr ""
 msgid "Use this area to share assessment information with students (e.g. grade composition)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:266
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:42
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:273
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:46
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Uses rubric in assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:198
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:202
 #, elixir-autogen, elixir-format
 msgid "You can manage curriculum items in the overview section."
 msgstr ""
@@ -6235,22 +6228,22 @@ msgstr ""
 msgid "We use essential cookies to keep you logged in. We'd also like to use analytics cookies (Google Analytics) to help us improve the app."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:399
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "Assessment points can be linked to only one lesson at a time, and this one is already linked to another lesson."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:391
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Could not link assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:392
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Could not unlink assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:404
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Do you want to unlink it from \"%{linked_lesson}\" and link to \"%{this_lesson}\" (this lesson)?"
 msgstr ""
@@ -6260,7 +6253,7 @@ msgstr ""
 msgid "Lesson assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:289
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:296
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lesson:"
 msgstr ""
@@ -6270,7 +6263,7 @@ msgstr ""
 msgid "Link assessment point to this lesson"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:397
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:458
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Link assessment point"
 msgstr ""
@@ -6305,13 +6298,13 @@ msgstr ""
 msgid "No linked assessment points"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:67
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:71
 #: lib/lanttern_web/live/shared/schools/class_staff_member_form_overlay_component.ex:48
 #, elixir-autogen, elixir-format
 msgid "Unlink"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:415
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:476
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Update link"
 msgstr ""
@@ -6763,4 +6756,40 @@ msgstr ""
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Here you'll find information about the strand assessments. Click the cards to view more details about it."
+msgstr ""
+
+#: lib/lanttern/lessons/lesson_curriculum_item.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Curriculum item already linked to this lesson"
+msgstr ""
+
+#: lib/lanttern/strands/strand_curriculum_item.ex:41
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Curriculum item already linked to this strand"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:352
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Lesson Curriculum"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:527
+#, elixir-autogen, elixir-format, fuzzy
+msgid "New strand goal"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:406
+#, elixir-autogen, elixir-format
+msgid "No curriculum items linked to this lesson"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:108
+#, elixir-autogen, elixir-format, fuzzy
+msgid "No curriculum items linked to this strand"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:92
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:392
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Replace"
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -122,7 +122,7 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:137
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:277
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:330
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:412
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:473
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.html.heex:102
 #: lib/lanttern_web/live/shared/agent_chat/agent_preferences_overlay_component.ex:73
 #: lib/lanttern_web/live/shared/agent_chat/rename_conversation_form_component.ex:28
@@ -519,7 +519,9 @@ msgstr "Adicionar rubrica"
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_component_form_component.ex:62
 #: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:62
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:71
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:100
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:83
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:398
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:36
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:139
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:183
@@ -557,10 +559,9 @@ msgstr "Você tem certeza?"
 msgid "Current assessment points"
 msgstr "Pontos de avaliação atuais"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:270
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:83
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:277
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:102
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:46
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:50
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:286
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:118
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:34
@@ -588,11 +589,12 @@ msgstr "Diferenciação"
 #: lib/lanttern_web/live/pages/settings/lesson_templates/lesson_template_card_component.ex:28
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:161
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:309
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:109
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:81
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:240
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:79
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:248
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:301
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:383
 #: lib/lanttern_web/live/pages/students/settings/tags_component.ex:46
 #: lib/lanttern_web/live/pages/students_records/settings/status_component.ex:61
 #: lib/lanttern_web/live/pages/students_records/settings/tags_component.ex:57
@@ -663,7 +665,7 @@ msgstr "Selecione uma escala"
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:64
 #, elixir-autogen, elixir-format
 msgid "Select curriculum item"
-msgstr "Selecionar item curricular"
+msgstr "Selecionar parâmetro curricular"
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1057
 #, elixir-autogen, elixir-format
@@ -751,7 +753,7 @@ msgstr "Criar novo momento"
 #: lib/lanttern/assessments/assessment_point.ex:125
 #, elixir-autogen, elixir-format
 msgid "Curriculum item already added to this strand"
-msgstr "Item curricular já adicionado à esta trilha"
+msgstr "Parâmetro curricular já adicionado à esta trilha"
 
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:525
 #, elixir-autogen, elixir-format
@@ -814,8 +816,8 @@ msgstr "Nenhum momento para esta trilha ainda"
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:261
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:297
 #: lib/lanttern_web/live/pages/report_cards/id/students_grades_component.ex:330
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:157
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:175
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:192
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:210
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:575
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:776
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:777
@@ -877,10 +879,11 @@ msgid "About the curriculum component"
 msgstr "Sobre o component curricular"
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.ex:67
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:57
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:117
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:497
 #, elixir-autogen, elixir-format
 msgid "Add curriculum item"
-msgstr "Adicionar item curricular"
+msgstr "Adicionar parâmetro curricular"
 
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:98
 #, elixir-autogen, elixir-format
@@ -973,7 +976,7 @@ msgstr "Diferenciação curricular"
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.ex:120
 #, elixir-autogen, elixir-format
 msgid "Curriculum item deleted"
-msgstr "Item curricular removido"
+msgstr "Parâmetro curricular removido"
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1131
 #: lib/lanttern_web/components/reporting_components.ex:225
@@ -1024,7 +1027,7 @@ msgstr "Ex: projeto, unidade, curso, etc."
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.ex:80
 #, elixir-autogen, elixir-format
 msgid "Edit curriculum item"
-msgstr "Editar item curricular"
+msgstr "Editar parâmetro curricular"
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:140
 #: lib/lanttern_web/live/pages/report_cards/id/grades_component.ex:39
@@ -1060,7 +1063,7 @@ msgstr "Erro ao adicionar disciplina ao relatório de notas"
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.ex:128
 #, elixir-autogen, elixir-format
 msgid "Error deleting curriculum item"
-msgstr "Erro ao deletar item curricular"
+msgstr "Erro ao deletar parâmetro curricular"
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.ex:153
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.ex:195
@@ -1107,12 +1110,12 @@ msgstr "Erro ao atualizar o peso do relatório de notas do ciclo"
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:66
 #, elixir-autogen, elixir-format
 msgid "Filter curriculum items by subject"
-msgstr "Filtrar itens curriculares por disciplina"
+msgstr "Filtrar parâmetros curriculares por disciplina"
 
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:77
 #, elixir-autogen, elixir-format
 msgid "Filter curriculum items by year"
-msgstr "Filtrar itens curriculares por ano"
+msgstr "Filtrar parâmetros curriculares por ano"
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1091
 #: lib/lanttern_web/components/grades_reports_components.ex:1158
@@ -1209,7 +1212,7 @@ msgstr "Nível"
 msgid "Link strand"
 msgstr "Vincular trilha"
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:118
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:133
 #, elixir-autogen, elixir-format
 msgid "List of report cards linked to this strand."
 msgstr "Lista de report cards vinculados a esta trilha"
@@ -1330,6 +1333,8 @@ msgstr "Recalcular nota"
 #: lib/lanttern_web/components/core_components.ex:356
 #: lib/lanttern_web/components/core_components.ex:1649
 #: lib/lanttern_web/components/form_components.ex:1243
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:98
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:396
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:196
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:158
 #, elixir-autogen, elixir-format
@@ -1355,7 +1360,7 @@ msgstr "Id do report card"
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.ex:22
 #: lib/lanttern_web/live/pages/report_cards/report_cards_live.html.heex:3
 #: lib/lanttern_web/live/pages/school/students/id/student_live.html.heex:29
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:116
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:131
 #: lib/lanttern_web/live/pages/student_report_cards/student_report_cards_live.html.heex:3
 #: lib/lanttern_web/live/shared/menu_component.ex:459
 #: lib/lanttern_web/live/shared/menu_component.ex:478
@@ -1385,7 +1390,7 @@ msgstr "Salvar relatório da Trilha"
 #: lib/lanttern_web/live/shared/curricula/curriculum_item_form_component.ex:56
 #, elixir-autogen, elixir-format
 msgid "Save curriculum item"
-msgstr "Salvar item curricular"
+msgstr "Salvar parâmetro curricular"
 
 #: lib/lanttern_web/live/shared/grades_reports/grades_report_form_component.ex:87
 #, elixir-autogen, elixir-format
@@ -1426,7 +1431,7 @@ msgid "Strand already linked to report card"
 msgstr "Trilha já vinculada ao report card"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:96
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:142
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:116
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Strand goal"
@@ -1612,11 +1617,6 @@ msgstr "Você precisa estar logado para acessar esta página."
 msgid "About this assessment"
 msgstr "Sobre esta avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:95
-#, elixir-autogen, elixir-format
-msgid "Report info"
-msgstr "Informações do relatório"
-
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:109
 #, elixir-autogen, elixir-format
 msgid "Report information"
@@ -1700,7 +1700,7 @@ msgid_plural "%{count} changes"
 msgstr[0] "1 alteração"
 msgstr[1] "%{count} alterações"
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:132
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:147
 #, elixir-autogen, elixir-format
 msgid "No report cards linked to this strand"
 msgstr "Nenhum report card vinculado a esta trilha"
@@ -2174,7 +2174,7 @@ msgid "Goal assessment"
 msgstr "Avaliação de objetivo"
 
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:76
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:183
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:187
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:305
 #, elixir-autogen, elixir-format
 msgid "Goals assessment"
@@ -2887,7 +2887,7 @@ msgid "Edit report to add a cover image"
 msgstr "Edite o relatório para adiconar uma imagem de capa"
 
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:26
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:23
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:21
 #, elixir-autogen, elixir-format
 msgid "Edit strand to add a cover image"
 msgstr "Edite a trilha para adicionar uma imagem de capa"
@@ -2949,7 +2949,7 @@ msgstr "Carregando ciclos"
 msgid "Loading profiles"
 msgstr "Carregando perfis"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:506
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:513
 #, elixir-autogen, elixir-format
 msgid "New assessment point"
 msgstr "Novo ponto de avaliação"
@@ -2957,7 +2957,7 @@ msgstr "Novo ponto de avaliação"
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:38
 #, elixir-autogen, elixir-format
 msgid "New curriculum item"
-msgstr "Novo item curricular"
+msgstr "Novo parâmetro curricular"
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:22
 #, elixir-autogen, elixir-format
@@ -3113,7 +3113,7 @@ msgstr "Começa em"
 #: lib/lanttern_web/live/pages/shared/strand_report/overview/strand_report_overview_live.html.heex:17
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_overview_component.ex:27
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:25
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:22
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:20
 #, elixir-autogen, elixir-format
 msgid "Strand cover image"
 msgstr "Imagem de capa da trilha"
@@ -3126,7 +3126,7 @@ msgstr "(Avaliação final da trilha)"
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:202
 #, elixir-autogen, elixir-format
 msgid "Strand final assessment for curriculum item"
-msgstr "Avaliação final do item curricular na trilha"
+msgstr "Avaliação final do parâmetro curricular na trilha"
 
 #: lib/lanttern_web/live/pages/strands/library/strands_library_live.ex:22
 #, elixir-autogen, elixir-format
@@ -3362,7 +3362,7 @@ msgstr "Compartilhar com estudantes e responsáveis"
 msgid "Shared with students and guardians"
 msgstr "Compartilhado com estudantes e responsáveis"
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:46
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:44
 #: lib/lanttern_web/live/shared/learning_context/strand_form_component.ex:86
 #, elixir-autogen, elixir-format
 msgid "Teacher instructions"
@@ -4471,28 +4471,24 @@ msgstr "Adicionar rubrica de diferenciação"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:132
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:132
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:174
 #, elixir-autogen, elixir-format
 msgid "Assessment point and entries deleted successfully"
 msgstr "Ponto de avaliação e registros deletados com sucesso"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:123
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:123
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:165
 #, elixir-autogen, elixir-format
 msgid "Assessment point created successfully"
 msgstr "Ponto de avaliação criado com sucesso"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:129
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:129
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:171
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted successfully"
 msgstr "Ponto de avaliação deletado com sucesso"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:126
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:126
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:168
 #, elixir-autogen, elixir-format
 msgid "Assessment point updated successfully"
 msgstr "Ponto de avaliação atualizado com sucesso"
@@ -4505,7 +4501,7 @@ msgstr "Atribuindo uma rubrica de diferenciação em um registro de ponto de ava
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:65
 #, elixir-autogen, elixir-format
 msgid "Curriculum item"
-msgstr "Item curricular"
+msgstr "Parâmetro curricular"
 
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:296
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:51
@@ -4576,7 +4572,7 @@ msgstr "Sem rubrica de diferenciação"
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:335
 #, elixir-autogen, elixir-format
 msgid "No differentiation rubric matching assessment point curriculum item and scale"
-msgstr "Nenhuma rubrica de diferenciação correspondente ao item curricular e escala do ponto de avaliação"
+msgstr "Nenhuma rubrica de diferenciação correspondente ao parâmetro curricular e escala do ponto de avaliação"
 
 #: lib/lanttern_web/live/shared/rubrics/rubric_diff_info_overlay_component.ex:56
 #, elixir-autogen, elixir-format
@@ -4596,7 +4592,7 @@ msgstr "Sem rubrica"
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:221
 #, elixir-autogen, elixir-format
 msgid "No rubric matching curriculum item and scale"
-msgstr "Nenhuma rubrica correspondente ao item curricular e escala"
+msgstr "Nenhuma rubrica correspondente ao parâmetro curricular e escala"
 
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:328
 #, elixir-autogen, elixir-format
@@ -4606,12 +4602,12 @@ msgstr "Rubrica deletada com sucesso"
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:39
 #, elixir-autogen, elixir-format
 msgid "Rubric for curriculum item"
-msgstr "Rubrica para item curricular"
+msgstr "Rubrica para parâmetro curricular"
 
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:106
 #, elixir-autogen, elixir-format
 msgid "Rubrics can be linked to assessment points with matching curriculum item, scale, and differentiation type."
-msgstr "Rubricas podem ser vinculadas a pontos de avaliação com item curricular, escala e tipo de diferenciação correspondentes."
+msgstr "Rubricas podem ser vinculadas a pontos de avaliação com parâmetro curricular, escala e tipo de diferenciação correspondentes."
 
 #: lib/lanttern_web/live/shared/rubrics/rubric_diff_info_overlay_component.ex:42
 #, elixir-autogen, elixir-format
@@ -4622,11 +4618,6 @@ msgstr "Estudantes atualmente vinculados à rubrica selecionada"
 #, elixir-autogen, elixir-format
 msgid "There are two ways to \"connect\" students and differentiation rubrics:"
 msgstr "Existem duas formas de \"conectar\" estudantes e rubricas de diferenciação:"
-
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:79
-#, elixir-autogen, elixir-format
-msgid "Uses rubric in final assessment"
-msgstr "Usa rubrica na avaliação final"
 
 #: lib/lanttern_web/live/shared/rubrics/rubric_diff_info_overlay_component.ex:34
 #, elixir-autogen, elixir-format
@@ -5096,7 +5087,7 @@ msgid "Edit content"
 msgstr "Editar conteúdo"
 
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:560
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:367
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:428
 #, elixir-autogen, elixir-format
 msgid "Edit lesson"
 msgstr "Editar aula"
@@ -5152,7 +5143,7 @@ msgstr "Aula no momento \"%{moment}\""
 msgid "Lesson name"
 msgstr "Nome da aula"
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:150
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:185
 #, elixir-autogen, elixir-format
 msgid "Lesson published"
 msgstr "Aula publicada"
@@ -5162,7 +5153,7 @@ msgstr "Aula publicada"
 msgid "Lesson resources"
 msgstr "Recursos da aula"
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:172
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:207
 #, elixir-autogen, elixir-format
 msgid "Lesson unpublished"
 msgstr "Aula despublicada"
@@ -5210,6 +5201,8 @@ msgstr "Momento (opcional)"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:95
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:85
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:55
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:358
 #, elixir-autogen, elixir-format
 msgid "New"
 msgstr "Novo"
@@ -5304,7 +5297,7 @@ msgstr "Selecione um momento para anexar esta aula ou deixe sem seleção para u
 msgid "Something went wrong when trying to delete the lesson"
 msgstr "Algo deu errado ao tentar deletar a aula"
 
-#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:51
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Strand Curriculum"
 msgstr "Currículo da trilha"
@@ -5627,12 +5620,12 @@ msgstr "(pode levar um tempo)"
 msgid "Chat"
 msgstr "Conversa"
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:359
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:420
 #, elixir-autogen, elixir-format
 msgid "Create with AI"
 msgstr "Criar com IA"
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:359
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:420
 #, elixir-autogen, elixir-format
 msgid "Enhance with AI"
 msgstr "Melhorar com IA"
@@ -5738,19 +5731,19 @@ msgstr "Tem certeza? Todas as aulas vinculadas também serão excluídas."
 msgid "Assessment information"
 msgstr "Informações de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:332
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:339
 #, elixir-autogen, elixir-format
 msgid "Assessment point created"
 msgstr "Ponto de avaliação criado"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:380
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:421
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:387
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted"
 msgstr "Ponto de avaliação excluído"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:347
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:406
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:354
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Assessment point updated"
 msgstr "Ponto de avaliação atualizado"
@@ -5796,8 +5789,8 @@ msgstr "Excluir aulas também"
 msgid "Edit assessment info"
 msgstr "Editar informações de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:518
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:355
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:539
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Edit assessment point"
 msgstr "Editar ponto de avaliação"
@@ -5812,7 +5805,7 @@ msgstr "Editar descrição"
 msgid "Edit lesson tag"
 msgstr "Editar tag de aula"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:193
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:197
 #, elixir-autogen, elixir-format
 msgid "Goals assessment are defined by the strand curriculum."
 msgstr "A avaliação dos objetivos é definida pelo currículo da trilha."
@@ -5854,9 +5847,9 @@ msgid "Manage lesson tags below"
 msgstr "Gerencie as tags de aula abaixo"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:8
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:122
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:152
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:189
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:126
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:156
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:193
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Marking"
@@ -5882,7 +5875,7 @@ msgstr "O momento possui aulas vinculadas."
 msgid "New lesson tag"
 msgstr "Nova tag de aula"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:176
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:180
 #, elixir-autogen, elixir-format
 msgid "No assessment points in this moment yet"
 msgstr "Nenhum ponto de avaliação neste momento ainda"
@@ -5956,7 +5949,7 @@ msgstr "Informações de avaliação da trilha"
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:28
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/goals_assessment_component.ex:44
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/moment_assessment_component.ex:47
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:137
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:141
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:57
 #, elixir-autogen, elixir-format
 msgid "Strand goals"
@@ -5986,16 +5979,16 @@ msgstr "Alternar card da tag de aula"
 msgid "Use this area to share assessment information with students (e.g. grade composition)"
 msgstr "Use esta área para compartilhar informações de avaliação com os estudantes (ex.: composição das notas)"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:266
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:42
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:273
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Uses rubric in assessment"
 msgstr "Usa rubrica na avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:198
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:202
 #, elixir-autogen, elixir-format
 msgid "You can manage curriculum items in the overview section."
-msgstr "Você pode gerenciar os itens de currículo na seção de visão geral."
+msgstr "Você pode gerenciar os parâmetros curriculares na seção de visão geral."
 
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tags_live.ex:34
 #, elixir-autogen, elixir-format
@@ -6178,7 +6171,7 @@ msgstr "ex.: Professor Principal, Assistente, etc."
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:78
 #, elixir-autogen, elixir-format
 msgid "Final assessment points information, grouped by curriculum item."
-msgstr "Informações dos pontos de avaliação finais, agrupados por item do currículo."
+msgstr "Informações dos pontos de avaliação finais, agrupados por parâmetro curricular."
 
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:49
 #, elixir-autogen, elixir-format
@@ -6235,22 +6228,22 @@ msgstr "Somente essenciais"
 msgid "We use essential cookies to keep you logged in. We'd also like to use analytics cookies (Google Analytics) to help us improve the app."
 msgstr "Usamos cookies essenciais para mantê-lo(a) conectado(a). Também gostaríamos de usar cookies de análise (Google Analytics) para nos ajudar a melhorar o aplicativo."
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:399
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:460
 #, elixir-autogen, elixir-format
 msgid "Assessment points can be linked to only one lesson at a time, and this one is already linked to another lesson."
 msgstr "Pontos de avaliação podem estar vinculados a somente uma aula por vez, e este já está vinculado a outra aula."
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:391
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:496
 #, elixir-autogen, elixir-format
 msgid "Could not link assessment point"
 msgstr "Não foi possível vincular o ponto de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:392
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:497
 #, elixir-autogen, elixir-format
 msgid "Could not unlink assessment point"
 msgstr "Não foi possível desvincular o ponto de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:404
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:465
 #, elixir-autogen, elixir-format
 msgid "Do you want to unlink it from \"%{linked_lesson}\" and link to \"%{this_lesson}\" (this lesson)?"
 msgstr "Você deseja desvincular de \"%{linked_lesson}\" e vincular a \"%{this_lesson}\" (esta aula)?"
@@ -6260,7 +6253,7 @@ msgstr "Você deseja desvincular de \"%{linked_lesson}\" e vincular a \"%{this_l
 msgid "Lesson assessment"
 msgstr "Avaliação da aula"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:289
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:296
 #, elixir-autogen, elixir-format
 msgid "Lesson:"
 msgstr "Aula:"
@@ -6270,7 +6263,7 @@ msgstr "Aula:"
 msgid "Link assessment point to this lesson"
 msgstr "Vincular ponto de avaliação a esta aula"
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:397
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:458
 #, elixir-autogen, elixir-format
 msgid "Link assessment point"
 msgstr "Vincular ponto de avaliação"
@@ -6305,13 +6298,13 @@ msgstr "Nenhum ponto de avaliação encontrado"
 msgid "No linked assessment points"
 msgstr "Nenhum ponto de avaliação vinculado"
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:67
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:71
 #: lib/lanttern_web/live/shared/schools/class_staff_member_form_overlay_component.ex:48
 #, elixir-autogen, elixir-format
 msgid "Unlink"
 msgstr "Desvincular"
 
-#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:415
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:476
 #, elixir-autogen, elixir-format
 msgid "Update link"
 msgstr "Atualizar vínculo"
@@ -6743,7 +6736,7 @@ msgstr "Nenhum currículo criado ainda"
 #: lib/lanttern_web/live/pages/curriculum/component/id/curriculum_component_live.html.heex:51
 #, elixir-autogen, elixir-format
 msgid "No curriculum items for current filters"
-msgstr "Nenhum item curricular com os filtros selecionados."
+msgstr "Nenhum parâmetro curricular com os filtros selecionados."
 
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_card_component.ex:38
 #, elixir-autogen, elixir-format
@@ -6764,3 +6757,39 @@ msgstr "Alternar card do currículo"
 #, elixir-autogen, elixir-format
 msgid "Here you'll find information about the strand assessments. Click the cards to view more details about it."
 msgstr "Aqui você encontrará informações sobre as avaliações da trilha. Clique nos cards para ver mais detalhes."
+
+#: lib/lanttern/lessons/lesson_curriculum_item.ex:41
+#, elixir-autogen, elixir-format
+msgid "Curriculum item already linked to this lesson"
+msgstr "Parâmetro curricular já vinculado à esta aula"
+
+#: lib/lanttern/strands/strand_curriculum_item.ex:41
+#, elixir-autogen, elixir-format
+msgid "Curriculum item already linked to this strand"
+msgstr "Parâmetro curricular já vinculado à esta trilha"
+
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:352
+#, elixir-autogen, elixir-format
+msgid "Lesson Curriculum"
+msgstr "Currículo da Aula"
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:527
+#, elixir-autogen, elixir-format
+msgid "New strand goal"
+msgstr "Novo objetivo da trilha"
+
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:406
+#, elixir-autogen, elixir-format
+msgid "No curriculum items linked to this lesson"
+msgstr "Nenhum parâmetro curricular vinculado à esta aula"
+
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:108
+#, elixir-autogen, elixir-format
+msgid "No curriculum items linked to this strand"
+msgstr "Nenhum parâmetro curricular vinculado à esta trilha"
+
+#: lib/lanttern_web/live/pages/strands/id/overview_component.ex:92
+#: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:392
+#, elixir-autogen, elixir-format
+msgid "Replace"
+msgstr "Substituir"

--- a/priv/repo/migrations/20260427154901_create_strand_curriculum_items.exs
+++ b/priv/repo/migrations/20260427154901_create_strand_curriculum_items.exs
@@ -1,0 +1,16 @@
+defmodule Lanttern.Repo.Migrations.CreateStrandCurriculumItems do
+  use Ecto.Migration
+
+  def change do
+    create table(:strand_curriculum_items) do
+      add :position, :integer, default: 0, null: false
+      add :strand_id, references(:strands, on_delete: :delete_all), null: false
+      add :curriculum_item_id, references(:curriculum_items, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:strand_curriculum_items, [:strand_id])
+    create unique_index(:strand_curriculum_items, [:curriculum_item_id, :strand_id])
+  end
+end

--- a/priv/repo/migrations/20260427154901_recreate_strand_curriculum_items.exs
+++ b/priv/repo/migrations/20260427154901_recreate_strand_curriculum_items.exs
@@ -1,4 +1,4 @@
-defmodule Lanttern.Repo.Migrations.CreateStrandCurriculumItems do
+defmodule Lanttern.Repo.Migrations.RecreateStrandCurriculumItems do
   use Ecto.Migration
 
   def change do

--- a/priv/repo/migrations/20260427164926_create_lesson_curriculum_items.exs
+++ b/priv/repo/migrations/20260427164926_create_lesson_curriculum_items.exs
@@ -1,0 +1,16 @@
+defmodule Lanttern.Repo.Migrations.CreateLessonCurriculumItems do
+  use Ecto.Migration
+
+  def change do
+    create table(:lesson_curriculum_items) do
+      add :position, :integer, default: 0, null: false
+      add :lesson_id, references(:lessons, on_delete: :delete_all), null: false
+      add :curriculum_item_id, references(:curriculum_items, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+
+    create index(:lesson_curriculum_items, [:lesson_id])
+    create unique_index(:lesson_curriculum_items, [:curriculum_item_id, :lesson_id])
+  end
+end

--- a/test/lanttern/lessons_test.exs
+++ b/test/lanttern/lessons_test.exs
@@ -824,10 +824,13 @@ defmodule Lanttern.LessonsTest do
 
     @invalid_attrs %{position: nil}
 
-    test "list_lesson_curriculum_items/1 returns all lesson_curriculum_items" do
+    test "list_lesson_curriculum_items/2 returns lesson_curriculum_items for given lesson" do
       scope = staff_scope_fixture()
-      %{id: id} = insert(:lesson_curriculum_item)
-      assert [%LessonCurriculumItem{id: ^id}] = Lessons.list_lesson_curriculum_items(scope)
+      %{id: id, lesson_id: lesson_id} = insert(:lesson_curriculum_item)
+      insert(:lesson_curriculum_item)
+
+      assert [%LessonCurriculumItem{id: ^id}] =
+               Lessons.list_lesson_curriculum_items(scope, lesson_id)
     end
 
     test "get_lesson_curriculum_item!/2 returns the lesson_curriculum_item with given id" do

--- a/test/lanttern/lessons_test.exs
+++ b/test/lanttern/lessons_test.exs
@@ -816,4 +816,108 @@ defmodule Lanttern.LessonsTest do
       assert %Ecto.Changeset{} = Lessons.change_tag(scope, tag)
     end
   end
+
+  describe "lesson_curriculum_items" do
+    alias Lanttern.Lessons.LessonCurriculumItem
+
+    import Lanttern.IdentityFixtures, only: [staff_scope_fixture: 0]
+
+    @invalid_attrs %{position: nil}
+
+    test "list_lesson_curriculum_items/1 returns all lesson_curriculum_items" do
+      scope = staff_scope_fixture()
+      %{id: id} = insert(:lesson_curriculum_item)
+      assert [%LessonCurriculumItem{id: ^id}] = Lessons.list_lesson_curriculum_items(scope)
+    end
+
+    test "get_lesson_curriculum_item!/2 returns the lesson_curriculum_item with given id" do
+      scope = staff_scope_fixture()
+      %{id: id} = insert(:lesson_curriculum_item)
+      assert %LessonCurriculumItem{id: ^id} = Lessons.get_lesson_curriculum_item!(scope, id)
+    end
+
+    test "create_lesson_curriculum_item/2 with valid data creates a lesson_curriculum_item" do
+      scope = staff_scope_fixture()
+      lesson = insert(:lesson)
+      curriculum_item = insert(:curriculum_item)
+      valid_attrs = %{position: 42, lesson_id: lesson.id, curriculum_item_id: curriculum_item.id}
+
+      assert {:ok, %LessonCurriculumItem{position: 42}} =
+               Lessons.create_lesson_curriculum_item(scope, valid_attrs)
+    end
+
+    test "create_lesson_curriculum_item/2 with invalid data returns error changeset" do
+      scope = staff_scope_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               Lessons.create_lesson_curriculum_item(scope, @invalid_attrs)
+    end
+
+    test "create_lesson_curriculum_item/2 raises when scope is not staff" do
+      scope = %Lanttern.Identity.Scope{profile_type: "student"}
+      assert_raise MatchError, fn -> Lessons.create_lesson_curriculum_item(scope, %{}) end
+    end
+
+    test "update_lesson_curriculum_item/3 with valid data updates the lesson_curriculum_item" do
+      scope = staff_scope_fixture()
+      lesson_curriculum_item = insert(:lesson_curriculum_item)
+
+      assert {:ok, %LessonCurriculumItem{position: 43}} =
+               Lessons.update_lesson_curriculum_item(scope, lesson_curriculum_item, %{
+                 position: 43
+               })
+    end
+
+    test "update_lesson_curriculum_item/3 with invalid data returns error changeset" do
+      scope = staff_scope_fixture()
+      %{id: id} = lesson_curriculum_item = insert(:lesson_curriculum_item)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Lessons.update_lesson_curriculum_item(
+                 scope,
+                 lesson_curriculum_item,
+                 @invalid_attrs
+               )
+
+      assert %LessonCurriculumItem{id: ^id} = Lessons.get_lesson_curriculum_item!(scope, id)
+    end
+
+    test "update_lesson_curriculum_item/3 raises when scope is not staff" do
+      scope = %Lanttern.Identity.Scope{profile_type: "student"}
+      lesson_curriculum_item = insert(:lesson_curriculum_item)
+
+      assert_raise MatchError, fn ->
+        Lessons.update_lesson_curriculum_item(scope, lesson_curriculum_item, %{})
+      end
+    end
+
+    test "delete_lesson_curriculum_item/2 deletes the lesson_curriculum_item" do
+      scope = staff_scope_fixture()
+      %{id: id} = lesson_curriculum_item = insert(:lesson_curriculum_item)
+
+      assert {:ok, %LessonCurriculumItem{id: ^id}} =
+               Lessons.delete_lesson_curriculum_item(scope, lesson_curriculum_item)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Lessons.get_lesson_curriculum_item!(scope, id)
+      end
+    end
+
+    test "delete_lesson_curriculum_item/2 raises when scope is not staff" do
+      scope = %Lanttern.Identity.Scope{profile_type: "student"}
+      lesson_curriculum_item = insert(:lesson_curriculum_item)
+
+      assert_raise MatchError, fn ->
+        Lessons.delete_lesson_curriculum_item(scope, lesson_curriculum_item)
+      end
+    end
+
+    test "change_lesson_curriculum_item/2 returns a lesson_curriculum_item changeset" do
+      scope = staff_scope_fixture()
+      lesson_curriculum_item = insert(:lesson_curriculum_item)
+
+      assert %Ecto.Changeset{} =
+               Lessons.change_lesson_curriculum_item(scope, lesson_curriculum_item)
+    end
+  end
 end

--- a/test/lanttern/llm_test.exs
+++ b/test/lanttern/llm_test.exs
@@ -65,6 +65,7 @@ defmodule Lanttern.LLMTest do
   end
 
   describe "generate_text_with_tools/4 tool loop" do
+    @tag capture_log: true
     test "returns :max_tool_iterations_exceeded when classify keeps asking for tools" do
       # Always say "call a tool" so the loop runs until the cap.
       Mimic.stub(ReqLLM, :generate_text, fn _model, _context, _opts ->
@@ -90,6 +91,7 @@ defmodule Lanttern.LLMTest do
                )
     end
 
+    @tag capture_log: true
     test "falls back to default max_tool_iterations (10) when opt is absent" do
       # Count how many iterations actually happen before the cap bites.
       counter = :counters.new(1, [])

--- a/test/lanttern/strands_test.exs
+++ b/test/lanttern/strands_test.exs
@@ -11,10 +11,14 @@ defmodule Lanttern.StrandsTest do
 
     @invalid_attrs %{position: nil}
 
-    test "list_strand_curriculum_items/1 returns all strand_curriculum_items" do
+    test "list_strand_curriculum_items/2 returns strand_curriculum_items for given strand" do
       scope = staff_scope_fixture()
-      %{id: id} = insert(:strand_curriculum_item)
-      assert [%StrandCurriculumItem{id: ^id}] = Strands.list_strand_curriculum_items(scope)
+      strand = insert(:strand)
+      %{id: id} = insert(:strand_curriculum_item, strand: strand)
+      _other = insert(:strand_curriculum_item)
+
+      assert [%StrandCurriculumItem{id: ^id}] =
+               Strands.list_strand_curriculum_items(scope, strand.id)
     end
 
     test "get_strand_curriculum_item!/2 returns the strand_curriculum_item with given id" do

--- a/test/lanttern/strands_test.exs
+++ b/test/lanttern/strands_test.exs
@@ -1,0 +1,110 @@
+defmodule Lanttern.StrandsTest do
+  use Lanttern.DataCase
+
+  alias Lanttern.Strands
+
+  describe "strand_curriculum_items" do
+    alias Lanttern.Strands.StrandCurriculumItem
+
+    import Lanttern.Factory
+    import Lanttern.IdentityFixtures, only: [staff_scope_fixture: 0]
+
+    @invalid_attrs %{position: nil}
+
+    test "list_strand_curriculum_items/1 returns all strand_curriculum_items" do
+      scope = staff_scope_fixture()
+      %{id: id} = insert(:strand_curriculum_item)
+      assert [%StrandCurriculumItem{id: ^id}] = Strands.list_strand_curriculum_items(scope)
+    end
+
+    test "get_strand_curriculum_item!/2 returns the strand_curriculum_item with given id" do
+      scope = staff_scope_fixture()
+      %{id: id} = insert(:strand_curriculum_item)
+      assert %StrandCurriculumItem{id: ^id} = Strands.get_strand_curriculum_item!(scope, id)
+    end
+
+    test "create_strand_curriculum_item/2 with valid data creates a strand_curriculum_item" do
+      scope = staff_scope_fixture()
+      strand = insert(:strand)
+      curriculum_item = insert(:curriculum_item)
+      valid_attrs = %{position: 42, strand_id: strand.id, curriculum_item_id: curriculum_item.id}
+
+      assert {:ok, %StrandCurriculumItem{position: 42}} =
+               Strands.create_strand_curriculum_item(scope, valid_attrs)
+    end
+
+    test "create_strand_curriculum_item/2 with invalid data returns error changeset" do
+      scope = staff_scope_fixture()
+
+      assert {:error, %Ecto.Changeset{}} =
+               Strands.create_strand_curriculum_item(scope, @invalid_attrs)
+    end
+
+    test "create_strand_curriculum_item/2 raises when scope is not staff" do
+      scope = %Lanttern.Identity.Scope{profile_type: "student"}
+      assert_raise MatchError, fn -> Strands.create_strand_curriculum_item(scope, %{}) end
+    end
+
+    test "update_strand_curriculum_item/3 with valid data updates the strand_curriculum_item" do
+      scope = staff_scope_fixture()
+      strand_curriculum_item = insert(:strand_curriculum_item)
+
+      assert {:ok, %StrandCurriculumItem{position: 43}} =
+               Strands.update_strand_curriculum_item(scope, strand_curriculum_item, %{
+                 position: 43
+               })
+    end
+
+    test "update_strand_curriculum_item/3 with invalid data returns error changeset" do
+      scope = staff_scope_fixture()
+      %{id: id} = strand_curriculum_item = insert(:strand_curriculum_item)
+
+      assert {:error, %Ecto.Changeset{}} =
+               Strands.update_strand_curriculum_item(
+                 scope,
+                 strand_curriculum_item,
+                 @invalid_attrs
+               )
+
+      assert %StrandCurriculumItem{id: ^id} = Strands.get_strand_curriculum_item!(scope, id)
+    end
+
+    test "update_strand_curriculum_item/3 raises when scope is not staff" do
+      scope = %Lanttern.Identity.Scope{profile_type: "student"}
+      strand_curriculum_item = insert(:strand_curriculum_item)
+
+      assert_raise MatchError, fn ->
+        Strands.update_strand_curriculum_item(scope, strand_curriculum_item, %{})
+      end
+    end
+
+    test "delete_strand_curriculum_item/2 deletes the strand_curriculum_item" do
+      scope = staff_scope_fixture()
+      %{id: id} = strand_curriculum_item = insert(:strand_curriculum_item)
+
+      assert {:ok, %StrandCurriculumItem{id: ^id}} =
+               Strands.delete_strand_curriculum_item(scope, strand_curriculum_item)
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Strands.get_strand_curriculum_item!(scope, id)
+      end
+    end
+
+    test "delete_strand_curriculum_item/2 raises when scope is not staff" do
+      scope = %Lanttern.Identity.Scope{profile_type: "student"}
+      strand_curriculum_item = insert(:strand_curriculum_item)
+
+      assert_raise MatchError, fn ->
+        Strands.delete_strand_curriculum_item(scope, strand_curriculum_item)
+      end
+    end
+
+    test "change_strand_curriculum_item/2 returns a strand_curriculum_item changeset" do
+      scope = staff_scope_fixture()
+      strand_curriculum_item = insert(:strand_curriculum_item)
+
+      assert %Ecto.Changeset{} =
+               Strands.change_strand_curriculum_item(scope, strand_curriculum_item)
+    end
+  end
+end

--- a/test/lanttern/workers/chat_response_worker_test.exs
+++ b/test/lanttern/workers/chat_response_worker_test.exs
@@ -152,6 +152,7 @@ defmodule Lanttern.ChatResponseWorkerTest do
                       {:conversation_renamed, %Conversation{name: "Paris Capital"}}}
     end
 
+    @tag capture_log: true
     test "broadcasts failed event when LLM chain fails", %{
       user: user,
       conversation: conversation

--- a/test/lanttern_web/live/pages/strands/id/overview/strand_overview_live_test.exs
+++ b/test/lanttern_web/live/pages/strands/id/overview/strand_overview_live_test.exs
@@ -2,6 +2,7 @@ defmodule LantternWeb.StrandOverviewLiveTest do
   use LantternWeb.ConnCase
 
   import Lanttern.Factory
+  import PhoenixTest
 
   alias Lanttern.LearningContextFixtures
   alias Lanttern.TaxonomyFixtures
@@ -44,9 +45,9 @@ defmodule LantternWeb.StrandOverviewLiveTest do
       strand = insert(:strand)
       sci = insert(:strand_curriculum_item, strand: strand)
 
-      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{strand.id}/overview")
-
-      assert view |> has_element?("p", sci.curriculum_item.name)
+      conn
+      |> visit("#{@live_view_base_path}/#{strand.id}/overview")
+      |> assert_has("p", text: sci.curriculum_item.name)
     end
 
     test "adds a curriculum item via search modal", %{conn: conn, user: user} do
@@ -54,15 +55,15 @@ defmodule LantternWeb.StrandOverviewLiveTest do
       strand = insert(:strand)
       curriculum_item = insert(:curriculum_item, school_id: school_id, name: "New CI xyz")
 
-      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{strand.id}/overview")
-
-      view |> element("#new-curriculum-item-button") |> render_click()
-
-      view
-      |> element("#curriculum-item-search")
-      |> render_hook("autocomplete_result_select", %{"id" => to_string(curriculum_item.id)})
-
-      assert view |> has_element?("p", "New CI xyz")
+      conn
+      |> visit("#{@live_view_base_path}/#{strand.id}/overview")
+      |> click_button("#new-curriculum-item-button", "New")
+      |> unwrap(fn view ->
+        view
+        |> element("#curriculum-item-search")
+        |> render_hook("autocomplete_result_select", %{"id" => to_string(curriculum_item.id)})
+      end)
+      |> assert_has("p", text: "New CI xyz")
     end
 
     test "removes a curriculum item", %{conn: conn} do
@@ -70,13 +71,11 @@ defmodule LantternWeb.StrandOverviewLiveTest do
       sci = insert(:strand_curriculum_item, strand: strand)
       curriculum_item_name = sci.curriculum_item.name
 
-      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{strand.id}/overview")
-
-      assert view |> has_element?("p", curriculum_item_name)
-
-      view |> element("button[role='menuitem']", "Remove") |> render_click()
-
-      refute view |> has_element?("p", curriculum_item_name)
+      conn
+      |> visit("#{@live_view_base_path}/#{strand.id}/overview")
+      |> assert_has("p", text: curriculum_item_name)
+      |> click_button("Remove")
+      |> refute_has("p", text: curriculum_item_name)
     end
   end
 

--- a/test/lanttern_web/live/pages/strands/id/overview/strand_overview_live_test.exs
+++ b/test/lanttern_web/live/pages/strands/id/overview/strand_overview_live_test.exs
@@ -1,6 +1,8 @@
 defmodule LantternWeb.StrandOverviewLiveTest do
   use LantternWeb.ConnCase
 
+  import Lanttern.Factory
+
   alias Lanttern.LearningContextFixtures
   alias Lanttern.TaxonomyFixtures
 
@@ -34,6 +36,47 @@ defmodule LantternWeb.StrandOverviewLiveTest do
       assert view |> has_element?("h1", strand.name)
       assert view |> has_element?("span", subject.name)
       assert view |> has_element?("span", year.name)
+    end
+  end
+
+  describe "Strand curriculum items management" do
+    test "displays existing curriculum items", %{conn: conn} do
+      strand = insert(:strand)
+      sci = insert(:strand_curriculum_item, strand: strand)
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{strand.id}/overview")
+
+      assert view |> has_element?("p", sci.curriculum_item.name)
+    end
+
+    test "adds a curriculum item via search modal", %{conn: conn, user: user} do
+      school_id = user.current_profile.school_id
+      strand = insert(:strand)
+      curriculum_item = insert(:curriculum_item, school_id: school_id, name: "New CI xyz")
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{strand.id}/overview")
+
+      view |> element("#new-curriculum-item-button") |> render_click()
+
+      view
+      |> element("#curriculum-item-search")
+      |> render_hook("autocomplete_result_select", %{"id" => to_string(curriculum_item.id)})
+
+      assert view |> has_element?("p", "New CI xyz")
+    end
+
+    test "removes a curriculum item", %{conn: conn} do
+      strand = insert(:strand)
+      sci = insert(:strand_curriculum_item, strand: strand)
+      curriculum_item_name = sci.curriculum_item.name
+
+      {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{strand.id}/overview")
+
+      assert view |> has_element?("p", curriculum_item_name)
+
+      view |> element("button[role='menuitem']", "Remove") |> render_click()
+
+      refute view |> has_element?("p", curriculum_item_name)
     end
   end
 

--- a/test/lanttern_web/live/pages/strands/id/overview/strand_overview_live_test.exs
+++ b/test/lanttern_web/live/pages/strands/id/overview/strand_overview_live_test.exs
@@ -1,9 +1,6 @@
 defmodule LantternWeb.StrandOverviewLiveTest do
   use LantternWeb.ConnCase
 
-  import Lanttern.Factory
-
-  alias Lanttern.AssessmentsFixtures
   alias Lanttern.LearningContextFixtures
   alias Lanttern.TaxonomyFixtures
 
@@ -24,7 +21,6 @@ defmodule LantternWeb.StrandOverviewLiveTest do
     test "display strand basic info", %{conn: conn} do
       subject = TaxonomyFixtures.subject_fixture(%{name: "subject abc"})
       year = TaxonomyFixtures.year_fixture(%{name: "year abc"})
-      curriculum_item = insert(:curriculum_item, %{name: "curriculum item abc"})
 
       strand =
         LearningContextFixtures.strand_fixture(%{
@@ -33,17 +29,11 @@ defmodule LantternWeb.StrandOverviewLiveTest do
           years_ids: [year.id]
         })
 
-      AssessmentsFixtures.assessment_point_fixture(%{
-        strand_id: strand.id,
-        curriculum_item_id: curriculum_item.id
-      })
-
       {:ok, view, _html} = live(conn, "#{@live_view_base_path}/#{strand.id}/overview")
 
       assert view |> has_element?("h1", strand.name)
       assert view |> has_element?("span", subject.name)
       assert view |> has_element?("span", year.name)
-      assert view |> has_element?("p", curriculum_item.name)
     end
   end
 

--- a/test/lanttern_web/live/pages/strands/lesson/id/lesson_live_test.exs
+++ b/test/lanttern_web/live/pages/strands/lesson/id/lesson_live_test.exs
@@ -72,6 +72,78 @@ defmodule LantternWeb.LessonLiveTest do
     end
   end
 
+  describe "Lesson curriculum items management" do
+    test "displays existing lesson curriculum items", %{conn: conn} do
+      strand = insert(:strand)
+      lesson = insert(:lesson, strand: strand)
+      lci = insert(:lesson_curriculum_item, lesson: lesson)
+
+      conn
+      |> visit("#{@live_view_base_path}/#{lesson.id}")
+      |> assert_has("p", text: lci.curriculum_item.name)
+    end
+
+    test "adds a lesson curriculum item via search modal", %{conn: conn, user: user} do
+      school_id = user.current_profile.school_id
+      strand = insert(:strand)
+      lesson = insert(:lesson, strand: strand)
+      curriculum_item = insert(:curriculum_item, school_id: school_id, name: "Lesson CI xyz")
+
+      conn
+      |> visit("#{@live_view_base_path}/#{lesson.id}")
+      |> click_button("#new-lesson-curriculum-item-button", "New")
+      |> unwrap(fn view ->
+        view
+        |> element("#lesson-curriculum-item-search")
+        |> render_hook("autocomplete_result_select", %{"id" => to_string(curriculum_item.id)})
+      end)
+      |> assert_has("p", text: "Lesson CI xyz")
+    end
+
+    test "removes a lesson curriculum item", %{conn: conn} do
+      strand = insert(:strand)
+      lesson = insert(:lesson, strand: strand)
+      lci = insert(:lesson_curriculum_item, lesson: lesson)
+      curriculum_item_name = lci.curriculum_item.name
+
+      conn
+      |> visit("#{@live_view_base_path}/#{lesson.id}")
+      |> assert_has("p", text: curriculum_item_name)
+      |> click_button("Remove")
+      |> refute_has("p", text: curriculum_item_name)
+    end
+
+    test "adding a curriculum item not in strand also adds it to strand curriculum", %{
+      conn: conn,
+      user: user
+    } do
+      import Ecto.Query
+
+      school_id = user.current_profile.school_id
+      strand = insert(:strand)
+      lesson = insert(:lesson, strand: strand)
+      curriculum_item = insert(:curriculum_item, school_id: school_id)
+
+      conn
+      |> visit("#{@live_view_base_path}/#{lesson.id}")
+      |> click_button("#new-lesson-curriculum-item-button", "New")
+      |> unwrap(fn view ->
+        view
+        |> element("#lesson-curriculum-item-search")
+        |> render_hook("autocomplete_result_select", %{"id" => to_string(curriculum_item.id)})
+
+        # flush the handle_info sent by the search component to the parent view
+        render(view)
+      end)
+
+      assert Lanttern.Repo.exists?(
+               from sci in Lanttern.Strands.StrandCurriculumItem,
+                 where:
+                   sci.strand_id == ^strand.id and sci.curriculum_item_id == ^curriculum_item.id
+             )
+    end
+  end
+
   describe "Linked assessment points" do
     test "link and unlink assessment point to lesson", %{conn: conn} do
       strand = insert(:strand)

--- a/test/support/factories/lesson_curriculum_item_factory.ex
+++ b/test/support/factories/lesson_curriculum_item_factory.ex
@@ -1,0 +1,19 @@
+defmodule Lanttern.LessonCurriculumItemFactory do
+  @moduledoc false
+  defmacro __using__(_opts) do
+    quote do
+      def lesson_curriculum_item_factory(attrs) do
+        lesson = Map.get(attrs, :lesson, build(:lesson))
+        curriculum_item = Map.get(attrs, :curriculum_item, build(:curriculum_item))
+
+        %Lanttern.Lessons.LessonCurriculumItem{
+          position: 0,
+          lesson: lesson,
+          curriculum_item: curriculum_item
+        }
+        |> merge_attributes(attrs)
+        |> evaluate_lazy_attributes()
+      end
+    end
+  end
+end

--- a/test/support/factories/strand_curriculum_item_factory.ex
+++ b/test/support/factories/strand_curriculum_item_factory.ex
@@ -1,0 +1,19 @@
+defmodule Lanttern.StrandCurriculumItemFactory do
+  @moduledoc false
+  defmacro __using__(_opts) do
+    quote do
+      def strand_curriculum_item_factory(attrs) do
+        strand = Map.get(attrs, :strand, build(:strand))
+        curriculum_item = Map.get(attrs, :curriculum_item, build(:curriculum_item))
+
+        %Lanttern.Strands.StrandCurriculumItem{
+          position: 0,
+          strand: strand,
+          curriculum_item: curriculum_item
+        }
+        |> merge_attributes(attrs)
+        |> evaluate_lazy_attributes()
+      end
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -39,6 +39,7 @@ defmodule Lanttern.Factory do
   use Lanttern.SectionFactory
   use Lanttern.StaffMemberFactory
   use Lanttern.StrandConversationFactory
+  use Lanttern.StrandCurriculumItemFactory
   use Lanttern.StrandFactory
   use Lanttern.StrandReportFactory
   use Lanttern.StudentFactory

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -25,6 +25,7 @@ defmodule Lanttern.Factory do
   use Lanttern.LessonAttachmentFactory
   use Lanttern.LessonFactory
   use Lanttern.LessonLogFactory
+  use Lanttern.LessonCurriculumItemFactory
   use Lanttern.LessonTagFactory
   use Lanttern.LessonTemplateFactory
   use Lanttern.MessageBoardFactory


### PR DESCRIPTION
### Summary

Adds explicit curriculum item management to both strands and lessons, allowing staff to directly tag curriculum items to learning units independent of assessment points.

### Related Issues

- Closes #526

### What This PR Does

- Introduces `StrandCurriculumItem` and `LessonCurriculumItem` schemas with position-ordered join tables
- Adds full CRUD context functions in `Lanttern.Strands` (new module) and `Lanttern.Lessons` with staff-only write access (enforced via `Scope.profile_type?/2`) and PubSub broadcasting for real-time updates
- Adds curriculum item management UI to the strand overview component and lesson live view, using the existing `CurriculumItemSearchComponent`
- Centralizes strand goal management in the strand assessment tab for a cleaner separation of concerns between assessment points and direct curriculum tagging
- Extracts `changeset_error_string/1` helper into `LantternWeb.Helpers.ChangesetHelpers`
- Suppresses expected log noise in two LLM test cases (`@tag capture_log: true`)

### Impact and Scope

- `Lanttern.Strands` — new context module (strand-related queries previously lived in `Lanttern.Curricula` and other contexts)
- `Lanttern.Lessons` — extended with `LessonCurriculumItem` CRUD and PubSub
- Strand overview and lesson live views — new interactive curriculum item sections
- Two new migrations: `recreate_strand_curriculum_items` and `create_lesson_curriculum_items`

### Testing Considerations

- Context-level tests for `StrandCurriculumItem` and `LessonCurriculumItem` CRUD
- LiveView integration tests covering add/remove flows in strand overview and lesson live using `phoenix_test`
- ExMachina factories added for both new schemas

### Additional Notes

- Run `mix ecto.migrate` to apply the two new migrations
- Remember to run `mix credo --strict`, `mix sobelow`, and the full test suite before merging

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>