### PR TITLE
refactor(grading): simplify numeric scale config, drop start field, add max_score, display scale in assessment point cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ Use the versioned `AGENTS.md` as reference for setting your own LLM agent instru
 
 /open-pr main                    # run precommit checks and creates the PR
 
-/review                          # diff current branch vs main
-/review develop                  # diff vs develop
-/review --issues #12,#34         # with issue context
-/review develop --issues 12      # both
+/review-local                          # diff current branch vs main
+/review-local develop                  # diff vs develop
+/review-local --issues #12,#34         # with issue context
+/review-local develop --issues 12      # both
 
 /pr-review 123                   # GitHub PR (issues auto-detected from PR)
 ```

--- a/lib/lanttern/assessments/assessment_point_entry.ex
+++ b/lib/lanttern/assessments/assessment_point_entry.ex
@@ -146,9 +146,9 @@ defmodule Lanttern.Assessments.AssessmentPointEntry do
 
         changeset
         |> validate_number(:score,
-          greater_than_or_equal_to: scale.start,
-          less_than_or_equal_to: scale.stop,
-          message: "score should be between #{scale.start} and #{scale.stop}"
+          greater_than_or_equal_to: 0.0,
+          less_than_or_equal_to: scale.max_score,
+          message: "score should be between 0 and #{scale.max_score}"
         )
 
       _ ->

--- a/lib/lanttern/color_utils.ex
+++ b/lib/lanttern/color_utils.ex
@@ -18,8 +18,8 @@ defmodule Lanttern.ColorUtils do
   """
   @spec interpolate_numeric_scale_colors(map(), float()) ::
           {String.t() | nil, String.t() | nil} | nil
-  def interpolate_numeric_scale_colors(%{start: range_start, stop: range_stop} = scale, score) do
-    t = compute_t(score, range_start, range_stop)
+  def interpolate_numeric_scale_colors(%{max_score: range_stop} = scale, score) do
+    t = compute_t(score, 0.0, range_stop)
 
     bg =
       case scale do

--- a/lib/lanttern/grades_reports.ex
+++ b/lib/lanttern/grades_reports.ex
@@ -954,7 +954,7 @@ defmodule Lanttern.GradesReports do
     do: entry.ordinal_value.normalized_value
 
   defp get_normalized_value_from_entry(%AssessmentPointEntry{scale_type: "numeric"} = entry),
-    do: (entry.score - entry.scale.start) / (entry.scale.stop - entry.scale.start)
+    do: entry.score / entry.scale.max_score
 
   defp build_comp_component(
          metadata,

--- a/lib/lanttern/grading.ex
+++ b/lib/lanttern/grading.ex
@@ -567,7 +567,7 @@ defmodule Lanttern.Grading do
   end
 
   def convert_normalized_value_to_scale_value(normalized_value, %Scale{type: "numeric"} = scale) do
-    normalized_value * (scale.stop - scale.start) + scale.start
+    normalized_value * scale.max_score
   end
 
   defp get_normalized_value_breakpoint_index(breakpoints, normalized_value, i \\ 0)

--- a/lib/lanttern/grading/scale.ex
+++ b/lib/lanttern/grading/scale.ex
@@ -70,7 +70,7 @@ defmodule Lanttern.Grading.Scale do
     |> validate_required([:name, :type])
     |> put_change(:school_id, scope.school_id)
     |> validate_scale_type()
-    |> validate_start_stop()
+    |> validate_max_score()
     |> parse_breakpoints_input()
     |> adjust_breakpoints()
     |> validate_hex_color(:start_bg_color, :scale_start_bg_color_should_be_hex)
@@ -112,17 +112,17 @@ defmodule Lanttern.Grading.Scale do
       if type in @valid_types do
         []
       else
-        [type: ~s(must be "numeric" or "ordinal")]
+        [type: gettext(~s(must be "numeric" or "ordinal"))]
       end
     end)
   end
 
-  defp validate_start_stop(%{changes: %{type: "numeric"}} = changeset) do
+  defp validate_max_score(%{changes: %{type: "numeric"}} = changeset) do
     changeset
-    |> validate_required([:max_score], message: "can't be blank when type is numeric")
+    |> validate_required([:max_score], message: gettext("can't be blank when type is numeric"))
   end
 
-  defp validate_start_stop(changeset), do: changeset
+  defp validate_max_score(changeset), do: changeset
 
   defp parse_breakpoints_input(changeset) do
     case get_change(changeset, :breakpoints_input) do

--- a/lib/lanttern/grading/scale.ex
+++ b/lib/lanttern/grading/scale.ex
@@ -18,10 +18,9 @@ defmodule Lanttern.Grading.Scale do
           name: String.t(),
           type: String.t(),
           position: non_neg_integer(),
-          start: float(),
+          max_score: float(),
           start_bg_color: String.t(),
           start_text_color: String.t(),
-          stop: float(),
           stop_bg_color: String.t(),
           stop_text_color: String.t(),
           breakpoints: [float()],
@@ -38,10 +37,9 @@ defmodule Lanttern.Grading.Scale do
     field :name, :string
     field :type, :string
     field :position, :integer, default: 0
-    field :start, :float
+    field :max_score, :float
     field :start_bg_color, :string
     field :start_text_color, :string
-    field :stop, :float
     field :stop_bg_color, :string
     field :stop_text_color, :string
     field :breakpoints, {:array, :float}
@@ -61,10 +59,9 @@ defmodule Lanttern.Grading.Scale do
       :name,
       :type,
       :position,
-      :start,
+      :max_score,
       :start_bg_color,
       :start_text_color,
-      :stop,
       :stop_bg_color,
       :stop_text_color,
       :breakpoints,
@@ -122,7 +119,7 @@ defmodule Lanttern.Grading.Scale do
 
   defp validate_start_stop(%{changes: %{type: "numeric"}} = changeset) do
     changeset
-    |> validate_required([:start, :stop], message: "can't be blank when type is numeric")
+    |> validate_required([:max_score], message: "can't be blank when type is numeric")
   end
 
   defp validate_start_stop(changeset), do: changeset

--- a/lib/lanttern/utils.ex
+++ b/lib/lanttern/utils.ex
@@ -24,4 +24,14 @@ defmodule Lanttern.Utils do
     {item, rest} = List.pop_at(list, cur_i)
     List.insert_at(rest, new_i, item)
   end
+
+  @doc """
+  Formats a float for display, removing `.0` suffix (showing as integer)
+  and removing trailing zeros from decimal places.
+  """
+  def format_float(float) do
+    float
+    |> Float.to_string()
+    |> String.replace(~r/\.0$|(?<=\.\d)0+$/, "")
+  end
 end

--- a/lib/lanttern_web/components/assessments_components.ex
+++ b/lib/lanttern_web/components/assessments_components.ex
@@ -8,6 +8,7 @@ defmodule LantternWeb.AssessmentsComponents do
   use Gettext, backend: Lanttern.Gettext
   import LantternWeb.CoreComponents
   import LantternWeb.OverlayComponents
+  import Lanttern.Utils, only: [format_float: 1]
 
   alias Lanttern.Grading.OrdinalValue
 
@@ -196,7 +197,7 @@ defmodule LantternWeb.AssessmentsComponents do
         do: assigns.entry.student_score,
         else: assigns.entry.score
 
-    {stop, color_map} =
+    {max_score, color_map} =
       case assigns.scale do
         %Lanttern.Grading.Scale{} = scale ->
           color_map =
@@ -213,9 +214,9 @@ defmodule LantternWeb.AssessmentsComponents do
 
     assigns =
       assigns
-      |> assign(:score, score)
+      |> assign(:score, score && format_float(score))
       |> assign(:color_map, color_map)
-      |> assign(:stop, stop)
+      |> assign(:max_score, max_score && format_float(max_score))
 
     ~H"""
     <%= if @score do %>
@@ -228,7 +229,9 @@ defmodule LantternWeb.AssessmentsComponents do
         style={create_color_map_style(@color_map)}
       >
         {@score}
-        <span :if={@stop} class="opacity-60"><span class="inline-block mx-1">/</span>{@stop}</span>
+        <span :if={@max_score} class="opacity-60">
+          <span class="inline-block mx-1">/</span>{@max_score}
+        </span>
       </div>
     <% else %>
       <.assessment_point_entry_value_empty_display />

--- a/lib/lanttern_web/components/assessments_components.ex
+++ b/lib/lanttern_web/components/assessments_components.ex
@@ -68,7 +68,7 @@ defmodule LantternWeb.AssessmentsComponents do
     <.badge color_map={@color_map} class={@class} id={@id}>
       {@entry.score}
       <span :if={@show_stop} class="inline-block ml-1 opacity-60">
-        / {@entry.scale.stop}
+        / {@entry.scale.max_score}
       </span>
     </.badge>
     """
@@ -205,7 +205,7 @@ defmodule LantternWeb.AssessmentsComponents do
               _ -> nil
             end
 
-          {scale.stop, color_map}
+          {scale.max_score, color_map}
 
         _ ->
           {nil, nil}

--- a/lib/lanttern_web/components/reporting_components.ex
+++ b/lib/lanttern_web/components/reporting_components.ex
@@ -9,6 +9,7 @@ defmodule LantternWeb.ReportingComponents do
   import LantternWeb.CoreComponents
 
   import Lanttern.SupabaseHelpers, only: [object_url_to_render_url: 2]
+  import Lanttern.Utils, only: [format_float: 1]
 
   alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.Assessments.AssessmentPointEntry
@@ -375,7 +376,7 @@ defmodule LantternWeb.ReportingComponents do
       style={create_color_map_gradient_bg_style(@scale)}
     >
       <div style={if @scale.start_text_color, do: "color: #{@scale.start_text_color}"}>
-        {0}
+        0
       </div>
       <div
         :if={@score}
@@ -396,7 +397,7 @@ defmodule LantternWeb.ReportingComponents do
         class="text-right"
         style={if @scale.stop_text_color, do: "color: #{@scale.stop_text_color}"}
       >
-        {@scale.max_score}
+        {format_float(@scale.max_score)}
       </div>
     </div>
     """

--- a/lib/lanttern_web/components/reporting_components.ex
+++ b/lib/lanttern_web/components/reporting_components.ex
@@ -375,12 +375,12 @@ defmodule LantternWeb.ReportingComponents do
       style={create_color_map_gradient_bg_style(@scale)}
     >
       <div style={if @scale.start_text_color, do: "color: #{@scale.start_text_color}"}>
-        {@scale.start}
+        {0}
       </div>
       <div
         :if={@score}
         class="absolute z-10 flex-1 flex items-center h-full"
-        style={"left: calc(#{(@score - @scale.start) * 100 / (@scale.stop - @scale.start)}% - #{((@score - @scale.start) / (@scale.stop - @scale.start)) * 48}px)"}
+        style={"left: calc(#{@score * 100 / @scale.max_score}% - #{(@score / @scale.max_score) * 48}px)"}
       >
         <div class={[
           "absolute flex items-center justify-center w-12 h-8 rounded-sm text-sm shadow-lg",
@@ -396,7 +396,7 @@ defmodule LantternWeb.ReportingComponents do
         class="text-right"
         style={if @scale.stop_text_color, do: "color: #{@scale.stop_text_color}"}
       >
-        {@scale.stop}
+        {@scale.max_score}
       </div>
     </div>
     """

--- a/lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex
+++ b/lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex
@@ -43,13 +43,13 @@ defmodule LantternWeb.GradingScalesLive.GradingScaleCardComponent do
               <.badge color_map={
                 %{bg_color: @scale.start_bg_color, text_color: @scale.start_text_color}
               }>
-                {@scale.start}
+                {0}
               </.badge>
               —
               <.badge color_map={
                 %{bg_color: @scale.stop_bg_color, text_color: @scale.stop_text_color}
               }>
-                {@scale.stop}
+                {@scale.max_score}
               </.badge>
             </div>
           </div>
@@ -143,8 +143,8 @@ defmodule LantternWeb.GradingScalesLive.GradingScaleCardComponent do
           <%!-- Numeric scale details --%>
           <p :if={@scale.type == "numeric"}>
             {gettext("Numeric scale, from %{start} to %{stop}",
-              start: @scale.start,
-              stop: @scale.stop
+              start: 0,
+              stop: @scale.max_score
             )}
           </p>
         </div>

--- a/lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex
+++ b/lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex
@@ -5,6 +5,8 @@ defmodule LantternWeb.GradingScalesLive.GradingScaleCardComponent do
 
   use LantternWeb, :live_component
 
+  import Lanttern.Utils, only: [format_float: 1]
+
   @impl true
   def render(assigns) do
     ~H"""
@@ -43,13 +45,13 @@ defmodule LantternWeb.GradingScalesLive.GradingScaleCardComponent do
               <.badge color_map={
                 %{bg_color: @scale.start_bg_color, text_color: @scale.start_text_color}
               }>
-                {0}
+                0
               </.badge>
               —
               <.badge color_map={
                 %{bg_color: @scale.stop_bg_color, text_color: @scale.stop_text_color}
               }>
-                {@scale.max_score}
+                {format_float(@scale.max_score)}
               </.badge>
             </div>
           </div>
@@ -144,7 +146,7 @@ defmodule LantternWeb.GradingScalesLive.GradingScaleCardComponent do
           <p :if={@scale.type == "numeric"}>
             {gettext("Numeric scale, from %{start} to %{stop}",
               start: 0,
-              stop: @scale.max_score
+              stop: format_float(@scale.max_score)
             )}
           </p>
         </div>

--- a/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
@@ -197,15 +197,6 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
                   sr_text={gettext("Marking")}
                 />
               </div>
-              <p class="mb-4">
-                {gettext("Goals assessment are defined by the strand curriculum.")}
-                <.link
-                  patch={~p"/strands/#{@strand}/overview#strand-curriculum"}
-                  class="hover:text-ltrn-subtle"
-                >
-                  {gettext("You can manage curriculum items in the overview section.")}
-                </.link>
-              </p>
               <div
                 id="strand-sortable-aps"
                 phx-hook="Sortable"

--- a/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
@@ -5,13 +5,13 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
   alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.LearningContext
 
-  import Lanttern.Utils, only: [reorder: 3]
+  import Lanttern.Utils, only: [format_float: 1, reorder: 3]
 
   # shared components
   alias LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayComponent
   alias LantternWeb.Assessments.AssessmentPointFormOverlayComponent
 
-  @ap_preloads [:scale, :lesson, curriculum_item: :curriculum_component]
+  @ap_preloads [:lesson, scale: :ordinal_values, curriculum_item: :curriculum_component]
 
   @impl true
   def render(assigns) do
@@ -265,117 +265,167 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
   defp assessment_point_card(assigns) do
     ~H"""
     <.draggable_card id={@id} class={@class}>
-      <div class="py-4 space-y-4">
-        <button
-          type="button"
-          phx-click={@on_edit}
-          class="flex-1 font-bold text-left text-ltrn-darkest hover:text-ltrn-subtle"
-        >
-          {if @assessment_point.moment_id,
-            do: @assessment_point.name,
-            else:
-              "(#{@assessment_point.curriculum_item.curriculum_component.name}) #{@assessment_point.curriculum_item.name}"}
-        </button>
+      <div class="flex items-center gap-4 py-4">
+        <div class="flex-1 space-y-4">
+          <button
+            type="button"
+            phx-click={@on_edit}
+            class="flex-1 font-bold text-left text-ltrn-darkest hover:text-ltrn-subtle"
+          >
+            {if @assessment_point.moment_id,
+              do: @assessment_point.name,
+              else:
+                "(#{@assessment_point.curriculum_item.curriculum_component.name}) #{@assessment_point.curriculum_item.name}"}
+          </button>
 
-        <.markdown
-          :if={@assessment_point.report_info}
-          text={@assessment_point.report_info}
-          class="line-clamp-2"
-        />
-        <div class="flex items-center gap-2">
-          <div :if={is_nil(@assessment_point.composition_type)} class="relative">
-            <.button
-              type="button"
-              size="xs"
-              id={"#{@id}-composition-button"}
-            >
-              {gettext("Add composition")}
-            </.button>
-            <.dropdown_menu
-              id={"#{@id}-composition-menu"}
-              button_id={"#{@id}-composition-button"}
-            >
-              <:instructions>
-                {gettext("Create composition using")}
-              </:instructions>
-              <:item
-                on_click={
-                  JS.push("add_composition",
-                    value: %{"assessment_point_id" => @assessment_point.id, "type" => "avg"},
+          <.markdown
+            :if={@assessment_point.report_info}
+            text={@assessment_point.report_info}
+            class="line-clamp-2"
+          />
+          <div class="flex items-center gap-2">
+            <div :if={is_nil(@assessment_point.composition_type)} class="relative">
+              <.button
+                type="button"
+                size="xs"
+                id={"#{@id}-composition-button"}
+              >
+                {gettext("Add composition")}
+              </.button>
+              <.dropdown_menu
+                id={"#{@id}-composition-menu"}
+                button_id={"#{@id}-composition-button"}
+              >
+                <:instructions>
+                  {gettext("Create composition using")}
+                </:instructions>
+                <:item
+                  on_click={
+                    JS.push("add_composition",
+                      value: %{"assessment_point_id" => @assessment_point.id, "type" => "avg"},
+                      target: @myself
+                    )
+                  }
+                  text={gettext("Average")}
+                />
+                <:item
+                  on_click={
+                    JS.push("add_composition",
+                      value: %{"assessment_point_id" => @assessment_point.id, "type" => "sum"},
+                      target: @myself
+                    )
+                  }
+                  text={gettext("Sum")}
+                />
+              </.dropdown_menu>
+            </div>
+            <div :if={@assessment_point.composition_type} class="relative">
+              <.button
+                type="button"
+                size="xs"
+                theme="primary"
+                icon_name={
+                  if @assessment_point.composition_type == :sum,
+                    do: "hero-plus-micro",
+                    else: "hero-divide-micro"
+                }
+                phx-click={
+                  JS.push("open_composition",
+                    value: %{id: @assessment_point.id},
                     target: @myself
                   )
                 }
-                text={gettext("Average")}
-              />
-              <:item
-                on_click={
-                  JS.push("add_composition",
-                    value: %{"assessment_point_id" => @assessment_point.id, "type" => "sum"},
-                    target: @myself
-                  )
-                }
-                text={gettext("Sum")}
-              />
-            </.dropdown_menu>
+              >
+                {if @assessment_point.composition_type == :sum,
+                  do: gettext("Sum"),
+                  else: gettext("Average")}
+              </.button>
+              <.tooltip id={"ap-#{@assessment_point.id}-composition-tooltip"}>
+                {gettext("Uses grade composition")}
+              </.tooltip>
+            </div>
+            <div :if={@assessment_point.rubric_id}>
+              <.icon name="hero-view-columns" />
+              <.tooltip id={"ap-#{@assessment_point.id}-rubric-tooltip"}>
+                {gettext("Uses rubric in assessment")}
+              </.tooltip>
+            </div>
+            <.badge :if={@assessment_point.is_differentiation} theme="diff" class="shrink-0">
+              {gettext("Differentiation")}
+            </.badge>
+            <%!-- render curriculum only for moment assessment poiint --%>
+            <div :if={@assessment_point.moment_id} class="flex-1 min-w-0">
+              <p class="max-w-sm font-sans text-sm text-ltrn-subtle truncate">
+                {@assessment_point.curriculum_item.name}
+              </p>
+              <.tooltip id={"ap-#{@assessment_point.id}-curriculum-tooltip"}>
+                ({@assessment_point.curriculum_item.curriculum_component.name}) {@assessment_point.curriculum_item.name}
+              </.tooltip>
+            </div>
           </div>
-          <div :if={@assessment_point.composition_type} class="relative">
-            <.button
-              type="button"
-              size="xs"
-              theme="primary"
-              icon_name={
-                if @assessment_point.composition_type == :sum,
-                  do: "hero-plus-micro",
-                  else: "hero-divide-micro"
-              }
-              phx-click={
-                JS.push("open_composition",
-                  value: %{id: @assessment_point.id},
-                  target: @myself
-                )
-              }
-            >
-              {if @assessment_point.composition_type == :sum,
-                do: gettext("Sum"),
-                else: gettext("Average")}
-            </.button>
-            <.tooltip id={"ap-#{@assessment_point.id}-composition-tooltip"}>
-              {gettext("Uses grade composition")}
-            </.tooltip>
-          </div>
-          <div :if={@assessment_point.rubric_id}>
-            <.icon name="hero-view-columns" />
-            <.tooltip id={"ap-#{@assessment_point.id}-rubric-tooltip"}>
-              {gettext("Uses rubric in assessment")}
-            </.tooltip>
-          </div>
-          <.badge :if={@assessment_point.is_differentiation} theme="diff" class="shrink-0">
-            {gettext("Differentiation")}
-          </.badge>
-          <.badge class="shrink-0">{@assessment_point.scale.name}</.badge>
-          <%!-- render curriculum only for moment assessment poiint --%>
-          <div :if={@assessment_point.moment_id} class="flex-1 min-w-0">
-            <p class="max-w-sm font-sans text-sm text-ltrn-subtle truncate">
-              {@assessment_point.curriculum_item.name}
-            </p>
-            <.tooltip id={"ap-#{@assessment_point.id}-curriculum-tooltip"}>
-              ({@assessment_point.curriculum_item.curriculum_component.name}) {@assessment_point.curriculum_item.name}
-            </.tooltip>
-          </div>
+          <.link
+            :if={@assessment_point.lesson}
+            navigate={~p"/strands/lesson/#{@assessment_point.lesson}"}
+            class="flex items-center gap-2 font-sans text-sm text-ltrn-subtle hover:text-ltrn-dark"
+          >
+            <.icon name="hero-link-mini" />
+            {gettext("Lesson:")}
+            <span>{@assessment_point.lesson.name}</span>
+          </.link>
         </div>
-        <.link
-          :if={@assessment_point.lesson}
-          navigate={~p"/strands/lesson/#{@assessment_point.lesson}"}
-          class="flex items-center gap-2 font-sans text-sm text-ltrn-subtle hover:text-ltrn-dark"
-        >
-          <.icon name="hero-link-mini" />
-          {gettext("Lesson:")}
-          <span>{@assessment_point.lesson.name}</span>
-        </.link>
+        <%= if @assessment_point.scale.type == "numeric" do %>
+          <div class="shrink-0 text-lg text-ltrn-subtle tabular-nums">
+            {format_float(@assessment_point.scale.max_score)}
+          </div>
+        <% else %>
+          <.ordinal_scale_range scale={@assessment_point.scale} id={"ap-#{@assessment_point.id}"} />
+        <% end %>
       </div>
     </.draggable_card>
     """
   end
+
+  defp ordinal_scale_range(%{scale: %{ordinal_values: []}} = assigns) do
+    ~H"""
+    —
+    """
+  end
+
+  defp ordinal_scale_range(%{scale: %{ordinal_values: [_only]}} = assigns) do
+    ~H"""
+    <div class="flex items-center gap-1">
+      <.badge class="shrink-0" color_map={hd(@scale.ordinal_values)}>
+        {ov_short(hd(@scale.ordinal_values))}
+      </.badge>
+      <.tooltip id={"#{@id}-scale-tooltip"}>
+        {@scale.name}: {ov_list_label(@scale.ordinal_values)}
+      </.tooltip>
+    </div>
+    """
+  end
+
+  defp ordinal_scale_range(assigns) do
+    ~H"""
+    <div class="flex items-center gap-1">
+      <.badge class="shrink-0" color_map={hd(@scale.ordinal_values)}>
+        {ov_short(hd(@scale.ordinal_values))}
+      </.badge>
+      —
+      <.badge class="shrink-0" color_map={List.last(@scale.ordinal_values)}>
+        {ov_short(List.last(@scale.ordinal_values))}
+      </.badge>
+      <.tooltip id={"#{@id}-scale-tooltip"}>
+        {@scale.name}: {ov_list_label(@scale.ordinal_values)}
+      </.tooltip>
+    </div>
+    """
+  end
+
+  defp ov_short(%{short_name: short_name, name: name}),
+    do: short_name || String.slice(name, 0..2)
+
+  defp ov_list_label(ordinal_values),
+    do: Enum.map_join(ordinal_values, ", ", & &1.name)
 
   # lifecycle
 

--- a/lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex
@@ -12,6 +12,8 @@ defmodule LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayCom
 
   use LantternWeb, :live_component
 
+  import Lanttern.Utils, only: [format_float: 1]
+
   alias Lanttern.AssessmentComposition
   alias Lanttern.Assessments
   alias Lanttern.LearningContext
@@ -185,9 +187,9 @@ defmodule LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayCom
 
   defp ap_display_name(ap), do: ap.name
 
-  defp ap_score_display(%{scale: %{type: "numeric", stop: stop}}) when not is_nil(stop) do
-    if trunc(stop) == stop, do: trunc(stop), else: stop
-  end
+  defp ap_score_display(%{scale: %{type: "numeric", max_score: max_score}})
+       when not is_nil(max_score),
+       do: format_float(max_score)
 
   defp ap_score_display(_), do: "—"
 
@@ -196,12 +198,15 @@ defmodule LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayCom
       components
       |> Enum.reduce(0, fn comp, acc ->
         case comp.component do
-          %{scale: %{type: "numeric", stop: stop}} when not is_nil(stop) -> acc + stop
-          _ -> acc
+          %{scale: %{type: "numeric", max_score: max_score}} when not is_nil(max_score) ->
+            acc + max_score
+
+          _ ->
+            acc
         end
       end)
 
-    if trunc(total) == total, do: trunc(total), else: total
+    format_float(total)
   end
 
   defp composition_total(:avg, components) do

--- a/lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex
@@ -28,16 +28,16 @@ defmodule LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayCom
         <:title>{gettext("Grade composition")}</:title>
         <%= if @view == :overview do %>
           <div class="flex items-start justify-between gap-6">
-            <.input
-              type="select"
-              name="composition_type"
-              label={gettext("Composition type")}
-              options={[{gettext("Sum"), "sum"}, {gettext("Average"), "avg"}]}
-              value={@ap.composition_type}
-              phx-change="update_type"
-              phx-target={@myself}
-              class="w-56"
-            />
+            <form phx-change="update_type" phx-target={@myself}>
+              <.input
+                type="select"
+                name="composition_type"
+                label={gettext("Composition type")}
+                options={[{gettext("Sum"), "sum"}, {gettext("Average"), "avg"}]}
+                value={@ap.composition_type}
+                class="w-56"
+              />
+            </form>
             <.button
               type="button"
               theme={if @composition_components == [], do: "primary"}
@@ -295,6 +295,7 @@ defmodule LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayCom
   def handle_event("update_type", %{"composition_type" => type}, socket) do
     ap = socket.assigns.ap
     {:ok, updated_ap} = Assessments.update_assessment_point(ap, %{composition_type: type})
+    notify(__MODULE__, {:composition_updated, ap.id}, socket.assigns)
     {:noreply, assign(socket, :ap, %{ap | composition_type: updated_ap.composition_type})}
   end
 

--- a/lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex
@@ -209,7 +209,7 @@ defmodule LantternWeb.Assessments.EntryDetailsOverlayComponent do
     assigns = assign(assigns, :field, field)
 
     ~H"""
-    <.input field={@field} type="number" phx-debounce="1000" min={0} max={@scale.max_score} />
+    <.input field={@field} type="number" phx-debounce="1000" min="0" max={@scale.max_score} />
     """
   end
 

--- a/lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex
@@ -209,7 +209,7 @@ defmodule LantternWeb.Assessments.EntryDetailsOverlayComponent do
     assigns = assign(assigns, :field, field)
 
     ~H"""
-    <.input field={@field} type="number" phx-debounce="1000" min={@scale.start} max={@scale.stop} />
+    <.input field={@field} type="number" phx-debounce="1000" min={0} max={@scale.max_score} />
     """
   end
 

--- a/lib/lanttern_web/live/shared/assessments/entry_particle_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_particle_component.ex
@@ -19,6 +19,8 @@ defmodule LantternWeb.Assessments.EntryParticleComponent do
   """
   use LantternWeb, :live_component
 
+  import Lanttern.Utils, only: [format_float: 1]
+
   alias Lanttern.Assessments.AssessmentPointEntry
   alias Lanttern.Grading
   alias Lanttern.Grading.OrdinalValue
@@ -156,7 +158,7 @@ defmodule LantternWeb.Assessments.EntryParticleComponent do
           {"text-ltrn-dark bg-ltrn-lighter", nil}
       end
 
-    {additional_classes, style, "#{score}", score}
+    {additional_classes, style, format_float(score), score}
   end
 
   defp get_particle_styles_and_text(_, %AssessmentPointEntry{is_missing: true}, _is_student, _) do

--- a/lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex
+++ b/lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex
@@ -63,7 +63,7 @@ defmodule LantternWeb.Grading.GradingScaleFormComponent do
             <.badge color_map={
               %{bg_color: @form[:start_bg_color].value, text_color: @form[:start_text_color].value}
             }>
-              {0}
+              0
             </.badge>
             <.badge color_map={
               %{bg_color: @form[:stop_bg_color].value, text_color: @form[:stop_text_color].value}

--- a/lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex
+++ b/lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex
@@ -12,22 +12,25 @@ defmodule LantternWeb.Grading.GradingScaleFormComponent do
     ~H"""
     <div class={@class}>
       <.form for={@form} id={@id} phx-target={@myself} phx-change="validate" phx-submit="save">
-        <.input
-          field={@form[:name]}
-          type="text"
-          label={gettext("Scale name")}
-          class="mb-6"
-          phx-debounce="500"
-        />
+        <div class="flex gap-4 mb-6">
+          <.input
+            field={@form[:name]}
+            type="text"
+            label={gettext("Scale name")}
+            class="flex-1 shrink-0"
+            phx-debounce="500"
+          />
+          <.input
+            :if={@scale.type == "numeric"}
+            field={@form[:max_score]}
+            type="number"
+            label={gettext("Max score")}
+            step="any"
+            class="shrink-0 min-w-20"
+          />
+        </div>
         <div :if={@scale.type == "numeric"} class="mb-6">
           <div class="flex items-start gap-4 mb-6">
-            <.input
-              field={@form[:start]}
-              type="number"
-              label={gettext("Start")}
-              step="1"
-              class="flex-1 shrink-0"
-            />
             <.input
               field={@form[:start_bg_color]}
               type="color"
@@ -42,13 +45,6 @@ defmodule LantternWeb.Grading.GradingScaleFormComponent do
             />
           </div>
           <div class="flex items-start gap-4 mb-6">
-            <.input
-              field={@form[:stop]}
-              type="number"
-              label={gettext("Stop")}
-              step="any"
-              class="flex-1 shrink-0"
-            />
             <.input
               field={@form[:stop_bg_color]}
               type="color"
@@ -67,12 +63,12 @@ defmodule LantternWeb.Grading.GradingScaleFormComponent do
             <.badge color_map={
               %{bg_color: @form[:start_bg_color].value, text_color: @form[:start_text_color].value}
             }>
-              {@form[:start].value}
+              {0}
             </.badge>
             <.badge color_map={
               %{bg_color: @form[:stop_bg_color].value, text_color: @form[:stop_text_color].value}
             }>
-              {@form[:stop].value}
+              {@form[:max_score].value}
             </.badge>
           </.card_base>
         </div>

--- a/lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex
@@ -185,7 +185,7 @@ defmodule LantternWeb.Rubrics.RubricFormOverlayComponent do
           <.input type="hidden" field={ef[:scale_type]} />
           <.input
             type="number"
-            min={0}
+            min="0"
             max={@scale.max_score}
             field={ef[:score]}
             label={gettext("Score")}

--- a/lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex
@@ -185,8 +185,8 @@ defmodule LantternWeb.Rubrics.RubricFormOverlayComponent do
           <.input type="hidden" field={ef[:scale_type]} />
           <.input
             type="number"
-            min={@scale.start}
-            max={@scale.stop}
+            min={0}
+            max={@scale.max_score}
             field={ef[:score]}
             label={gettext("Score")}
             class="mt-6"
@@ -475,10 +475,10 @@ defmodule LantternWeb.Rubrics.RubricFormOverlayComponent do
         %{
           "0" =>
             blank_numeric_descriptor(scale)
-            |> Map.put("score", scale.start),
+            |> Map.put("score", 0.0),
           "1" =>
             blank_numeric_descriptor(scale)
-            |> Map.put("score", scale.stop)
+            |> Map.put("score", scale.max_score)
         }
     end
   end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -126,7 +126,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/agent_chat/agent_preferences_overlay_component.ex:73
 #: lib/lanttern_web/live/shared/agent_chat/rename_conversation_form_component.ex:28
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:47
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:162
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:164
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:150
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:283
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:100
@@ -137,7 +137,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:71
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:74
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:114
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:110
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:95
 #: lib/lanttern_web/live/shared/ilp/ilp_template_form_component.ex:162
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:110
@@ -212,7 +212,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/agent_chat/agent_preferences_overlay_component.ex:75
 #: lib/lanttern_web/live/shared/agent_chat/rename_conversation_form_component.ex:31
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:50
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:170
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:172
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:159
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:163
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:75
@@ -221,7 +221,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:64
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:77
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:117
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:113
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:105
 #: lib/lanttern_web/live/shared/ilp/ilp_template_form_component.ex:165
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:119
@@ -462,12 +462,12 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:73
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:80
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:38
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:153
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:155
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:141
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:52
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:62
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:65
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:105
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:101
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:85
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:100
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:51
@@ -518,20 +518,20 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/staff/deactivated/deactivated_staff_live.html.heex:48
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_card_component.ex:34
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_component_form_component.ex:62
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:62
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:64
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:71
 #: lib/lanttern_web/live/pages/strands/id/overview_component.ex:100
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:83
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:398
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:36
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:151
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:153
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:139
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:183
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:151
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:50
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:60
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:63
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:103
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:99
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:83
 #: lib/lanttern_web/live/shared/ilp/ilp_template_form_component.ex:155
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:98
@@ -561,7 +561,7 @@ msgstr ""
 msgid "Current assessment points"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:353
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:345
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:102
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:50
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:286
@@ -713,8 +713,8 @@ msgstr ""
 msgid "Rubric updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:62
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:93
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:64
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:95
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:34
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex:34
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:191
@@ -983,7 +983,7 @@ msgid "Curriculum item deleted"
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1131
-#: lib/lanttern_web/components/reporting_components.ex:225
+#: lib/lanttern_web/components/reporting_components.ex:226
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:57
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:69
@@ -1004,8 +1004,8 @@ msgstr ""
 msgid "Cycle already added to this grade report"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:82
-#: lib/lanttern_web/components/reporting_components.ex:438
+#: lib/lanttern_web/components/reporting_components.ex:83
+#: lib/lanttern_web/components/reporting_components.ex:439
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:297
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:290
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:339
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Grade calculated succesfully"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:26
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:28
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:82
 #: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:87
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:39
@@ -1272,7 +1272,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:640
 #: lib/lanttern_web/components/grades_reports_components.ex:868
-#: lib/lanttern_web/components/reporting_components.ex:584
+#: lib/lanttern_web/components/reporting_components.ex:585
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr ""
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1061
 #: lib/lanttern_web/components/grades_reports_components.ex:1134
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:94
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:96
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:27
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:47
 #, elixir-autogen, elixir-format
@@ -1320,7 +1320,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:311
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_component_form_component.ex:41
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:50
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:66
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:62
 #: lib/lanttern_web/live/shared/lessons/lesson_tag_form_component.ex:37
 #: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:56
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:73
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Report cards"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:156
+#: lib/lanttern_web/components/reporting_components.ex:157
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_rubrics_component.ex:105
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:236
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:71
@@ -1531,8 +1531,8 @@ msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1060
 #: lib/lanttern_web/components/grades_reports_components.ex:1133
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:62
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:93
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:64
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:95
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Weight"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Students report cards access updated"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:236
+#: lib/lanttern_web/components/reporting_components.ex:237
 #, elixir-autogen, elixir-format
 msgid "Under development"
 msgstr ""
@@ -2034,13 +2034,13 @@ msgstr ""
 msgid "%{student} comment"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:161
+#: lib/lanttern_web/components/assessments_components.ex:162
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Student self-assessment"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:113
+#: lib/lanttern_web/components/reporting_components.ex:114
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:320
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:236
 #, elixir-autogen, elixir-format
@@ -2142,14 +2142,14 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:319
-#: lib/lanttern_web/components/assessments_components.ex:345
+#: lib/lanttern_web/components/assessments_components.ex:322
+#: lib/lanttern_web/components/assessments_components.ex:348
 #, elixir-autogen, elixir-format
 msgid "Assessed by students"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:318
-#: lib/lanttern_web/components/assessments_components.ex:340
+#: lib/lanttern_web/components/assessments_components.ex:321
+#: lib/lanttern_web/components/assessments_components.ex:343
 #, elixir-autogen, elixir-format
 msgid "Assessed by teacher"
 msgstr ""
@@ -2164,12 +2164,12 @@ msgstr ""
 msgid "Assessment point entry's evidences"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:350
+#: lib/lanttern_web/components/assessments_components.ex:353
 #, elixir-autogen, elixir-format
 msgid "Compare teacher and students assessments"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:320
+#: lib/lanttern_web/components/assessments_components.ex:323
 #, elixir-autogen, elixir-format
 msgid "Compare teacher/students"
 msgstr ""
@@ -2207,25 +2207,25 @@ msgstr ""
 msgid "Save comment"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:271
-#: lib/lanttern_web/components/assessments_components.ex:295
+#: lib/lanttern_web/components/assessments_components.ex:274
+#: lib/lanttern_web/components/assessments_components.ex:298
 #, elixir-autogen, elixir-format
 msgid "Show all, grouped by curriculum"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:272
-#: lib/lanttern_web/components/assessments_components.ex:300
+#: lib/lanttern_web/components/assessments_components.ex:275
+#: lib/lanttern_web/components/assessments_components.ex:303
 #, elixir-autogen, elixir-format
 msgid "Show all, grouped by moment"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:273
-#: lib/lanttern_web/components/assessments_components.ex:290
+#: lib/lanttern_web/components/assessments_components.ex:276
+#: lib/lanttern_web/components/assessments_components.ex:293
 #, elixir-autogen, elixir-format
 msgid "Show only goals assessments"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:158
+#: lib/lanttern_web/components/assessments_components.ex:159
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:48
 #, elixir-autogen, elixir-format
 msgid "Teacher assessment"
@@ -2298,20 +2298,20 @@ msgstr ""
 msgid "Has rubric"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:82
-#: lib/lanttern_web/components/assessments_components.ex:251
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:172
+#: lib/lanttern_web/components/assessments_components.ex:83
+#: lib/lanttern_web/components/assessments_components.ex:254
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:174
 #, elixir-autogen, elixir-format
 msgid "No entry"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:117
+#: lib/lanttern_web/components/reporting_components.ex:118
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:325
 #, elixir-autogen, elixir-format
 msgid "Student comment"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:119
+#: lib/lanttern_web/components/assessments_components.ex:120
 #, elixir-autogen, elixir-format
 msgid "Final assessment not available yet"
 msgstr ""
@@ -2321,7 +2321,7 @@ msgstr ""
 msgid "No assessment entries for this strand yet"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:153
+#: lib/lanttern_web/components/reporting_components.ex:154
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_rubrics_component.ex:102
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:233
 #, elixir-autogen, elixir-format
@@ -2333,7 +2333,7 @@ msgstr ""
 msgid "Add students to report card to track entries"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:539
+#: lib/lanttern_web/components/reporting_components.ex:540
 #, elixir-autogen, elixir-format
 msgid "No strands with moments assessment linked to this report card"
 msgstr ""
@@ -2343,12 +2343,12 @@ msgstr ""
 msgid "Tracking"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:170
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:172
 #, elixir-autogen, elixir-format
 msgid "No student self-assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:171
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:173
 #, elixir-autogen, elixir-format
 msgid "No teacher assessment"
 msgstr ""
@@ -2958,7 +2958,7 @@ msgstr ""
 msgid "Loading profiles"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:612
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:653
 #, elixir-autogen, elixir-format
 msgid "New assessment point"
 msgstr ""
@@ -5734,18 +5734,18 @@ msgstr ""
 msgid "Assessment information"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:416
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:457
 #, elixir-autogen, elixir-format
 msgid "Assessment point created"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:464
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:505
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:431
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:472
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Assessment point updated"
@@ -5792,7 +5792,7 @@ msgstr ""
 msgid "Edit assessment info"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:638
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:679
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Edit assessment point"
@@ -5806,11 +5806,6 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tags_live.ex:123
 #, elixir-autogen, elixir-format
 msgid "Edit lesson tag"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:201
-#, elixir-autogen, elixir-format
-msgid "Goals assessment are defined by the strand curriculum."
 msgstr ""
 
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:71
@@ -5982,15 +5977,10 @@ msgstr ""
 msgid "Use this area to share assessment information with students (e.g. grade composition)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:349
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:341
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Uses rubric in assessment"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:206
-#, elixir-autogen, elixir-format
-msgid "You can manage curriculum items in the overview section."
 msgstr ""
 
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tags_live.ex:34
@@ -6257,7 +6247,7 @@ msgstr ""
 msgid "Lesson assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:372
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:363
 #, elixir-autogen, elixir-format
 msgid "Lesson:"
 msgstr ""
@@ -6313,29 +6303,29 @@ msgstr ""
 msgid "Update link"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:132
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:134
 #, elixir-autogen, elixir-format
 msgid "Add value"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:139
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:83
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:141
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Breakpoints"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:65
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Deactivate scale"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:116
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:118
 #: lib/lanttern_web/live/pages/settings/grading_scales/grading_scales_live.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Edit ordinal value"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:71
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:73
 #: lib/lanttern_web/live/pages/settings/grading_scales/grading_scales_live.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Edit scale"
@@ -6377,7 +6367,7 @@ msgstr ""
 msgid "Numeric"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:145
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:147
 #, elixir-autogen, elixir-format
 msgid "Numeric scale, from %{start} to %{stop}"
 msgstr ""
@@ -6405,17 +6395,17 @@ msgstr ""
 msgid "Ordinal value updated"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:92
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:94
 #, elixir-autogen, elixir-format
 msgid "Ordinal values"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:65
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Reactivate scale"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:216
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:212
 #, elixir-autogen, elixir-format
 msgid "Scale created"
 msgstr ""
@@ -6425,12 +6415,12 @@ msgstr ""
 msgid "Scale deactivated"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:180
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:176
 #, elixir-autogen, elixir-format
 msgid "Scale deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:18
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:19
 #, elixir-autogen, elixir-format
 msgid "Scale name"
 msgstr ""
@@ -6440,7 +6430,7 @@ msgstr ""
 msgid "Scale reactivated"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:239
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:235
 #, elixir-autogen, elixir-format
 msgid "Scale updated"
 msgstr ""
@@ -6450,7 +6440,7 @@ msgstr ""
 msgid "Select a scale type"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:93
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:95
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:23
 #, elixir-autogen, elixir-format
 msgid "Short name"
@@ -6462,12 +6452,12 @@ msgstr ""
 msgid "This ordinal value is being used and cannot be deleted"
 msgstr ""
 
-#: lib/lanttern/grading/scale.ex:107
+#: lib/lanttern/grading/scale.ex:104
 #, elixir-autogen, elixir-format
 msgid "This scale is being used and cannot be deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:79
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Toggle scale card"
 msgstr ""
@@ -6477,12 +6467,12 @@ msgstr ""
 msgid "current, deactivated"
 msgstr ""
 
-#: lib/lanttern/grading/scale.ex:165
+#: lib/lanttern/grading/scale.ex:162
 #, elixir-autogen, elixir-format
 msgid "each value must be greater than 0 and less than 1"
 msgstr ""
 
-#: lib/lanttern/grading/scale.ex:157
+#: lib/lanttern/grading/scale.ex:154
 #, elixir-autogen, elixir-format
 msgid "must be a list of numbers separated by commas"
 msgstr ""
@@ -6492,32 +6482,22 @@ msgstr ""
 msgid "Deactivated scales"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:27
-#, elixir-autogen, elixir-format
-msgid "Start"
-msgstr ""
-
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:34
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Start background color"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:40
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:43
 #, elixir-autogen, elixir-format
 msgid "Start text color"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:48
-#, elixir-autogen, elixir-format
-msgid "Stop"
-msgstr ""
-
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:55
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Stop background color"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:61
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:57
 #, elixir-autogen, elixir-format
 msgid "Stop text color"
 msgstr ""
@@ -6777,7 +6757,7 @@ msgstr ""
 msgid "Lesson Curriculum"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:626
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:667
 #, elixir-autogen, elixir-format
 msgid "New strand goal"
 msgstr ""
@@ -6799,7 +6779,7 @@ msgid "Replace"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:102
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:164
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:166
 #, elixir-autogen, elixir-format
 msgid "Lack of evidence"
 msgstr ""
@@ -6822,30 +6802,30 @@ msgstr ""
 msgid "Extra classes"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:53
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "%{name} grading composition not setup yet"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:292
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:284
 #, elixir-autogen, elixir-format
 msgid "Add composition"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:60
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:91
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:93
 #, elixir-autogen, elixir-format
 msgid "Assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:308
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:340
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:33
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:300
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:332
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Average"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:181
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
 msgid "Average-based grade composition"
 msgstr ""
@@ -6855,44 +6835,59 @@ msgstr ""
 msgid "Component cannot be the same as the parent assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:32
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Composition type"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:299
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:291
 #, elixir-autogen, elixir-format
 msgid "Create composition using"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:48
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:50
 #, elixir-autogen, elixir-format
 msgid "Manage composition"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:89
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:91
 #, elixir-autogen, elixir-format
 msgid "Select the assessment points that will be part of the grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:47
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Setup composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:317
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:339
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:33
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:309
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:331
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Sum"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:180
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:182
 #, elixir-autogen, elixir-format
 msgid "Sum-based grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:343
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:335
 #, elixir-autogen, elixir-format
 msgid "Uses grade composition"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:27
+#, elixir-autogen, elixir-format
+msgid "Max score"
+msgstr ""
+
+#: lib/lanttern/grading/scale.ex:122
+#, elixir-autogen, elixir-format
+msgid "can't be blank when type is numeric"
+msgstr ""
+
+#: lib/lanttern/grading/scale.ex:115
+#, elixir-autogen, elixir-format
+msgid "must be \"numeric\" or \"ordinal\""
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -126,7 +126,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/agent_chat/agent_preferences_overlay_component.ex:73
 #: lib/lanttern_web/live/shared/agent_chat/rename_conversation_form_component.ex:28
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:47
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:162
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:164
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:150
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:283
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:100
@@ -137,7 +137,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:71
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:74
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:114
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:110
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:95
 #: lib/lanttern_web/live/shared/ilp/ilp_template_form_component.ex:162
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:110
@@ -212,7 +212,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/agent_chat/agent_preferences_overlay_component.ex:75
 #: lib/lanttern_web/live/shared/agent_chat/rename_conversation_form_component.ex:31
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:50
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:170
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:172
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:159
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:163
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:75
@@ -221,7 +221,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:64
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:77
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:117
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:113
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:105
 #: lib/lanttern_web/live/shared/ilp/ilp_template_form_component.ex:165
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:119
@@ -462,12 +462,12 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:73
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:80
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:38
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:153
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:155
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:141
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:52
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:62
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:65
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:105
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:101
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:85
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:100
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:51
@@ -518,20 +518,20 @@ msgstr ""
 #: lib/lanttern_web/live/pages/school/staff/deactivated/deactivated_staff_live.html.heex:48
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_card_component.ex:34
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_component_form_component.ex:62
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:62
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:64
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:71
 #: lib/lanttern_web/live/pages/strands/id/overview_component.ex:100
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:83
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:398
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:36
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:151
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:153
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:139
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:183
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:151
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:50
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:60
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:63
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:103
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:99
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:83
 #: lib/lanttern_web/live/shared/ilp/ilp_template_form_component.ex:155
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:98
@@ -561,7 +561,7 @@ msgstr ""
 msgid "Current assessment points"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:353
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:345
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:102
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:50
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:286
@@ -713,8 +713,8 @@ msgstr ""
 msgid "Rubric updated successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:62
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:93
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:64
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:95
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:34
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex:34
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:191
@@ -983,7 +983,7 @@ msgid "Curriculum item deleted"
 msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1131
-#: lib/lanttern_web/components/reporting_components.ex:225
+#: lib/lanttern_web/components/reporting_components.ex:226
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:57
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:69
@@ -1004,8 +1004,8 @@ msgstr ""
 msgid "Cycle already added to this grade report"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:82
-#: lib/lanttern_web/components/reporting_components.ex:438
+#: lib/lanttern_web/components/reporting_components.ex:83
+#: lib/lanttern_web/components/reporting_components.ex:439
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:297
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:290
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:339
@@ -1133,7 +1133,7 @@ msgstr ""
 msgid "Grade calculated succesfully"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:26
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:28
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:82
 #: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:87
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:39
@@ -1272,7 +1272,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:640
 #: lib/lanttern_web/components/grades_reports_components.ex:868
-#: lib/lanttern_web/components/reporting_components.ex:584
+#: lib/lanttern_web/components/reporting_components.ex:585
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr ""
@@ -1291,7 +1291,7 @@ msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1061
 #: lib/lanttern_web/components/grades_reports_components.ex:1134
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:94
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:96
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:27
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:47
 #, elixir-autogen, elixir-format
@@ -1320,7 +1320,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:311
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_component_form_component.ex:41
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:50
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:66
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:62
 #: lib/lanttern_web/live/shared/lessons/lesson_tag_form_component.ex:37
 #: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:56
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:73
@@ -1374,7 +1374,7 @@ msgstr ""
 msgid "Report cards"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:156
+#: lib/lanttern_web/components/reporting_components.ex:157
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_rubrics_component.ex:105
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:236
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:71
@@ -1531,8 +1531,8 @@ msgstr ""
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1060
 #: lib/lanttern_web/components/grades_reports_components.ex:1133
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:62
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:93
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:64
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:95
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Weight"
@@ -1918,7 +1918,7 @@ msgstr ""
 msgid "Students report cards access updated"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:236
+#: lib/lanttern_web/components/reporting_components.ex:237
 #, elixir-autogen, elixir-format
 msgid "Under development"
 msgstr ""
@@ -2034,13 +2034,13 @@ msgstr ""
 msgid "%{student} comment"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:161
+#: lib/lanttern_web/components/assessments_components.ex:162
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Student self-assessment"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:113
+#: lib/lanttern_web/components/reporting_components.ex:114
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:320
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:236
 #, elixir-autogen, elixir-format, fuzzy
@@ -2142,14 +2142,14 @@ msgstr ""
 msgid "Add"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:319
-#: lib/lanttern_web/components/assessments_components.ex:345
+#: lib/lanttern_web/components/assessments_components.ex:322
+#: lib/lanttern_web/components/assessments_components.ex:348
 #, elixir-autogen, elixir-format
 msgid "Assessed by students"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:318
-#: lib/lanttern_web/components/assessments_components.ex:340
+#: lib/lanttern_web/components/assessments_components.ex:321
+#: lib/lanttern_web/components/assessments_components.ex:343
 #, elixir-autogen, elixir-format
 msgid "Assessed by teacher"
 msgstr ""
@@ -2164,12 +2164,12 @@ msgstr ""
 msgid "Assessment point entry's evidences"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:350
+#: lib/lanttern_web/components/assessments_components.ex:353
 #, elixir-autogen, elixir-format
 msgid "Compare teacher and students assessments"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:320
+#: lib/lanttern_web/components/assessments_components.ex:323
 #, elixir-autogen, elixir-format
 msgid "Compare teacher/students"
 msgstr ""
@@ -2207,25 +2207,25 @@ msgstr ""
 msgid "Save comment"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:271
-#: lib/lanttern_web/components/assessments_components.ex:295
+#: lib/lanttern_web/components/assessments_components.ex:274
+#: lib/lanttern_web/components/assessments_components.ex:298
 #, elixir-autogen, elixir-format
 msgid "Show all, grouped by curriculum"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:272
-#: lib/lanttern_web/components/assessments_components.ex:300
+#: lib/lanttern_web/components/assessments_components.ex:275
+#: lib/lanttern_web/components/assessments_components.ex:303
 #, elixir-autogen, elixir-format
 msgid "Show all, grouped by moment"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:273
-#: lib/lanttern_web/components/assessments_components.ex:290
+#: lib/lanttern_web/components/assessments_components.ex:276
+#: lib/lanttern_web/components/assessments_components.ex:293
 #, elixir-autogen, elixir-format
 msgid "Show only goals assessments"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:158
+#: lib/lanttern_web/components/assessments_components.ex:159
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:48
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Teacher assessment"
@@ -2298,20 +2298,20 @@ msgstr ""
 msgid "Has rubric"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:82
-#: lib/lanttern_web/components/assessments_components.ex:251
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:172
+#: lib/lanttern_web/components/assessments_components.ex:83
+#: lib/lanttern_web/components/assessments_components.ex:254
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:174
 #, elixir-autogen, elixir-format
 msgid "No entry"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:117
+#: lib/lanttern_web/components/reporting_components.ex:118
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:325
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student comment"
 msgstr ""
 
-#: lib/lanttern_web/components/assessments_components.ex:119
+#: lib/lanttern_web/components/assessments_components.ex:120
 #, elixir-autogen, elixir-format
 msgid "Final assessment not available yet"
 msgstr ""
@@ -2321,7 +2321,7 @@ msgstr ""
 msgid "No assessment entries for this strand yet"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:153
+#: lib/lanttern_web/components/reporting_components.ex:154
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_rubrics_component.ex:102
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:233
 #, elixir-autogen, elixir-format, fuzzy
@@ -2333,7 +2333,7 @@ msgstr ""
 msgid "Add students to report card to track entries"
 msgstr ""
 
-#: lib/lanttern_web/components/reporting_components.ex:539
+#: lib/lanttern_web/components/reporting_components.ex:540
 #, elixir-autogen, elixir-format
 msgid "No strands with moments assessment linked to this report card"
 msgstr ""
@@ -2343,12 +2343,12 @@ msgstr ""
 msgid "Tracking"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:170
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:172
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No student self-assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:171
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:173
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No teacher assessment"
 msgstr ""
@@ -2958,7 +2958,7 @@ msgstr ""
 msgid "Loading profiles"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:612
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:653
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New assessment point"
 msgstr ""
@@ -5734,18 +5734,18 @@ msgstr ""
 msgid "Assessment information"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:416
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:457
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point created"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:464
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:505
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:526
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:431
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:472
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:511
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point updated"
@@ -5792,7 +5792,7 @@ msgstr ""
 msgid "Edit assessment info"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:638
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:679
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:390
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit assessment point"
@@ -5806,11 +5806,6 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tags_live.ex:123
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit lesson tag"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:201
-#, elixir-autogen, elixir-format
-msgid "Goals assessment are defined by the strand curriculum."
 msgstr ""
 
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:71
@@ -5982,15 +5977,10 @@ msgstr ""
 msgid "Use this area to share assessment information with students (e.g. grade composition)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:349
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:341
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:46
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Uses rubric in assessment"
-msgstr ""
-
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:206
-#, elixir-autogen, elixir-format
-msgid "You can manage curriculum items in the overview section."
 msgstr ""
 
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tags_live.ex:34
@@ -6257,7 +6247,7 @@ msgstr ""
 msgid "Lesson assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:372
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:363
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lesson:"
 msgstr ""
@@ -6313,29 +6303,29 @@ msgstr ""
 msgid "Update link"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:132
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:134
 #, elixir-autogen, elixir-format
 msgid "Add value"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:139
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:83
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:141
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Breakpoints"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:65
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:67
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Deactivate scale"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:116
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:118
 #: lib/lanttern_web/live/pages/settings/grading_scales/grading_scales_live.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Edit ordinal value"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:71
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:73
 #: lib/lanttern_web/live/pages/settings/grading_scales/grading_scales_live.html.heex:78
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit scale"
@@ -6377,7 +6367,7 @@ msgstr ""
 msgid "Numeric"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:145
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:147
 #, elixir-autogen, elixir-format
 msgid "Numeric scale, from %{start} to %{stop}"
 msgstr ""
@@ -6405,17 +6395,17 @@ msgstr ""
 msgid "Ordinal value updated"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:92
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:94
 #, elixir-autogen, elixir-format
 msgid "Ordinal values"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:65
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:67
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Reactivate scale"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:216
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:212
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Scale created"
 msgstr ""
@@ -6425,12 +6415,12 @@ msgstr ""
 msgid "Scale deactivated"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:180
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:176
 #, elixir-autogen, elixir-format
 msgid "Scale deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:18
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:19
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Scale name"
 msgstr ""
@@ -6440,7 +6430,7 @@ msgstr ""
 msgid "Scale reactivated"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:239
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:235
 #, elixir-autogen, elixir-format
 msgid "Scale updated"
 msgstr ""
@@ -6450,7 +6440,7 @@ msgstr ""
 msgid "Select a scale type"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:93
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:95
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:23
 #, elixir-autogen, elixir-format
 msgid "Short name"
@@ -6462,12 +6452,12 @@ msgstr ""
 msgid "This ordinal value is being used and cannot be deleted"
 msgstr ""
 
-#: lib/lanttern/grading/scale.ex:107
+#: lib/lanttern/grading/scale.ex:104
 #, elixir-autogen, elixir-format
 msgid "This scale is being used and cannot be deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:79
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:81
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Toggle scale card"
 msgstr ""
@@ -6477,12 +6467,12 @@ msgstr ""
 msgid "current, deactivated"
 msgstr ""
 
-#: lib/lanttern/grading/scale.ex:165
+#: lib/lanttern/grading/scale.ex:162
 #, elixir-autogen, elixir-format
 msgid "each value must be greater than 0 and less than 1"
 msgstr ""
 
-#: lib/lanttern/grading/scale.ex:157
+#: lib/lanttern/grading/scale.ex:154
 #, elixir-autogen, elixir-format
 msgid "must be a list of numbers separated by commas"
 msgstr ""
@@ -6492,32 +6482,22 @@ msgstr ""
 msgid "Deactivated scales"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:27
-#, elixir-autogen, elixir-format, fuzzy
-msgid "Start"
-msgstr ""
-
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:34
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Start background color"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:40
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:43
 #, elixir-autogen, elixir-format
 msgid "Start text color"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:48
-#, elixir-autogen, elixir-format
-msgid "Stop"
-msgstr ""
-
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:55
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Stop background color"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:61
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:57
 #, elixir-autogen, elixir-format
 msgid "Stop text color"
 msgstr ""
@@ -6777,7 +6757,7 @@ msgstr ""
 msgid "Lesson Curriculum"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:626
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:667
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New strand goal"
 msgstr ""
@@ -6799,7 +6779,7 @@ msgid "Replace"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:102
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:164
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:166
 #, elixir-autogen, elixir-format
 msgid "Lack of evidence"
 msgstr ""
@@ -6822,30 +6802,30 @@ msgstr ""
 msgid "Extra classes"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:53
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "%{name} grading composition not setup yet"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:292
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:284
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add composition"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:60
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:91
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:93
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:308
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:340
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:33
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:300
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:332
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Average"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:181
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
 msgid "Average-based grade composition"
 msgstr ""
@@ -6855,44 +6835,59 @@ msgstr ""
 msgid "Component cannot be the same as the parent assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:32
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Composition type"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:299
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:291
 #, elixir-autogen, elixir-format
 msgid "Create composition using"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:48
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:50
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Manage composition"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:89
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:91
 #, elixir-autogen, elixir-format
 msgid "Select the assessment points that will be part of the grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:47
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Setup composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:317
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:339
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:33
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:309
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:331
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Sum"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:180
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:182
 #, elixir-autogen, elixir-format
 msgid "Sum-based grade composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:343
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:335
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Uses grade composition"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:27
+#, elixir-autogen, elixir-format
+msgid "Max score"
+msgstr ""
+
+#: lib/lanttern/grading/scale.ex:122
+#, elixir-autogen, elixir-format
+msgid "can't be blank when type is numeric"
+msgstr ""
+
+#: lib/lanttern/grading/scale.ex:115
+#, elixir-autogen, elixir-format
+msgid "must be \"numeric\" or \"ordinal\""
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -126,7 +126,7 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/shared/agent_chat/agent_preferences_overlay_component.ex:73
 #: lib/lanttern_web/live/shared/agent_chat/rename_conversation_form_component.ex:28
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:47
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:162
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:164
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:150
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:283
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:100
@@ -137,7 +137,7 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/shared/filters/filters_overlay_component.ex:25
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:71
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:74
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:114
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:110
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:95
 #: lib/lanttern_web/live/shared/ilp/ilp_template_form_component.ex:162
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:110
@@ -212,7 +212,7 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/shared/agent_chat/agent_preferences_overlay_component.ex:75
 #: lib/lanttern_web/live/shared/agent_chat/rename_conversation_form_component.ex:31
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:50
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:170
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:172
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:159
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:163
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:75
@@ -221,7 +221,7 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:64
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:74
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:77
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:117
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:113
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:105
 #: lib/lanttern_web/live/shared/ilp/ilp_template_form_component.ex:165
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:119
@@ -462,12 +462,12 @@ msgstr "Não foi possível encontrar a trilha"
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:73
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:80
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:38
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:153
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:155
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:141
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:52
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:62
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:65
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:105
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:101
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:85
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:100
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:51
@@ -518,20 +518,20 @@ msgstr "Adicionar rubrica"
 #: lib/lanttern_web/live/pages/school/staff/deactivated/deactivated_staff_live.html.heex:48
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_card_component.ex:34
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_component_form_component.ex:62
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:62
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:64
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:71
 #: lib/lanttern_web/live/pages/strands/id/overview_component.ex:100
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:83
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:398
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:36
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:151
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:153
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:139
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:183
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:151
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:50
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:60
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:63
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:103
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:99
 #: lib/lanttern_web/live/shared/ilp/ilp_comment_form_overlay_component.ex:83
 #: lib/lanttern_web/live/shared/ilp/ilp_template_form_component.ex:155
 #: lib/lanttern_web/live/shared/ilp/student_ilp_form_overlay_component.ex:98
@@ -561,7 +561,7 @@ msgstr "Você tem certeza?"
 msgid "Current assessment points"
 msgstr "Pontos de avaliação atuais"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:353
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:345
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:102
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:50
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:286
@@ -713,8 +713,8 @@ msgstr "Rubrica criada com sucesso"
 msgid "Rubric updated successfully"
 msgstr "Rubrica atualizada com sucesso"
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:62
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:93
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:64
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:95
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:34
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_form_component.ex:34
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:191
@@ -983,7 +983,7 @@ msgid "Curriculum item deleted"
 msgstr "Parâmetro curricular removido"
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1131
-#: lib/lanttern_web/components/reporting_components.ex:225
+#: lib/lanttern_web/components/reporting_components.ex:226
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:57
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:10
 #: lib/lanttern_web/live/pages/report_cards/id/report_card_live.html.heex:69
@@ -1004,8 +1004,8 @@ msgstr "Ciclo"
 msgid "Cycle already added to this grade report"
 msgstr "Ciclo já adicionado à este relatório de nota"
 
-#: lib/lanttern_web/components/reporting_components.ex:82
-#: lib/lanttern_web/components/reporting_components.ex:438
+#: lib/lanttern_web/components/reporting_components.ex:83
+#: lib/lanttern_web/components/reporting_components.ex:439
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:297
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:290
 #: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:339
@@ -1133,7 +1133,7 @@ msgstr "Nota final"
 msgid "Grade calculated succesfully"
 msgstr "Nota calculada com sucesso"
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:26
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:28
 #: lib/lanttern_web/live/shared/grades_reports/final_grade_details_overlay_component.ex:82
 #: lib/lanttern_web/live/shared/grades_reports/grade_details_overlay_component.ex:87
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:39
@@ -1272,7 +1272,7 @@ msgstr "Nenhuma trilha vinculada a este relatório ainda"
 
 #: lib/lanttern_web/components/grades_reports_components.ex:640
 #: lib/lanttern_web/components/grades_reports_components.ex:868
-#: lib/lanttern_web/components/reporting_components.ex:584
+#: lib/lanttern_web/components/reporting_components.ex:585
 #, elixir-autogen, elixir-format
 msgid "No students linked to this grades report"
 msgstr "Nenhum estudante vinculado a este relatório de notas"
@@ -1291,7 +1291,7 @@ msgstr "Nenhuma disciplina vinculada a este relatório de notas"
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1061
 #: lib/lanttern_web/components/grades_reports_components.ex:1134
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:94
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:96
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:27
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_form_component.ex:47
 #, elixir-autogen, elixir-format
@@ -1320,7 +1320,7 @@ msgstr "Resultados parciais"
 #: lib/lanttern_web/live/pages/report_cards/id/students_component.ex:311
 #: lib/lanttern_web/live/pages/settings/curricula/curriculum_component_form_component.ex:41
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:50
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:66
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:62
 #: lib/lanttern_web/live/shared/lessons/lesson_tag_form_component.ex:37
 #: lib/lanttern_web/live/shared/students/student_tag_form_overlay_component.ex:56
 #: lib/lanttern_web/live/shared/students_records/student_record_status_form_overlay.ex:73
@@ -1374,7 +1374,7 @@ msgstr "Id do report card"
 msgid "Report cards"
 msgstr "Report cards"
 
-#: lib/lanttern_web/components/reporting_components.ex:156
+#: lib/lanttern_web/components/reporting_components.ex:157
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_rubrics_component.ex:105
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:236
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:71
@@ -1531,8 +1531,8 @@ msgstr "Utilize a marcação de diferenciação ao criar pontos de avaliação r
 
 #: lib/lanttern_web/components/grades_reports_components.ex:1060
 #: lib/lanttern_web/components/grades_reports_components.ex:1133
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:62
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:93
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:64
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:95
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Weight"
@@ -1918,7 +1918,7 @@ msgstr "Acesso de estudantes"
 msgid "Students report cards access updated"
 msgstr "Report cards de estudante atualizados"
 
-#: lib/lanttern_web/components/reporting_components.ex:236
+#: lib/lanttern_web/components/reporting_components.ex:237
 #, elixir-autogen, elixir-format
 msgid "Under development"
 msgstr "Em desenvolvimento"
@@ -2034,13 +2034,13 @@ msgstr "Professor"
 msgid "%{student} comment"
 msgstr "Comentário de %{student}"
 
-#: lib/lanttern_web/components/assessments_components.ex:161
+#: lib/lanttern_web/components/assessments_components.ex:162
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Student self-assessment"
 msgstr "Autoavaliação do estudante"
 
-#: lib/lanttern_web/components/reporting_components.ex:113
+#: lib/lanttern_web/components/reporting_components.ex:114
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:320
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:236
 #, elixir-autogen, elixir-format
@@ -2142,14 +2142,14 @@ msgstr "(Avaliação final da trilha)"
 msgid "Add"
 msgstr "Adicionar"
 
-#: lib/lanttern_web/components/assessments_components.ex:319
-#: lib/lanttern_web/components/assessments_components.ex:345
+#: lib/lanttern_web/components/assessments_components.ex:322
+#: lib/lanttern_web/components/assessments_components.ex:348
 #, elixir-autogen, elixir-format
 msgid "Assessed by students"
 msgstr "Avaliado por estudantes"
 
-#: lib/lanttern_web/components/assessments_components.ex:318
-#: lib/lanttern_web/components/assessments_components.ex:340
+#: lib/lanttern_web/components/assessments_components.ex:321
+#: lib/lanttern_web/components/assessments_components.ex:343
 #, elixir-autogen, elixir-format
 msgid "Assessed by teacher"
 msgstr "Avaliado por professores"
@@ -2164,12 +2164,12 @@ msgstr "Detalhes do registro do ponto de avaliação"
 msgid "Assessment point entry's evidences"
 msgstr "Evidências do registro do ponto de avaliação"
 
-#: lib/lanttern_web/components/assessments_components.ex:350
+#: lib/lanttern_web/components/assessments_components.ex:353
 #, elixir-autogen, elixir-format
 msgid "Compare teacher and students assessments"
 msgstr "Comparar avaliações de professor e estudantes"
 
-#: lib/lanttern_web/components/assessments_components.ex:320
+#: lib/lanttern_web/components/assessments_components.ex:323
 #, elixir-autogen, elixir-format
 msgid "Compare teacher/students"
 msgstr "Comparar professor/estudantes"
@@ -2207,25 +2207,25 @@ msgstr "Nenhum comentário de professor"
 msgid "Save comment"
 msgstr "Salvar comentário"
 
-#: lib/lanttern_web/components/assessments_components.ex:271
-#: lib/lanttern_web/components/assessments_components.ex:295
+#: lib/lanttern_web/components/assessments_components.ex:274
+#: lib/lanttern_web/components/assessments_components.ex:298
 #, elixir-autogen, elixir-format
 msgid "Show all, grouped by curriculum"
 msgstr "Mostrar tudo, agrupado por currículo"
 
-#: lib/lanttern_web/components/assessments_components.ex:272
-#: lib/lanttern_web/components/assessments_components.ex:300
+#: lib/lanttern_web/components/assessments_components.ex:275
+#: lib/lanttern_web/components/assessments_components.ex:303
 #, elixir-autogen, elixir-format
 msgid "Show all, grouped by moment"
 msgstr "Mostrar tudo, agrupado por momento"
 
-#: lib/lanttern_web/components/assessments_components.ex:273
-#: lib/lanttern_web/components/assessments_components.ex:290
+#: lib/lanttern_web/components/assessments_components.ex:276
+#: lib/lanttern_web/components/assessments_components.ex:293
 #, elixir-autogen, elixir-format
 msgid "Show only goals assessments"
 msgstr "Mostrar somente avaliações dos objetivos"
 
-#: lib/lanttern_web/components/assessments_components.ex:158
+#: lib/lanttern_web/components/assessments_components.ex:159
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:48
 #, elixir-autogen, elixir-format
 msgid "Teacher assessment"
@@ -2298,20 +2298,20 @@ msgstr "Padrão da avaliação formativa"
 msgid "Has rubric"
 msgstr "Possui rubrica"
 
-#: lib/lanttern_web/components/assessments_components.ex:82
-#: lib/lanttern_web/components/assessments_components.ex:251
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:172
+#: lib/lanttern_web/components/assessments_components.ex:83
+#: lib/lanttern_web/components/assessments_components.ex:254
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:174
 #, elixir-autogen, elixir-format
 msgid "No entry"
 msgstr "Sem registro"
 
-#: lib/lanttern_web/components/reporting_components.ex:117
+#: lib/lanttern_web/components/reporting_components.ex:118
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:325
 #, elixir-autogen, elixir-format
 msgid "Student comment"
 msgstr "Comentário do estudante"
 
-#: lib/lanttern_web/components/assessments_components.ex:119
+#: lib/lanttern_web/components/assessments_components.ex:120
 #, elixir-autogen, elixir-format
 msgid "Final assessment not available yet"
 msgstr "A avaliação final ainda não está disponível"
@@ -2321,7 +2321,7 @@ msgstr "A avaliação final ainda não está disponível"
 msgid "No assessment entries for this strand yet"
 msgstr "Nenhum registro de avaliação para esta trilha ainda"
 
-#: lib/lanttern_web/components/reporting_components.ex:153
+#: lib/lanttern_web/components/reporting_components.ex:154
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_rubrics_component.ex:102
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:233
 #, elixir-autogen, elixir-format
@@ -2333,7 +2333,7 @@ msgstr "Rubrica de diferenciação"
 msgid "Add students to report card to track entries"
 msgstr "Adicione estudantes ao report card para acompanhar os registros"
 
-#: lib/lanttern_web/components/reporting_components.ex:539
+#: lib/lanttern_web/components/reporting_components.ex:540
 #, elixir-autogen, elixir-format
 msgid "No strands with moments assessment linked to this report card"
 msgstr "Nenhuma trilha com avaliações nos momentos vinculada a este report card"
@@ -2343,12 +2343,12 @@ msgstr "Nenhuma trilha com avaliações nos momentos vinculada a este report car
 msgid "Tracking"
 msgstr "Acompanhamento"
 
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:170
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:172
 #, elixir-autogen, elixir-format
 msgid "No student self-assessment"
 msgstr "Sem autoavaliação do estudante"
 
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:171
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:173
 #, elixir-autogen, elixir-format
 msgid "No teacher assessment"
 msgstr "Sem avaliação do professor"
@@ -2958,7 +2958,7 @@ msgstr "Carregando ciclos"
 msgid "Loading profiles"
 msgstr "Carregando perfis"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:612
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:653
 #, elixir-autogen, elixir-format
 msgid "New assessment point"
 msgstr "Novo ponto de avaliação"
@@ -5734,18 +5734,18 @@ msgstr "Tem certeza? Todas as aulas vinculadas também serão excluídas."
 msgid "Assessment information"
 msgstr "Informações de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:416
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:457
 #, elixir-autogen, elixir-format
 msgid "Assessment point created"
 msgstr "Ponto de avaliação criado"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:464
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:505
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:526
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted"
 msgstr "Ponto de avaliação excluído"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:431
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:472
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:511
 #, elixir-autogen, elixir-format
 msgid "Assessment point updated"
@@ -5792,7 +5792,7 @@ msgstr "Excluir aulas também"
 msgid "Edit assessment info"
 msgstr "Editar informações de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:638
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:679
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:390
 #, elixir-autogen, elixir-format
 msgid "Edit assessment point"
@@ -5807,11 +5807,6 @@ msgstr "Editar descrição"
 #, elixir-autogen, elixir-format
 msgid "Edit lesson tag"
 msgstr "Editar tag de aula"
-
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:201
-#, elixir-autogen, elixir-format
-msgid "Goals assessment are defined by the strand curriculum."
-msgstr "A avaliação dos objetivos é definida pelo currículo da trilha."
 
 #: lib/lanttern_web/live/shared/learning_context/moment_form_component.ex:71
 #, elixir-autogen, elixir-format
@@ -5982,16 +5977,11 @@ msgstr "Alternar card da tag de aula"
 msgid "Use this area to share assessment information with students (e.g. grade composition)"
 msgstr "Use esta área para compartilhar informações de avaliação com os estudantes (ex.: composição das notas)"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:349
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:341
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:46
 #, elixir-autogen, elixir-format
 msgid "Uses rubric in assessment"
 msgstr "Usa rubrica na avaliação"
-
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:206
-#, elixir-autogen, elixir-format
-msgid "You can manage curriculum items in the overview section."
-msgstr "Você pode gerenciar os parâmetros curriculares na seção de visão geral."
 
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tags_live.ex:34
 #, elixir-autogen, elixir-format
@@ -6257,7 +6247,7 @@ msgstr "Você deseja desvincular de \"%{linked_lesson}\" e vincular a \"%{this_l
 msgid "Lesson assessment"
 msgstr "Avaliação da aula"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:372
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:363
 #, elixir-autogen, elixir-format
 msgid "Lesson:"
 msgstr "Aula:"
@@ -6313,29 +6303,29 @@ msgstr "Desvincular"
 msgid "Update link"
 msgstr "Atualizar vínculo"
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:132
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:134
 #, elixir-autogen, elixir-format
 msgid "Add value"
 msgstr "Adicionar valor"
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:139
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:83
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:141
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:79
 #, elixir-autogen, elixir-format
 msgid "Breakpoints"
 msgstr "Intervalos"
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:65
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Deactivate scale"
 msgstr "Desativar escala"
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:116
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:118
 #: lib/lanttern_web/live/pages/settings/grading_scales/grading_scales_live.html.heex:96
 #, elixir-autogen, elixir-format
 msgid "Edit ordinal value"
 msgstr "Editar valor ordinal"
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:71
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:73
 #: lib/lanttern_web/live/pages/settings/grading_scales/grading_scales_live.html.heex:78
 #, elixir-autogen, elixir-format
 msgid "Edit scale"
@@ -6377,7 +6367,7 @@ msgstr "Valor normalizado deve estar entre 0 e 1"
 msgid "Numeric"
 msgstr "Numérica"
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:145
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:147
 #, elixir-autogen, elixir-format
 msgid "Numeric scale, from %{start} to %{stop}"
 msgstr "Escala numérica, de %{start} a %{stop}"
@@ -6405,17 +6395,17 @@ msgstr "Valor ordinal deletado"
 msgid "Ordinal value updated"
 msgstr "Valor ordinal atualizado"
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:92
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:94
 #, elixir-autogen, elixir-format
 msgid "Ordinal values"
 msgstr "Valores ordinais"
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:65
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:67
 #, elixir-autogen, elixir-format
 msgid "Reactivate scale"
 msgstr "Reativar escala"
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:216
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:212
 #, elixir-autogen, elixir-format
 msgid "Scale created"
 msgstr "Escala criada"
@@ -6425,12 +6415,12 @@ msgstr "Escala criada"
 msgid "Scale deactivated"
 msgstr "Escala desativada"
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:180
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:176
 #, elixir-autogen, elixir-format
 msgid "Scale deleted"
 msgstr "Escala deletada"
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:18
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:19
 #, elixir-autogen, elixir-format
 msgid "Scale name"
 msgstr "Nome da escala"
@@ -6440,7 +6430,7 @@ msgstr "Nome da escala"
 msgid "Scale reactivated"
 msgstr "Escala reativada"
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:239
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:235
 #, elixir-autogen, elixir-format
 msgid "Scale updated"
 msgstr "Escala atualizada"
@@ -6450,7 +6440,7 @@ msgstr "Escala atualizada"
 msgid "Select a scale type"
 msgstr "Selecione um tipo de escala"
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:93
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:95
 #: lib/lanttern_web/live/pages/settings/grading_scales/ordinal_value_form_component.ex:23
 #, elixir-autogen, elixir-format
 msgid "Short name"
@@ -6462,12 +6452,12 @@ msgstr "Nome curto"
 msgid "This ordinal value is being used and cannot be deleted"
 msgstr "Este valor ordinal está sendo utilizado e não pode ser deletado"
 
-#: lib/lanttern/grading/scale.ex:107
+#: lib/lanttern/grading/scale.ex:104
 #, elixir-autogen, elixir-format
 msgid "This scale is being used and cannot be deleted"
 msgstr "Esta escala está sendo utilizada e não pode ser deletada"
 
-#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:79
+#: lib/lanttern_web/live/pages/settings/grading_scales/grading_scale_card_component.ex:81
 #, elixir-autogen, elixir-format
 msgid "Toggle scale card"
 msgstr "Alternar card de escala"
@@ -6477,12 +6467,12 @@ msgstr "Alternar card de escala"
 msgid "current, deactivated"
 msgstr "atual, desativada"
 
-#: lib/lanttern/grading/scale.ex:165
+#: lib/lanttern/grading/scale.ex:162
 #, elixir-autogen, elixir-format
 msgid "each value must be greater than 0 and less than 1"
 msgstr "cada valor deve ser maior que 0 e menor que 1"
 
-#: lib/lanttern/grading/scale.ex:157
+#: lib/lanttern/grading/scale.ex:154
 #, elixir-autogen, elixir-format
 msgid "must be a list of numbers separated by commas"
 msgstr "deve ser uma lista de números separados por vírgulas"
@@ -6492,32 +6482,22 @@ msgstr "deve ser uma lista de números separados por vírgulas"
 msgid "Deactivated scales"
 msgstr "Escalas desativadas"
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:27
-#, elixir-autogen, elixir-format
-msgid "Start"
-msgstr "Início"
-
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:34
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:37
 #, elixir-autogen, elixir-format
 msgid "Start background color"
 msgstr "Cor de fundo de início"
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:40
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:43
 #, elixir-autogen, elixir-format
 msgid "Start text color"
 msgstr "Cor de texto de início"
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:48
-#, elixir-autogen, elixir-format
-msgid "Stop"
-msgstr "Término"
-
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:55
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Stop background color"
 msgstr "Cor de fundo de término"
 
-#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:61
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:57
 #, elixir-autogen, elixir-format
 msgid "Stop text color"
 msgstr "Cor de texto de término"
@@ -6777,7 +6757,7 @@ msgstr "Parâmetro curricular já vinculado à esta trilha"
 msgid "Lesson Curriculum"
 msgstr "Currículo da Aula"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:626
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:667
 #, elixir-autogen, elixir-format
 msgid "New strand goal"
 msgstr "Novo objetivo da trilha"
@@ -6799,7 +6779,7 @@ msgid "Replace"
 msgstr "Substituir"
 
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:102
-#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:164
+#: lib/lanttern_web/live/shared/assessments/entry_particle_component.ex:166
 #, elixir-autogen, elixir-format
 msgid "Lack of evidence"
 msgstr "Sem evidências"
@@ -6822,30 +6802,30 @@ msgstr "Turma principal"
 msgid "Extra classes"
 msgstr "Turmas extras"
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:53
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:55
 #, elixir-autogen, elixir-format
 msgid "%{name} grading composition not setup yet"
 msgstr "Composição de notas de %{name} ainda não configurada"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:292
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:284
 #, elixir-autogen, elixir-format
 msgid "Add composition"
 msgstr "Adicionar composição"
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:60
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:91
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:62
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:93
 #, elixir-autogen, elixir-format
 msgid "Assessment point"
 msgstr "Ponto de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:308
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:340
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:33
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:300
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:332
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Average"
 msgstr "Média"
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:181
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:183
 #, elixir-autogen, elixir-format
 msgid "Average-based grade composition"
 msgstr "Composição de nota baseada na média"
@@ -6855,44 +6835,59 @@ msgstr "Composição de nota baseada na média"
 msgid "Component cannot be the same as the parent assessment point"
 msgstr "Componente não pode ser o mesmo do ponto de avaliação pai"
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:32
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Composition type"
 msgstr "Tipo de composição"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:299
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:291
 #, elixir-autogen, elixir-format
 msgid "Create composition using"
 msgstr "Criar composição usando"
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:48
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:50
 #, elixir-autogen, elixir-format
 msgid "Manage composition"
 msgstr "Gerenciar composição"
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:89
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:91
 #, elixir-autogen, elixir-format
 msgid "Select the assessment points that will be part of the grade composition"
 msgstr "Selecione os pontos de avaliação para compor a nota"
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:47
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:49
 #, elixir-autogen, elixir-format
 msgid "Setup composition"
 msgstr "Configurar composição"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:317
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:339
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:33
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:309
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:331
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Sum"
 msgstr "Soma"
 
-#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:180
+#: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:182
 #, elixir-autogen, elixir-format
 msgid "Sum-based grade composition"
 msgstr "Composição de nota baseada em soma"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:343
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:335
 #, elixir-autogen, elixir-format
 msgid "Uses grade composition"
 msgstr "Utiliza composição de nota"
+
+#: lib/lanttern_web/live/shared/grading/grading_scale_form_component.ex:27
+#, elixir-autogen, elixir-format
+msgid "Max score"
+msgstr "Score máximo"
+
+#: lib/lanttern/grading/scale.ex:122
+#, elixir-autogen, elixir-format
+msgid "can't be blank when type is numeric"
+msgstr "não pode estar em branco quando o tipo é numérico"
+
+#: lib/lanttern/grading/scale.ex:115
+#, elixir-autogen, elixir-format
+msgid "must be \"numeric\" or \"ordinal\""
+msgstr "deve ser \"numérica\" ou \"ordinal\""

--- a/priv/repo/migrations/20260512164548_drop_scale_start_rename_stop_to_max_score.exs
+++ b/priv/repo/migrations/20260512164548_drop_scale_start_rename_stop_to_max_score.exs
@@ -1,0 +1,11 @@
+defmodule Lanttern.Repo.Migrations.DropScaleStartRenameStopToMaxScore do
+  use Ecto.Migration
+
+  def change do
+    alter table(:grading_scales) do
+      remove :start
+    end
+
+    rename table(:grading_scales), :stop, to: :max_score
+  end
+end

--- a/test/lanttern/assessments_test.exs
+++ b/test/lanttern/assessments_test.exs
@@ -531,7 +531,7 @@ defmodule Lanttern.AssessmentsTest do
     end
 
     test "create_assessment_point_entry/1 of type numeric with valid data creates a assessment_point_entry" do
-      scale = insert(:scale, type: "numeric", start: 0, stop: 1)
+      scale = insert(:scale, type: "numeric", max_score: 1)
       assessment_point = assessment_point_fixture(%{scale_id: scale.id})
       student = SchoolsFixtures.student_fixture()
 
@@ -579,7 +579,7 @@ defmodule Lanttern.AssessmentsTest do
     end
 
     test "create_assessment_point_entry/1 with score out of scale returns error changeset" do
-      scale = insert(:scale, type: "numeric", start: 0, stop: 10)
+      scale = insert(:scale, type: "numeric", max_score: 10)
       assessment_point = assessment_point_fixture(%{scale_id: scale.id})
       student = SchoolsFixtures.student_fixture()
 
@@ -992,7 +992,7 @@ defmodule Lanttern.AssessmentsTest do
 
       ordinal_scale = insert(:scale, type: "ordinal", breakpoints: [0.4, 0.8])
       ordinal_value = insert(:ordinal_value, scale_id: ordinal_scale.id)
-      numeric_scale = insert(:scale, type: "numeric", start: 0.0, stop: 100.0)
+      numeric_scale = insert(:scale, type: "numeric", max_score: 100.0)
 
       rubric_1 = RubricsFixtures.rubric_fixture(%{scale_id: ordinal_scale.id})
       rubric_3 = RubricsFixtures.rubric_fixture(%{scale_id: ordinal_scale.id})

--- a/test/lanttern/color_utils_test.exs
+++ b/test/lanttern/color_utils_test.exs
@@ -4,8 +4,7 @@ defmodule Lanttern.ColorUtilsTest do
   alias Lanttern.ColorUtils
 
   @scale %{
-    start: 0.0,
-    stop: 10.0,
+    max_score: 10.0,
     start_bg_color: "#000000",
     start_text_color: "#ffffff",
     stop_bg_color: "#ffffff",
@@ -38,23 +37,23 @@ defmodule Lanttern.ColorUtilsTest do
     end
 
     test "returns {bg, nil} when only bg colors are present" do
-      scale = %{start: 0.0, stop: 10.0, start_bg_color: "#000000", stop_bg_color: "#ffffff"}
+      scale = %{max_score: 10.0, start_bg_color: "#000000", stop_bg_color: "#ffffff"}
       assert {bg, nil} = ColorUtils.interpolate_numeric_scale_colors(scale, 5.0)
       assert String.match?(bg, ~r/^#[0-9a-f]{6}$/i)
     end
 
     test "returns {nil, text} when only text colors are present" do
-      scale = %{start: 0.0, stop: 10.0, start_text_color: "#000000", stop_text_color: "#ffffff"}
+      scale = %{max_score: 10.0, start_text_color: "#000000", stop_text_color: "#ffffff"}
       assert {nil, text} = ColorUtils.interpolate_numeric_scale_colors(scale, 5.0)
       assert String.match?(text, ~r/^#[0-9a-f]{6}$/i)
     end
 
     test "returns nil when scale has no color fields" do
-      assert ColorUtils.interpolate_numeric_scale_colors(%{start: 0.0, stop: 10.0}, 5.0) == nil
+      assert ColorUtils.interpolate_numeric_scale_colors(%{max_score: 10.0}, 5.0) == nil
     end
 
     test "handles degenerate scale where start equals stop" do
-      degenerate = %{@scale | stop: 0.0}
+      degenerate = %{@scale | max_score: 0.0}
       assert {"#000000", _} = ColorUtils.interpolate_numeric_scale_colors(degenerate, 0.0)
     end
   end

--- a/test/lanttern/grading_test.exs
+++ b/test/lanttern/grading_test.exs
@@ -147,14 +147,12 @@ defmodule Lanttern.GradingTest do
     import Lanttern.Factory
     import Lanttern.IdentityFixtures
 
-    @invalid_attrs %{name: nil, start: nil, stop: nil, type: nil}
+    @invalid_attrs %{name: nil, type: nil}
 
-    @invalid_numeric_attrs %{name: "0 to 10", start: nil, stop: nil, type: "numeric"}
+    @invalid_numeric_attrs %{name: "0 to 10", max_score: nil, type: "numeric"}
 
     @invalid_breakpoint_attrs %{
       name: "Letter grades",
-      start: nil,
-      stop: nil,
       type: "ordinal",
       breakpoints: [0.5, 1.5]
     }
@@ -172,7 +170,7 @@ defmodule Lanttern.GradingTest do
     test "list_scales/1 with preloads and scales_ids opts returns all scales as expected",
          %{scope: scope} do
       num_scale =
-        insert(:scale, school_id: scope.school_id, type: "numeric", start: 0.0, stop: 100.0)
+        insert(:scale, school_id: scope.school_id, type: "numeric", max_score: 100.0)
 
       ord_scale = insert(:scale, school_id: scope.school_id, type: "ordinal")
       ov_1 = insert(:ordinal_value, scale_id: ord_scale.id, normalized_value: 0.0)
@@ -231,16 +229,14 @@ defmodule Lanttern.GradingTest do
     test "create_scale/1 with valid data creates a scale", %{scope: scope} do
       valid_attrs = %{
         name: "some name",
-        start: 120.5,
-        stop: 120.5,
+        max_score: 120.5,
         type: "numeric",
         breakpoints: [0.4, 0.8]
       }
 
       assert {:ok, %Scale{} = scale} = Grading.create_scale(scope, valid_attrs)
       assert scale.name == "some name"
-      assert scale.start == 120.5
-      assert scale.stop == 120.5
+      assert scale.max_score == 120.5
       assert scale.type == "numeric"
       assert scale.breakpoints == [0.4, 0.8]
     end
@@ -248,8 +244,6 @@ defmodule Lanttern.GradingTest do
     test "create_scale/1 orders and remove duplications of breakpoints", %{scope: scope} do
       valid_attrs = %{
         name: "some name",
-        start: nil,
-        stop: nil,
         type: "ordinal",
         breakpoints: [0.4, 0.8, 0.80, 0.6]
       }
@@ -264,7 +258,7 @@ defmodule Lanttern.GradingTest do
       assert {:error, %Ecto.Changeset{}} = Grading.create_scale(scope, @invalid_attrs)
     end
 
-    test "create_scale/1 of type numeric without start and stop returns error changeset",
+    test "create_scale/1 of type numeric without max_score returns error changeset",
          %{scope: scope} do
       assert {:error, %Ecto.Changeset{}} = Grading.create_scale(scope, @invalid_numeric_attrs)
     end
@@ -278,15 +272,13 @@ defmodule Lanttern.GradingTest do
 
       update_attrs = %{
         name: "some updated name",
-        start: 456.7,
-        stop: 456.7,
+        max_score: 456.7,
         type: "numeric"
       }
 
       assert {:ok, %Scale{} = scale} = Grading.update_scale(scope, scale, update_attrs)
       assert scale.name == "some updated name"
-      assert scale.start == 456.7
-      assert scale.stop == 456.7
+      assert scale.max_score == 456.7
       assert scale.type == "numeric"
     end
 
@@ -528,11 +520,11 @@ defmodule Lanttern.GradingTest do
     end
 
     test "convert_normalized_value_to_scale_value/1 returns the correct values for a numeric scale" do
-      scale = insert(:scale, type: "numeric", start: 5.0, stop: 10.0)
+      scale = insert(:scale, type: "numeric", max_score: 10.0)
 
-      assert Grading.convert_normalized_value_to_scale_value(0, scale) == 5.0
-      assert Grading.convert_normalized_value_to_scale_value(0.5, scale) == 7.5
-      assert Grading.convert_normalized_value_to_scale_value(0.789, scale) == 8.945
+      assert Grading.convert_normalized_value_to_scale_value(0, scale) == 0.0
+      assert Grading.convert_normalized_value_to_scale_value(0.5, scale) == 5.0
+      assert_in_delta Grading.convert_normalized_value_to_scale_value(0.789, scale), 7.89, 0.0001
       assert Grading.convert_normalized_value_to_scale_value(1, scale) == 10.0
     end
   end

--- a/test/lanttern/reporting_test.exs
+++ b/test/lanttern/reporting_test.exs
@@ -1075,7 +1075,7 @@ defmodule Lanttern.ReportingTest do
       student_report_card =
         student_report_card_fixture(%{report_card_id: report_card.id, student_id: student.id})
 
-      n_scale = insert(:scale, type: "numeric", start: 0, stop: 10)
+      n_scale = insert(:scale, type: "numeric", max_score: 10)
       o_scale = insert(:scale, type: "ordinal", breakpoints: [0.4, 0.8])
       ov_1 = insert(:ordinal_value, scale_id: o_scale.id)
       ov_2 = insert(:ordinal_value, scale_id: o_scale.id)
@@ -1218,7 +1218,7 @@ defmodule Lanttern.ReportingTest do
 
       student = SchoolsFixtures.student_fixture()
 
-      n_scale = insert(:scale, type: "numeric", start: 0, stop: 10)
+      n_scale = insert(:scale, type: "numeric", max_score: 10)
       o_scale = insert(:scale, type: "ordinal", breakpoints: [0.4, 0.8])
       ov_1 = insert(:ordinal_value, scale_id: o_scale.id)
       ov_2 = insert(:ordinal_value, scale_id: o_scale.id)
@@ -1344,7 +1344,7 @@ defmodule Lanttern.ReportingTest do
       # assessment points
 
       curriculum_item = insert(:curriculum_item)
-      scale = insert(:scale, type: "numeric", start: 0.0, stop: 100.0)
+      scale = insert(:scale, type: "numeric", max_score: 100.0)
 
       goal =
         AssessmentsFixtures.assessment_point_fixture(%{
@@ -1426,7 +1426,7 @@ defmodule Lanttern.ReportingTest do
 
       student = SchoolsFixtures.student_fixture()
 
-      n_scale = insert(:scale, type: "numeric", start: 0, stop: 10)
+      n_scale = insert(:scale, type: "numeric", max_score: 10)
       o_scale = insert(:scale, type: "ordinal", breakpoints: [0.4, 0.8])
       ov_1 = insert(:ordinal_value, scale_id: o_scale.id)
       ov_2 = insert(:ordinal_value, scale_id: o_scale.id)
@@ -1616,7 +1616,7 @@ defmodule Lanttern.ReportingTest do
 
       student = SchoolsFixtures.student_fixture()
 
-      n_scale = insert(:scale, type: "numeric", start: 0, stop: 10)
+      n_scale = insert(:scale, type: "numeric", max_score: 10)
       o_scale = insert(:scale, type: "ordinal", breakpoints: [0.4, 0.8])
       ov_1 = insert(:ordinal_value, scale_id: o_scale.id)
       ov_2 = insert(:ordinal_value, scale_id: o_scale.id)
@@ -1805,7 +1805,7 @@ defmodule Lanttern.ReportingTest do
 
       # assessments fixtures
 
-      scale = insert(:scale, type: "numeric", start: 0.0, stop: 100.0)
+      scale = insert(:scale, type: "numeric", max_score: 100.0)
 
       ap_1_1_1 =
         AssessmentsFixtures.assessment_point_fixture(%{

--- a/test/lanttern/rubrics_test.exs
+++ b/test/lanttern/rubrics_test.exs
@@ -1149,7 +1149,7 @@ defmodule Lanttern.RubricsTest do
     end
 
     test "create_rubric_descriptor/1 with valid data creates a rubric_descriptor" do
-      scale = insert(:scale, type: "numeric", start: 0.0, stop: 100.0)
+      scale = insert(:scale, type: "numeric", max_score: 100.0)
       rubric = rubric_fixture(%{scale_id: scale.id})
 
       valid_attrs = %{

--- a/test/lanttern/utils_test.exs
+++ b/test/lanttern/utils_test.exs
@@ -1,0 +1,21 @@
+defmodule Lanttern.UtilsTest do
+  use ExUnit.Case, async: true
+
+  alias Lanttern.Utils
+
+  describe "format_float/1" do
+    test "removes .0 suffix for whole numbers" do
+      assert Utils.format_float(10.0) == "10"
+      assert Utils.format_float(100.0) == "100"
+    end
+
+    test "returns zero without decimal suffix" do
+      assert Utils.format_float(0.0) == "0"
+    end
+
+    test "preserves meaningful decimal places" do
+      assert Utils.format_float(1.5) == "1.5"
+      assert Utils.format_float(1.25) == "1.25"
+    end
+  end
+end

--- a/test/support/factories/scale_factory.ex
+++ b/test/support/factories/scale_factory.ex
@@ -13,8 +13,7 @@ defmodule Lanttern.ScaleFactory do
         base = %Lanttern.Grading.Scale{
           name: "Scale",
           type: "numeric",
-          start: 0.0,
-          stop: 100.0,
+          max_score: 100.0,
           breakpoints: []
         }
 


### PR DESCRIPTION
### Summary

Simplifies numeric scale configuration by fixing the start value at 0, replacing the `start`/`stop` field pair with a single `max_score` field, and displaying scale config in assessment point cards.

### Related Issues

- Closes #535

### What This PR Does

- **Drops the `start` field from numeric scales** — scales now always start at 0; the `stop` field is renamed to `max_score` for clarity
- **Adds a `max_score` input to the grading scale form** — replaces the previous `Start` and `Stop` number inputs
- **Displays scale config in assessment point cards** — numeric scales show their max score; ordinal scales show their value range (first and last ordinal values) with a tooltip listing all values
- **Applies `format_float/1` consistently** — a new utility that strips trailing `.0` and zeros from float displays (e.g. `10.0` → `10`, `9.50` → `9.5`) across entry particles, composition overlays, reporting components, and scale cards
- **Fixes composition type change notification** — wraps the composition type select in a `<form>` and fires a `notify` event on change so parent components stay in sync
- **Updates score validation and normalization** — all numeric score validation, color interpolation, and normalized value calculations now hardcode `0` as the range start

### Impact and Scope

- **Database migration** — drops the `scale_start` column and renames `scale_stop` to `max_score` on the `scales` table; existing data must be migrated
- **Grading module** — `Scale` schema, changeset validation, and all normalization/conversion functions updated
- **Assessment entry validation** — `AssessmentPointEntry` now validates score between `0` and `max_score`
- **UI components** — `AssessmentsComponents`, `ReportingComponents`, `GradingScaleFormComponent`, `GradingScaleCardComponent`, `EntryParticleComponent`, `EntryDetailsOverlayComponent`, `RubricFormOverlayComponent`, and `AssessmentComponent` all updated

### Testing Considerations

- 1,646 tests pass with 0 failures
- Tests updated in `grading_test`, `assessments_test`, `reporting_test`, `rubrics_test`, `color_utils_test`, `utils_test`, and `scale_factory`

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>