### PR TITLE
feat(assessments): add is_hidden flag and audit logging for student access control

### DIFF
--- a/assets/js/entry-cell-hook.js
+++ b/assets/js/entry-cell-hook.js
@@ -280,6 +280,10 @@ const EntryCellHook = {
       this._inner.dispatchEvent(new Event("input", { bubbles: true }));
     }
     this._inner.focus();
+    if (prefill === null && this._inner.type === "text") {
+      const len = this._inner.value.length;
+      this._inner.setSelectionRange(len, len);
+    }
   },
 
   _clearAndEnterInput() {

--- a/lib/lanttern/assessments.ex
+++ b/lib/lanttern/assessments.ex
@@ -948,6 +948,7 @@ defmodule Lanttern.Assessments do
         join: cc in assoc(ci, :curriculum_component),
         left_join: sc in assoc(ap, :scale),
         where: ap.strand_id == ^strand_id,
+        where: ap.is_hidden != true,
         order_by: ap.position,
         preload: [
           curriculum_item: {ci, curriculum_component: cc},
@@ -978,6 +979,7 @@ defmodule Lanttern.Assessments do
         join: e in AssessmentPointEntry,
         on: e.assessment_point_id == ap.id and e.student_id == ^student_id,
         where: m.strand_id == ^strand_id,
+        where: ap.is_hidden != true,
         where: e.has_marking,
         order_by: [asc: m.position, asc: ap.position],
         select: {ap.curriculum_item_id, e}
@@ -1052,6 +1054,7 @@ defmodule Lanttern.Assessments do
       where: m.strand_id == ^strand_id,
       where: e.student_id == ^student.id,
       where: e.has_marking,
+      where: ap.is_hidden != true,
       order_by: [asc: m.position, asc: ap.position],
       select: %{ap | scale: sc, student_entry: %{e | ordinal_value: ov}}
     )

--- a/lib/lanttern/assessments.ex
+++ b/lib/lanttern/assessments.ex
@@ -948,7 +948,7 @@ defmodule Lanttern.Assessments do
         join: cc in assoc(ci, :curriculum_component),
         left_join: sc in assoc(ap, :scale),
         where: ap.strand_id == ^strand_id,
-        where: ap.is_hidden != true,
+        where: ap.is_hidden == false,
         order_by: ap.position,
         preload: [
           curriculum_item: {ci, curriculum_component: cc},
@@ -979,7 +979,7 @@ defmodule Lanttern.Assessments do
         join: e in AssessmentPointEntry,
         on: e.assessment_point_id == ap.id and e.student_id == ^student_id,
         where: m.strand_id == ^strand_id,
-        where: ap.is_hidden != true,
+        where: ap.is_hidden == false,
         where: e.has_marking,
         order_by: [asc: m.position, asc: ap.position],
         select: {ap.curriculum_item_id, e}
@@ -1054,7 +1054,7 @@ defmodule Lanttern.Assessments do
       where: m.strand_id == ^strand_id,
       where: e.student_id == ^student.id,
       where: e.has_marking,
-      where: ap.is_hidden != true,
+      where: ap.is_hidden == false,
       order_by: [asc: m.position, asc: ap.position],
       select: %{ap | scale: sc, student_entry: %{e | ordinal_value: ov}}
     )

--- a/lib/lanttern/assessments.ex
+++ b/lib/lanttern/assessments.ex
@@ -632,7 +632,7 @@ defmodule Lanttern.Assessments do
         join: ci in assoc(ap, :curriculum_item),
         join: cc in assoc(ci, :curriculum_component),
         join: sc in assoc(ap, :scale),
-        preload: [curriculum_item: {ci, curriculum_component: cc}, scale: sc]
+        preload: [curriculum_item: {ci, curriculum_component: cc}, scale: {sc, :ordinal_values}]
       )
       |> Repo.all()
 

--- a/lib/lanttern/assessments.ex
+++ b/lib/lanttern/assessments.ex
@@ -10,9 +10,11 @@ defmodule Lanttern.Assessments do
   alias Lanttern.Assessments.AssessmentPoint
   alias Lanttern.Assessments.AssessmentPointEntry
   alias Lanttern.Assessments.AssessmentPointEntryEvidence
+  alias Lanttern.Assessments.AssessmentPointLog
   alias Lanttern.AssessmentsLog
   alias Lanttern.Attachments
   alias Lanttern.Attachments.Attachment
+  alias Lanttern.AuditLog
   alias Lanttern.Identity.Scope
   alias Lanttern.Identity.User
   alias Lanttern.LearningContext.Moment
@@ -141,7 +143,7 @@ defmodule Lanttern.Assessments do
       {:error, %Ecto.Changeset{}}
 
   """
-  def create_assessment_point(attrs \\ %{}) do
+  def create_assessment_point(%Scope{} = scope, attrs \\ %{}) do
     attrs =
       AssessmentPoint
       |> filter_assessment_points_by_context(attrs)
@@ -150,6 +152,7 @@ defmodule Lanttern.Assessments do
     %AssessmentPoint{}
     |> AssessmentPoint.changeset(attrs)
     |> Repo.insert()
+    |> AuditLog.maybe_log(AssessmentPointLog, "CREATE", scope, [])
   end
 
   defp filter_assessment_points_by_context(queryable, %{moment_id: moment_id})
@@ -191,10 +194,15 @@ defmodule Lanttern.Assessments do
       {:error, %Ecto.Changeset{}}
 
   """
-  def update_assessment_point(%AssessmentPoint{} = assessment_point, attrs) do
+  def update_assessment_point(
+        %Scope{} = scope,
+        %AssessmentPoint{} = assessment_point,
+        attrs
+      ) do
     assessment_point
     |> AssessmentPoint.changeset(attrs)
     |> Repo.update()
+    |> AuditLog.maybe_log(AssessmentPointLog, "UPDATE", scope, [])
   end
 
   @doc """
@@ -209,10 +217,11 @@ defmodule Lanttern.Assessments do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_assessment_point(%AssessmentPoint{} = assessment_point) do
+  def delete_assessment_point(%Scope{} = scope, %AssessmentPoint{} = assessment_point) do
     assessment_point
     |> AssessmentPoint.delete_changeset()
     |> Repo.delete()
+    |> AuditLog.maybe_log(AssessmentPointLog, "DELETE", scope, [])
   end
 
   @doc """
@@ -227,17 +236,28 @@ defmodule Lanttern.Assessments do
       {:error, %Ecto.Changeset{}}
 
   """
-  def delete_assessment_point_and_entries(%AssessmentPoint{} = assessment_point) do
-    Ecto.Multi.new()
-    |> Ecto.Multi.delete_all(
-      :delete_entries,
-      from(
-        e in AssessmentPointEntry,
-        where: e.assessment_point_id == ^assessment_point.id
+  def delete_assessment_point_and_entries(%Scope{} = scope, %AssessmentPoint{} = assessment_point) do
+    result =
+      Ecto.Multi.new()
+      |> Ecto.Multi.delete_all(
+        :delete_entries,
+        from(
+          e in AssessmentPointEntry,
+          where: e.assessment_point_id == ^assessment_point.id
+        )
       )
-    )
-    |> Ecto.Multi.delete(:delete_assessment_point, assessment_point)
-    |> Repo.transaction()
+      |> Ecto.Multi.delete(:delete_assessment_point, assessment_point)
+      |> Repo.transaction()
+
+    case result do
+      {:ok, _} ->
+        AuditLog.maybe_log({:ok, assessment_point}, AssessmentPointLog, "DELETE", scope, [])
+
+      _ ->
+        :noop
+    end
+
+    result
   end
 
   @doc """
@@ -1202,7 +1222,7 @@ defmodule Lanttern.Assessments do
           assessment_point -> assessment_point
         end
 
-      case update_assessment_point(assessment_point, %{rubric_id: rubric.id}) do
+      case update_assessment_point(%Scope{}, assessment_point, %{rubric_id: rubric.id}) do
         {:ok, _assessment_point} ->
           :ok
 

--- a/lib/lanttern/assessments/assessment_point.ex
+++ b/lib/lanttern/assessments/assessment_point.ex
@@ -29,6 +29,7 @@ defmodule Lanttern.Assessments.AssessmentPoint do
           report_info: String.t(),
           position: non_neg_integer(),
           is_differentiation: boolean(),
+          is_hidden: boolean(),
           date: Date.t(),
           hour: non_neg_integer(),
           minute: non_neg_integer(),
@@ -65,6 +66,7 @@ defmodule Lanttern.Assessments.AssessmentPoint do
     field :report_info, :string
     field :position, :integer, default: 0
     field :is_differentiation, :boolean, default: false
+    field :is_hidden, :boolean, default: false
     field :composition_type, Ecto.Enum, values: [:sum, :avg]
 
     # create assessment point UI fields
@@ -110,6 +112,7 @@ defmodule Lanttern.Assessments.AssessmentPoint do
       :report_info,
       :position,
       :is_differentiation,
+      :is_hidden,
       :curriculum_item_id,
       :scale_id,
       :rubric_id,

--- a/lib/lanttern/assessments/assessment_point_log.ex
+++ b/lib/lanttern/assessments/assessment_point_log.ex
@@ -1,0 +1,82 @@
+defmodule Lanttern.Assessments.AssessmentPointLog do
+  @moduledoc """
+  The `AssessmentPointLog` schema.
+  """
+
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @behaviour Lanttern.AuditLog
+
+  @schema_prefix "log"
+  schema "assessment_points" do
+    field :assessment_point_id, :integer
+    field :profile_id, :integer
+    field :operation, :string
+    field :name, :string
+    field :datetime, :utc_datetime
+    field :description, :string
+    field :report_info, :string
+    field :position, :integer
+    field :is_differentiation, :boolean
+    field :is_hidden, :boolean
+    field :composition_type, :string
+    field :curriculum_item_id, :integer
+    field :scale_id, :integer
+    field :rubric_id, :integer
+    field :lesson_id, :integer
+    field :moment_id, :integer
+    field :strand_id, :integer
+
+    timestamps(updated_at: false)
+  end
+
+  @doc false
+  def changeset(assessment_point_log, attrs) do
+    assessment_point_log
+    |> cast(attrs, [
+      :assessment_point_id,
+      :profile_id,
+      :operation,
+      :name,
+      :datetime,
+      :description,
+      :report_info,
+      :position,
+      :is_differentiation,
+      :is_hidden,
+      :composition_type,
+      :curriculum_item_id,
+      :scale_id,
+      :rubric_id,
+      :lesson_id,
+      :moment_id,
+      :strand_id
+    ])
+    |> validate_required([:assessment_point_id, :profile_id, :operation])
+  end
+
+  @impl Lanttern.AuditLog
+  def build_log_attrs(%Lanttern.Assessments.AssessmentPoint{} = assessment_point) do
+    assessment_point = Lanttern.Repo.preload(assessment_point, [:classes])
+
+    %{
+      assessment_point_id: assessment_point.id,
+      name: assessment_point.name,
+      datetime: assessment_point.datetime,
+      description: assessment_point.description,
+      report_info: assessment_point.report_info,
+      position: assessment_point.position,
+      is_differentiation: assessment_point.is_differentiation,
+      is_hidden: assessment_point.is_hidden,
+      composition_type:
+        assessment_point.composition_type && to_string(assessment_point.composition_type),
+      curriculum_item_id: assessment_point.curriculum_item_id,
+      scale_id: assessment_point.scale_id,
+      rubric_id: assessment_point.rubric_id,
+      lesson_id: assessment_point.lesson_id,
+      moment_id: assessment_point.moment_id,
+      strand_id: assessment_point.strand_id
+    }
+  end
+end

--- a/lib/lanttern/learning_context.ex
+++ b/lib/lanttern/learning_context.ex
@@ -246,6 +246,7 @@ defmodule Lanttern.LearningContext do
         where: e.student_id == ^student_id,
         # exclude empty entries and entries where there are only student self-assessments
         where: e.has_marking,
+        where: ap.is_hidden != true,
         order_by: [asc: m.position, asc: ap.position],
         select: {e, m.strand_id}
       )

--- a/lib/lanttern/learning_context.ex
+++ b/lib/lanttern/learning_context.ex
@@ -246,7 +246,7 @@ defmodule Lanttern.LearningContext do
         where: e.student_id == ^student_id,
         # exclude empty entries and entries where there are only student self-assessments
         where: e.has_marking,
-        where: ap.is_hidden != true,
+        where: ap.is_hidden == false,
         order_by: [asc: m.position, asc: ap.position],
         select: {e, m.strand_id}
       )

--- a/lib/lanttern/reporting.ex
+++ b/lib/lanttern/reporting.ex
@@ -1029,6 +1029,7 @@ defmodule Lanttern.Reporting do
         join: sr in assoc(s, :strand_reports),
         where: sr.report_card_id == ^report_card_id and e.student_id == ^student_id,
         where: e.has_marking,
+        where: ap.is_hidden != true,
         order_by: ap.position,
         preload: [scale: sc, ordinal_value: ov],
         select: {sr.id, e}
@@ -1254,6 +1255,7 @@ defmodule Lanttern.Reporting do
         left_join: r in assoc(ap, :rubric),
         select: {m, %{ap | rubric: r}},
         where: m.strand_id == ^strand_id,
+        where: ap.is_hidden != true,
         order_by: [asc: m.position, asc: ap.position]
       )
       |> Repo.all()

--- a/lib/lanttern/reporting.ex
+++ b/lib/lanttern/reporting.ex
@@ -1029,7 +1029,7 @@ defmodule Lanttern.Reporting do
         join: sr in assoc(s, :strand_reports),
         where: sr.report_card_id == ^report_card_id and e.student_id == ^student_id,
         where: e.has_marking,
-        where: ap.is_hidden != true,
+        where: ap.is_hidden == false,
         order_by: ap.position,
         preload: [scale: sc, ordinal_value: ov],
         select: {sr.id, e}
@@ -1255,7 +1255,7 @@ defmodule Lanttern.Reporting do
         left_join: r in assoc(ap, :rubric),
         select: {m, %{ap | rubric: r}},
         where: m.strand_id == ^strand_id,
-        where: ap.is_hidden != true,
+        where: ap.is_hidden == false,
         order_by: [asc: m.position, asc: ap.position]
       )
       |> Repo.all()

--- a/lib/lanttern_web/components/core_components.ex
+++ b/lib/lanttern_web/components/core_components.ex
@@ -2402,6 +2402,8 @@ defmodule LantternWeb.CoreComponents do
       </div>
     </div>
     <script :type={Phoenix.LiveView.ColocatedHook} name=".Tooltip">
+      let _activeTooltip = null;
+
       export default {
         mounted() {
           this.parent = this.el.parentElement;
@@ -2414,10 +2416,15 @@ defmodule LantternWeb.CoreComponents do
           document.body.appendChild(this.el);
 
           this._show = () => {
+            if (_activeTooltip && _activeTooltip !== this) {
+              _activeTooltip._hide();
+            }
+            _activeTooltip = this;
             this.el.style.display = "block";
           };
 
           this._hide = () => {
+            if (_activeTooltip === this) _activeTooltip = null;
             this.el.style.display = "none";
           };
 
@@ -2444,15 +2451,11 @@ defmodule LantternWeb.CoreComponents do
           };
 
           this._onFocus = () => {
+            this._show();
             const parentRect = this.parent.getBoundingClientRect();
-            const rect = this.el.getBoundingClientRect();
+            const tooltipRect = this.el.getBoundingClientRect();
             const vw = window.innerWidth;
             const vh = window.innerHeight;
-
-            this.el.style.display = "block";
-
-            // Re-measure after display to get actual dimensions
-            const tooltipRect = this.el.getBoundingClientRect();
 
             let x = parentRect.left;
             let y = parentRect.bottom + this.offset.y;
@@ -2484,6 +2487,7 @@ defmodule LantternWeb.CoreComponents do
           this.parent.removeEventListener("focusin", this._onFocus);
           this.parent.removeEventListener("focusout", this._hide);
           this.parent.removeAttribute("aria-describedby");
+          if (_activeTooltip === this) _activeTooltip = null;
           // Clean up the element we moved to body
           if (this.el.parentElement === document.body) {
             document.body.removeChild(this.el);

--- a/lib/lanttern_web/components/grading_components.ex
+++ b/lib/lanttern_web/components/grading_components.ex
@@ -11,13 +11,12 @@ defmodule LantternWeb.GradingComponents do
   giving a quick visual sense of the scale range.
 
   Requires `ordinal_values` preloaded on `scale`.
-  When `id` is omitted, no tooltip is rendered.
+  Set `show_tooltip={true}` to render a tooltip with the full scale name and values.
+  When `show_tooltip` is true, `id` is required.
   """
   attr :scale, :any, required: true
-
-  attr :id, :string,
-    default: nil,
-    doc: "When set, renders a tooltip with the full scale name and values"
+  attr :id, :string, default: nil, doc: "Required when `show_tooltip` is true"
+  attr :show_tooltip, :boolean, default: false
 
   def ordinal_scale_range(%{scale: %{ordinal_values: []}} = assigns) do
     ~H"—"
@@ -29,7 +28,7 @@ defmodule LantternWeb.GradingComponents do
       <.badge class="shrink-0" color_map={hd(@scale.ordinal_values)}>
         {ov_short(hd(@scale.ordinal_values))}
       </.badge>
-      <.tooltip :if={@id} id={"#{@id}-scale-tooltip"}>
+      <.tooltip :if={@show_tooltip} id={"#{@id}-scale-tooltip"}>
         {@scale.name}: {ov_list_label(@scale.ordinal_values)}
       </.tooltip>
     </div>
@@ -46,7 +45,7 @@ defmodule LantternWeb.GradingComponents do
       <.badge class="shrink-0" color_map={List.last(@scale.ordinal_values)}>
         {ov_short(List.last(@scale.ordinal_values))}
       </.badge>
-      <.tooltip :if={@id} id={"#{@id}-scale-tooltip"}>
+      <.tooltip :if={@show_tooltip} id={"#{@id}-scale-tooltip"}>
         {@scale.name}: {ov_list_label(@scale.ordinal_values)}
       </.tooltip>
     </div>

--- a/lib/lanttern_web/components/grading_components.ex
+++ b/lib/lanttern_web/components/grading_components.ex
@@ -1,0 +1,61 @@
+defmodule LantternWeb.GradingComponents do
+  @moduledoc """
+  Shared function components related to `Grading` context
+  """
+
+  use Phoenix.Component
+  import LantternWeb.CoreComponents
+
+  @doc """
+  Renders the first and last ordinal values of a scale as badges,
+  giving a quick visual sense of the scale range.
+
+  Requires `ordinal_values` preloaded on `scale`.
+  When `id` is omitted, no tooltip is rendered.
+  """
+  attr :scale, :any, required: true
+
+  attr :id, :string,
+    default: nil,
+    doc: "When set, renders a tooltip with the full scale name and values"
+
+  def ordinal_scale_range(%{scale: %{ordinal_values: []}} = assigns) do
+    ~H"—"
+  end
+
+  def ordinal_scale_range(%{scale: %{ordinal_values: [_only]}} = assigns) do
+    ~H"""
+    <div class="flex items-center gap-1">
+      <.badge class="shrink-0" color_map={hd(@scale.ordinal_values)}>
+        {ov_short(hd(@scale.ordinal_values))}
+      </.badge>
+      <.tooltip :if={@id} id={"#{@id}-scale-tooltip"}>
+        {@scale.name}: {ov_list_label(@scale.ordinal_values)}
+      </.tooltip>
+    </div>
+    """
+  end
+
+  def ordinal_scale_range(assigns) do
+    ~H"""
+    <div class="flex items-center gap-1">
+      <.badge class="shrink-0" color_map={hd(@scale.ordinal_values)}>
+        {ov_short(hd(@scale.ordinal_values))}
+      </.badge>
+      —
+      <.badge class="shrink-0" color_map={List.last(@scale.ordinal_values)}>
+        {ov_short(List.last(@scale.ordinal_values))}
+      </.badge>
+      <.tooltip :if={@id} id={"#{@id}-scale-tooltip"}>
+        {@scale.name}: {ov_list_label(@scale.ordinal_values)}
+      </.tooltip>
+    </div>
+    """
+  end
+
+  defp ov_short(%{short_name: short_name, name: name}),
+    do: short_name || String.slice(name, 0..2)
+
+  defp ov_list_label(ordinal_values),
+    do: Enum.map_join(ordinal_values, ", ", & &1.name)
+end

--- a/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
@@ -666,7 +666,12 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
 
   def handle_event("add_composition", %{"assessment_point_id" => ap_id, "type" => type}, socket) do
     ap = Assessments.get_assessment_point!(ap_id)
-    {:ok, updated_ap} = Assessments.update_assessment_point(ap, %{composition_type: type})
+
+    {:ok, updated_ap} =
+      Assessments.update_assessment_point(socket.assigns.current_scope, ap, %{
+        composition_type: type
+      })
+
     ap = Assessments.get_assessment_point!(updated_ap.id, preloads: @ap_preloads)
 
     socket =
@@ -694,7 +699,12 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
 
   def handle_event("toggle_hidden", %{"id" => ap_id, "hidden" => is_hidden}, socket) do
     ap = Assessments.get_assessment_point!(ap_id, preloads: @ap_preloads)
-    {:ok, _} = Assessments.update_assessment_point(ap, %{is_hidden: is_hidden})
+
+    {:ok, _} =
+      Assessments.update_assessment_point(socket.assigns.current_scope, ap, %{
+        is_hidden: is_hidden
+      })
+
     {:noreply, stream_insert(socket, ap_stream_key(ap.moment_id), %{ap | is_hidden: is_hidden})}
   end
 
@@ -729,7 +739,7 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
     Assessments.update_assessment_points_positions(to_ids)
 
     ap = Assessments.get_assessment_point!(ap_id)
-    Assessments.update_assessment_point(ap, %{moment_id: to_key})
+    Assessments.update_assessment_point(socket.assigns.current_scope, ap, %{moment_id: to_key})
 
     moments_map =
       socket.assigns.moments_assessment_points_ids_map

--- a/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
@@ -309,7 +309,7 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
                   icon_name="hero-eye-slash-micro"
                   phx-click={
                     JS.push("toggle_hidden",
-                      value: %{id: @assessment_point.id},
+                      value: %{id: @assessment_point.id, hidden: false},
                       target: @myself
                     )
                   }
@@ -325,7 +325,7 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
                   size="xs"
                   phx-click={
                     JS.push("toggle_hidden",
-                      value: %{id: @assessment_point.id},
+                      value: %{id: @assessment_point.id, hidden: true},
                       target: @myself
                     )
                   }
@@ -373,7 +373,11 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
             {format_float(@assessment_point.scale.max_score)}
           </div>
         <% else %>
-          <.ordinal_scale_range scale={@assessment_point.scale} id={"ap-#{@assessment_point.id}"} />
+          <.ordinal_scale_range
+            scale={@assessment_point.scale}
+            id={"ap-#{@assessment_point.id}"}
+            show_tooltip={true}
+          />
         <% end %>
       </div>
     </.draggable_card>
@@ -688,12 +692,10 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
   def handle_event("close_composition_overlay", _params, socket),
     do: {:noreply, assign(socket, :composition_overlay_ap, nil)}
 
-  def handle_event("toggle_hidden", %{"id" => ap_id}, socket) do
-    ap = Assessments.get_assessment_point!(ap_id)
-    {:ok, updated_ap} = Assessments.update_assessment_point(ap, %{is_hidden: !ap.is_hidden})
-    ap = Assessments.get_assessment_point!(updated_ap.id, preloads: @ap_preloads)
-
-    {:noreply, stream_insert(socket, ap_stream_key(ap.moment_id), ap)}
+  def handle_event("toggle_hidden", %{"id" => ap_id, "hidden" => is_hidden}, socket) do
+    ap = Assessments.get_assessment_point!(ap_id, preloads: @ap_preloads)
+    {:ok, _} = Assessments.update_assessment_point(ap, %{is_hidden: is_hidden})
+    {:noreply, stream_insert(socket, ap_stream_key(ap.moment_id), %{ap | is_hidden: is_hidden})}
   end
 
   def handle_event("close_assessment_point_form", _params, socket),

--- a/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
@@ -207,6 +207,7 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
         ap={@composition_overlay_ap}
         strand_id={@strand.id}
         notify_component={@myself}
+        initial_view={@composition_overlay_initial_view}
         on_cancel={JS.push("close_composition_overlay", target: @myself)}
       />
     </div>
@@ -388,6 +389,7 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
       |> assign(:strand_form, nil)
       |> assign(:assessment_point, nil)
       |> assign(:composition_overlay_ap, nil)
+      |> assign(:composition_overlay_initial_view, :overview)
       |> assign(:initialized, false)
 
     {:ok, socket}
@@ -667,13 +669,20 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
       socket
       |> stream_insert(ap_stream_key(ap.moment_id), ap)
       |> assign(:composition_overlay_ap, ap)
+      |> assign(:composition_overlay_initial_view, :setup)
 
     {:noreply, socket}
   end
 
   def handle_event("open_composition", %{"id" => ap_id}, socket) do
     ap = Assessments.get_assessment_point!(ap_id, preloads: @ap_preloads)
-    {:noreply, assign(socket, :composition_overlay_ap, ap)}
+
+    socket =
+      socket
+      |> assign(:composition_overlay_ap, ap)
+      |> assign(:composition_overlay_initial_view, :overview)
+
+    {:noreply, socket}
   end
 
   def handle_event("close_composition_overlay", _params, socket),

--- a/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
@@ -227,7 +227,10 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
           <button
             type="button"
             phx-click={@on_edit}
-            class="flex-1 font-bold text-left text-ltrn-darkest hover:text-ltrn-subtle"
+            class={[
+              "flex-1 font-bold text-left hover:text-ltrn-subtle",
+              if(@assessment_point.is_hidden, do: "text-ltrn-subtle", else: "text-ltrn-darkest")
+            ]}
           >
             {if @assessment_point.moment_id,
               do: @assessment_point.name,
@@ -295,6 +298,45 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
                   do: gettext("Sum-based"),
                   else: gettext("Average-based")}
               </.tooltip>
+            </div>
+            <div class="relative">
+              <%= if @assessment_point.is_hidden do %>
+                <.button
+                  type="button"
+                  size="xs"
+                  theme="primary"
+                  icon_name="hero-eye-slash-micro"
+                  phx-click={
+                    JS.push("toggle_hidden",
+                      value: %{id: @assessment_point.id},
+                      target: @myself
+                    )
+                  }
+                >
+                  {gettext("Hidden")}
+                </.button>
+                <.tooltip id={"ap-#{@assessment_point.id}-hide-flag-tooltip"}>
+                  {gettext("Students won't see marking results for this assessment point.")}
+                </.tooltip>
+              <% else %>
+                <.button
+                  type="button"
+                  size="xs"
+                  phx-click={
+                    JS.push("toggle_hidden",
+                      value: %{id: @assessment_point.id},
+                      target: @myself
+                    )
+                  }
+                >
+                  {gettext("Hide")}
+                </.button>
+                <.tooltip id={"ap-#{@assessment_point.id}-hide-flag-tooltip"}>
+                  {gettext(
+                    "When hidden, students won't see marking results for this assessment point. Use this while marking is in progress."
+                  )}
+                </.tooltip>
+              <% end %>
             </div>
             <div :if={@assessment_point.rubric_id}>
               <.icon name="hero-view-columns" />
@@ -636,6 +678,14 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
 
   def handle_event("close_composition_overlay", _params, socket),
     do: {:noreply, assign(socket, :composition_overlay_ap, nil)}
+
+  def handle_event("toggle_hidden", %{"id" => ap_id}, socket) do
+    ap = Assessments.get_assessment_point!(ap_id)
+    {:ok, updated_ap} = Assessments.update_assessment_point(ap, %{is_hidden: !ap.is_hidden})
+    ap = Assessments.get_assessment_point!(updated_ap.id, preloads: @ap_preloads)
+
+    {:noreply, stream_insert(socket, ap_stream_key(ap.moment_id), ap)}
+  end
 
   def handle_event("close_assessment_point_form", _params, socket),
     do: {:noreply, assign(socket, :assessment_point, nil)}

--- a/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
+++ b/lib/lanttern_web/live/pages/strands/id/assessment_component.ex
@@ -7,6 +7,7 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
   alias Lanttern.LearningContext
 
   import Lanttern.Utils, only: [format_float: 1, reorder: 3]
+  import LantternWeb.GradingComponents
 
   # shared components
   alias LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayComponent
@@ -335,48 +336,6 @@ defmodule LantternWeb.StrandLive.AssessmentComponent do
     </.draggable_card>
     """
   end
-
-  defp ordinal_scale_range(%{scale: %{ordinal_values: []}} = assigns) do
-    ~H"""
-    —
-    """
-  end
-
-  defp ordinal_scale_range(%{scale: %{ordinal_values: [_only]}} = assigns) do
-    ~H"""
-    <div class="flex items-center gap-1">
-      <.badge class="shrink-0" color_map={hd(@scale.ordinal_values)}>
-        {ov_short(hd(@scale.ordinal_values))}
-      </.badge>
-      <.tooltip id={"#{@id}-scale-tooltip"}>
-        {@scale.name}: {ov_list_label(@scale.ordinal_values)}
-      </.tooltip>
-    </div>
-    """
-  end
-
-  defp ordinal_scale_range(assigns) do
-    ~H"""
-    <div class="flex items-center gap-1">
-      <.badge class="shrink-0" color_map={hd(@scale.ordinal_values)}>
-        {ov_short(hd(@scale.ordinal_values))}
-      </.badge>
-      —
-      <.badge class="shrink-0" color_map={List.last(@scale.ordinal_values)}>
-        {ov_short(List.last(@scale.ordinal_values))}
-      </.badge>
-      <.tooltip id={"#{@id}-scale-tooltip"}>
-        {@scale.name}: {ov_list_label(@scale.ordinal_values)}
-      </.tooltip>
-    </div>
-    """
-  end
-
-  defp ov_short(%{short_name: short_name, name: name}),
-    do: short_name || String.slice(name, 0..2)
-
-  defp ov_list_label(ordinal_values),
-    do: Enum.map_join(ordinal_values, ", ", & &1.name)
 
   # lifecycle
 

--- a/lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex
+++ b/lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex
@@ -494,7 +494,9 @@ defmodule LantternWeb.LessonLive do
   # handle_event helpers
 
   defp update_assessment_point_lesson_link(socket, ap, lesson_id) do
-    case Assessments.update_assessment_point(ap, %{lesson_id: lesson_id}) do
+    case Assessments.update_assessment_point(socket.assigns.current_scope, ap, %{
+           lesson_id: lesson_id
+         }) do
       {:ok, _} ->
         socket
         |> stream_lesson_assessment_points()

--- a/lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex
@@ -302,7 +302,12 @@ defmodule LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayCom
   @impl true
   def handle_event("update_type", %{"composition_type" => type}, socket) do
     ap = socket.assigns.ap
-    {:ok, updated_ap} = Assessments.update_assessment_point(ap, %{composition_type: type})
+
+    {:ok, updated_ap} =
+      Assessments.update_assessment_point(socket.assigns.current_scope, ap, %{
+        composition_type: type
+      })
+
     notify(__MODULE__, {:composition_updated, ap.id}, socket.assigns)
     {:noreply, assign(socket, :ap, %{ap | composition_type: updated_ap.composition_type})}
   end
@@ -376,7 +381,8 @@ defmodule LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayCom
       ap.id
     )
 
-    Assessments.update_assessment_point(ap, %{composition_type: nil})
+    Assessments.update_assessment_point(socket.assigns.current_scope, ap, %{composition_type: nil})
+
     notify(__MODULE__, {:deleted, ap.id}, socket.assigns)
     {:noreply, socket}
   end

--- a/lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex
@@ -234,12 +234,20 @@ defmodule LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayCom
     composition_components =
       AssessmentComposition.list_assessment_point_components(assigns.current_scope, assigns.ap.id)
 
-    {:ok,
-     socket
-     |> assign(assigns)
-     |> assign(:view, :overview)
-     |> assign(:composition_components, composition_components)}
+    initial_view = Map.get(assigns, :initial_view, :overview)
+
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(:view, initial_view)
+      |> assign(:composition_components, composition_components)
+      |> maybe_load_all_aps()
+
+    {:ok, socket}
   end
+
+  defp maybe_load_all_aps(%{assigns: %{view: :setup}} = socket), do: load_all_aps(socket)
+  defp maybe_load_all_aps(socket), do: socket
 
   defp load_all_aps(socket) do
     strand_id = socket.assigns.strand_id

--- a/lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex
@@ -1,0 +1,123 @@
+defmodule LantternWeb.Assessments.AssessmentPointCommandPaletteComponent do
+  @moduledoc """
+  Command palette modal for assessment point management.
+
+  Shows 3 sections: edit, grade composition, and student visibility.
+  Notifies the parent component on all actions.
+
+  ### Required attrs
+
+  - `:ap` - `AssessmentPoint` (needs `composition_type` and `is_hidden`)
+  - `:on_cancel` - JS action to close the palette
+  - `:notify_component` - parent LiveComponent CID (`@myself`)
+  """
+  use LantternWeb, :live_component
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div>
+      <.modal id={@id} show on_cancel={@on_cancel}>
+        <:title>{@ap.name || @ap.curriculum_item.name}</:title>
+        <div class="-mx-10">
+          <div class="px-10 pb-10">
+            <.button type="button" phx-click="edit" phx-target={@myself}>
+              {gettext("Edit assessment point")}
+            </.button>
+          </div>
+          <div class="border-t border-ltrn-light p-10">
+            <%= if is_nil(@ap.composition_type) do %>
+              <div class="flex flex-wrap gap-2">
+                <.button
+                  type="button"
+                  phx-click="add_composition"
+                  phx-value-type="sum"
+                  phx-target={@myself}
+                >
+                  {gettext("Add sum-based composition")}
+                </.button>
+                <.button
+                  type="button"
+                  phx-click="add_composition"
+                  phx-value-type="avg"
+                  phx-target={@myself}
+                >
+                  {gettext("Add average-based composition")}
+                </.button>
+              </div>
+              <p class="mt-4">
+                {gettext(
+                  "Use grade composition to calculate entries based on sum or average of other assessment points."
+                )}
+              </p>
+            <% else %>
+              <.button
+                type="button"
+                theme="primary"
+                icon_name="hero-calculator-micro"
+                phx-click="manage_composition"
+                phx-target={@myself}
+              >
+                {gettext("Manage grade composition")}
+              </.button>
+              <p class="mt-4">
+                <%= if @ap.composition_type == :sum do %>
+                  {gettext("This assessment point uses a sum-based grade composition.")}
+                <% else %>
+                  {gettext("This assessment point uses an average-based grade composition.")}
+                <% end %>
+              </p>
+            <% end %>
+          </div>
+          <div class="border-t border-ltrn-light px-10 pt-10">
+            <%= if @ap.is_hidden do %>
+              <.button
+                type="button"
+                theme="primary"
+                icon_name="hero-eye-slash-micro"
+                phx-click="toggle_hidden"
+                phx-target={@myself}
+              >
+                {gettext("Hidden from students")}
+              </.button>
+              <p class="mt-4">
+                {gettext("Students won't see marking results for this assessment point.")}
+              </p>
+            <% else %>
+              <.button type="button" phx-click="toggle_hidden" phx-target={@myself}>
+                {gettext("Hide from students")}
+              </.button>
+              <p class="mt-4">
+                {gettext(
+                  "When hidden, students won't see marking results for this assessment point. Use this while marking is in progress."
+                )}
+              </p>
+            <% end %>
+          </div>
+        </div>
+      </.modal>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("edit", _, socket) do
+    notify(__MODULE__, {:edit}, socket.assigns)
+    {:noreply, socket}
+  end
+
+  def handle_event("add_composition", %{"type" => type}, socket) do
+    notify(__MODULE__, {:add_composition, type}, socket.assigns)
+    {:noreply, socket}
+  end
+
+  def handle_event("manage_composition", _, socket) do
+    notify(__MODULE__, {:manage_composition}, socket.assigns)
+    {:noreply, socket}
+  end
+
+  def handle_event("toggle_hidden", _, socket) do
+    notify(__MODULE__, {:toggle_hidden}, socket.assigns)
+    {:noreply, socket}
+  end
+end

--- a/lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex
@@ -13,6 +13,12 @@ defmodule LantternWeb.Assessments.AssessmentPointCommandPaletteComponent do
   """
   use LantternWeb, :live_component
 
+  alias Lanttern.Assessments.AssessmentPoint
+
+  attr :ap, AssessmentPoint, required: true
+  attr :on_cancel, :any, required: true, doc: "JS action to close the palette"
+  attr :notify_component, :any, required: true, doc: "parent LiveComponent CID (`@myself`)"
+
   @impl true
   def render(assigns) do
     ~H"""

--- a/lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex
@@ -56,35 +56,6 @@ defmodule LantternWeb.Assessments.AssessmentPointFormOverlayComponent do
             phx-debounce="1500"
             class="mb-6"
           />
-          <.live_component
-            module={CurriculumItemSearchComponent}
-            id="curriculum-item-search"
-            current_scope={@current_scope}
-            notify_component={@myself}
-            label={gettext("Curriculum")}
-            initial_results={@initial_curriculum_results}
-          />
-          <div class="mt-2 mb-6">
-            <div
-              :if={@selected_curriculum_item}
-              class="flex items-center gap-4 p-4 rounded-sm bg-ltrn-lightest"
-            >
-              <div class="flex-1">
-                <.badge theme="dark">
-                  {@selected_curriculum_item.curriculum_component.name}
-                </.badge>
-                <p class="mt-2">{@selected_curriculum_item.name}</p>
-              </div>
-              <button
-                type="button"
-                phx-click={JS.push("remove_curriculum_item", target: @myself)}
-                class="shrink-0 text-ltrn-subtle hover:text-ltrn-dark"
-              >
-                <.icon name="hero-x-mark" class="w-6 h-6" />
-              </button>
-            </div>
-          </div>
-          <.input field={@form[:curriculum_item_id]} type="hidden" class="mb-6" />
           <.input
             field={@form[:scale_id]}
             type="select"
@@ -114,6 +85,35 @@ defmodule LantternWeb.Assessments.AssessmentPointFormOverlayComponent do
             </p>
           </div>
           <.rubric_area id={@id} field={@form[:rubric_id]} rubric={@rubric} options={@rubric_options} />
+          <.live_component
+            module={CurriculumItemSearchComponent}
+            id="curriculum-item-search"
+            current_scope={@current_scope}
+            notify_component={@myself}
+            label={gettext("Curriculum")}
+            initial_results={@initial_curriculum_results}
+          />
+          <div class="mt-2 mb-6">
+            <div
+              :if={@selected_curriculum_item}
+              class="flex items-center gap-4 p-4 rounded-sm bg-ltrn-lightest"
+            >
+              <div class="flex-1">
+                <.badge theme="dark">
+                  {@selected_curriculum_item.curriculum_component.name}
+                </.badge>
+                <p class="mt-2">{@selected_curriculum_item.name}</p>
+              </div>
+              <button
+                type="button"
+                phx-click={JS.push("remove_curriculum_item", target: @myself)}
+                class="shrink-0 text-ltrn-subtle hover:text-ltrn-dark"
+              >
+                <.icon name="hero-x-mark" class="w-6 h-6" />
+              </button>
+            </div>
+          </div>
+          <.input field={@form[:curriculum_item_id]} type="hidden" class="mb-6" />
         </.form>
         <.delete_error
           error_message={@delete_error}

--- a/lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex
@@ -401,7 +401,10 @@ defmodule LantternWeb.Assessments.AssessmentPointFormOverlayComponent do
   end
 
   def handle_event("delete", _params, socket) do
-    case Assessments.delete_assessment_point(socket.assigns.assessment_point) do
+    case Assessments.delete_assessment_point(
+           socket.assigns.current_scope,
+           socket.assigns.assessment_point
+         ) do
       {:ok, assessment_point} ->
         notify(__MODULE__, {:deleted, assessment_point}, socket.assigns)
         {:noreply, socket}
@@ -418,7 +421,10 @@ defmodule LantternWeb.Assessments.AssessmentPointFormOverlayComponent do
   end
 
   def handle_event("delete_assessment_point_and_entries", _, socket) do
-    case Assessments.delete_assessment_point_and_entries(socket.assigns.assessment_point) do
+    case Assessments.delete_assessment_point_and_entries(
+           socket.assigns.current_scope,
+           socket.assigns.assessment_point
+         ) do
       {:ok, assessment_point} ->
         notify(__MODULE__, {:deleted_with_entries, assessment_point}, socket.assigns)
         {:noreply, socket}
@@ -453,7 +459,7 @@ defmodule LantternWeb.Assessments.AssessmentPointFormOverlayComponent do
   end
 
   defp save(socket, nil, params) do
-    case Assessments.create_assessment_point(params) do
+    case Assessments.create_assessment_point(socket.assigns.current_scope, params) do
       {:ok, assessment_point} ->
         notify(__MODULE__, {:created, assessment_point}, socket.assigns)
         {:noreply, socket}
@@ -464,7 +470,11 @@ defmodule LantternWeb.Assessments.AssessmentPointFormOverlayComponent do
   end
 
   defp save(socket, _assessment_point_id, params) do
-    case Assessments.update_assessment_point(socket.assigns.assessment_point, params) do
+    case Assessments.update_assessment_point(
+           socket.assigns.current_scope,
+           socket.assigns.assessment_point,
+           params
+         ) do
       {:ok, assessment_point} ->
         notify(__MODULE__, {:updated, assessment_point}, socket.assigns)
         {:noreply, socket}

--- a/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
@@ -100,6 +100,7 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
                   assessment_point={assessment_point}
                   assessment_view={@current_assessment_view}
                   url_params={@url_params}
+                  myself={@myself}
                 />
               </div>
             </div>
@@ -213,6 +214,7 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
   attr :assessment_view, :string, required: true
   attr :url_params, :map, required: true
   attr :id, :string, required: true
+  attr :myself, :any, required: true
 
   def assessment_point(assigns) do
     display_name =
@@ -239,16 +241,18 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
           class="flex flex-1 gap-2 p-1 rounded-sm hover:bg-ltrn-lightest"
         >
           <div class="flex flex-col flex-1">
-            <div class="self-start mb-1">
-              <%= if @assessment_point.scale.type == "numeric" do %>
-                <.badge>{@assessment_point.scale.max_score}</.badge>
-              <% else %>
-                <.ordinal_scale_range scale={@assessment_point.scale} />
-              <% end %>
+            <div class={if(@assessment_point.is_hidden, do: "opacity-50")}>
+              <div class="flex items-center gap-2 mb-1">
+                <%= if @assessment_point.scale.type == "numeric" do %>
+                  <.badge>{@assessment_point.scale.max_score}</.badge>
+                <% else %>
+                  <.ordinal_scale_range scale={@assessment_point.scale} />
+                <% end %>
+              </div>
+              <p class="flex-1 font-sans text-sm line-clamp-2">
+                {@display_name}
+              </p>
             </div>
-            <p class="flex-1 font-sans text-sm line-clamp-2">
-              {@display_name}
-            </p>
           </div>
           <div class="shrink-0 flex flex-col gap-1 text-ltrn-light">
             <.icon
@@ -293,6 +297,43 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
             class="mt-2"
           />
         </.tooltip>
+      </div>
+      <div class="relative mt-2">
+        <%= if @assessment_point.is_hidden do %>
+          <.button
+            type="button"
+            size="xs"
+            theme="primary"
+            icon_name="hero-eye-slash-micro"
+            class="w-full"
+            phx-click="toggle_hidden"
+            phx-value-id={@assessment_point.id}
+            phx-target={@myself}
+          >
+            {gettext("Hidden")}
+          </.button>
+          <.tooltip id={"assessment-point-#{@assessment_point.id}-hide-flag-tooltip"}>
+            {gettext("Students won't see marking results for this assessment point.")}
+          </.tooltip>
+        <% else %>
+          <.button
+            type="button"
+            size="xs"
+            theme="ghost"
+            icon_name="hero-eye-micro"
+            class="w-full"
+            phx-click="toggle_hidden"
+            phx-value-id={@assessment_point.id}
+            phx-target={@myself}
+          >
+            {gettext("Hide")}
+          </.button>
+          <.tooltip id={"assessment-point-#{@assessment_point.id}-hide-flag-tooltip"}>
+            {gettext(
+              "When hidden, students won't see marking results for this assessment point. Use this while marking is in progress."
+            )}
+          </.tooltip>
+        <% end %>
       </div>
       <.compare_header :if={@assessment_view == "compare"} />
     </div>
@@ -582,6 +623,25 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
 
       {:noreply, socket}
     end
+  end
+
+  def handle_event("toggle_hidden", %{"id" => id}, socket) do
+    ap =
+      Assessments.get_assessment_point!(
+        String.to_integer(id),
+        preloads: [curriculum_item: :curriculum_component, scale: :ordinal_values]
+      )
+
+    socket =
+      case Assessments.update_assessment_point(ap, %{is_hidden: !ap.is_hidden}) do
+        {:ok, updated_ap} ->
+          stream_insert(socket, :assessment_points, updated_ap)
+
+        {:error, _changeset} ->
+          put_flash(socket, :error, gettext("Error updating assessment point"))
+      end
+
+    {:noreply, socket}
   end
 
   def handle_event("close_entry_details_overlay", _, socket) do

--- a/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
@@ -744,7 +744,7 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
   def handle_event("open_command_palette", %{"id" => id}, socket) do
     ap =
       Assessments.get_assessment_point!(
-        String.to_integer(id),
+        id,
         preloads: [curriculum_item: :curriculum_component, scale: :ordinal_values]
       )
 

--- a/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
@@ -204,6 +204,7 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
         ap={@composition_overlay_ap}
         strand_id={@strand_id}
         notify_component={@myself}
+        initial_view={@composition_overlay_initial_view}
         on_cancel={JS.push("close_composition_overlay", target: @myself)}
       />
     </div>
@@ -414,6 +415,7 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
       |> assign(:command_palette_ap, nil)
       |> assign(:assessment_point_overlay, nil)
       |> assign(:composition_overlay_ap, nil)
+      |> assign(:composition_overlay_initial_view, :overview)
       |> assign(:has_entry_details_change, false)
       |> assign(:has_assessment_points, false)
       |> assign(:assessment_points_count, 0)
@@ -531,6 +533,7 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
       |> stream_insert(:assessment_points, ap)
       |> assign(:command_palette_ap, nil)
       |> assign(:composition_overlay_ap, ap)
+      |> assign(:composition_overlay_initial_view, :setup)
 
     {:ok, socket}
   end
@@ -542,6 +545,7 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
       socket
       |> assign(:command_palette_ap, nil)
       |> assign(:composition_overlay_ap, ap)
+      |> assign(:composition_overlay_initial_view, :overview)
 
     {:ok, socket}
   end

--- a/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
@@ -33,6 +33,9 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
   import LantternWeb.GradingComponents
 
   # shared components
+  alias LantternWeb.AssessmentComposition.AssessmentPointCompositionOverlayComponent
+  alias LantternWeb.Assessments.AssessmentPointCommandPaletteComponent
+  alias LantternWeb.Assessments.AssessmentPointFormOverlayComponent
   alias LantternWeb.Assessments.EntryCellComponent
   alias LantternWeb.Assessments.EntryDetailsOverlayComponent
 
@@ -174,6 +177,35 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
         on_cancel={JS.push("close_entry_details_overlay", target: @myself)}
         notify_component={@myself}
       />
+      <.live_component
+        :if={@command_palette_ap}
+        module={AssessmentPointCommandPaletteComponent}
+        id={"#{@id}-ap-command-palette"}
+        ap={@command_palette_ap}
+        notify_component={@myself}
+        on_cancel={JS.push("close_command_palette", target: @myself)}
+      />
+      <.live_component
+        :if={@assessment_point_overlay}
+        module={AssessmentPointFormOverlayComponent}
+        id={"#{@id}-assessment-point-form-overlay"}
+        current_scope={@current_scope}
+        assessment_point={@assessment_point_overlay}
+        notify_component={@myself}
+        title={gettext("Edit assessment point")}
+        on_cancel={JS.push("close_assessment_point_form", target: @myself)}
+        initial_curriculum_results={[]}
+      />
+      <.live_component
+        :if={@composition_overlay_ap}
+        module={AssessmentPointCompositionOverlayComponent}
+        id={"#{@id}-ap-composition-overlay"}
+        current_scope={@current_scope}
+        ap={@composition_overlay_ap}
+        strand_id={@strand_id}
+        notify_component={@myself}
+        on_cancel={JS.push("close_composition_overlay", target: @myself)}
+      />
     </div>
     """
   end
@@ -236,9 +268,12 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
     ~H"""
     <div id={@id} class="flex flex-col p-1">
       <div class="flex flex-1 gap-1">
-        <.link
-          patch={"?#{URI.encode_query(Map.put(@url_params, "edit_assessment_point", @assessment_point.id))}"}
-          class="flex flex-1 gap-2 p-1 rounded-sm hover:bg-ltrn-lightest"
+        <button
+          type="button"
+          phx-click="open_command_palette"
+          phx-value-id={@assessment_point.id}
+          phx-target={@myself}
+          class="flex flex-1 gap-2 p-1 rounded-sm text-left hover:bg-ltrn-lightest"
         >
           <div class="flex flex-col flex-1">
             <div class={if(@assessment_point.is_hidden, do: "opacity-50")}>
@@ -268,7 +303,7 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
               class={["size-3", if(@assessment_point.composition_type, do: "text-ltrn-primary")]}
             />
           </div>
-        </.link>
+        </button>
         <.tooltip id={"assessment-point-#{@assessment_point.id}-tooltip"}>
           <p>{@tooltip_name}</p>
           <p class="mt-2">
@@ -298,43 +333,13 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
           />
         </.tooltip>
       </div>
-      <div class="relative mt-2">
-        <%= if @assessment_point.is_hidden do %>
-          <.button
-            type="button"
-            size="xs"
-            theme="primary"
-            icon_name="hero-eye-slash-micro"
-            class="w-full"
-            phx-click="toggle_hidden"
-            phx-value-id={@assessment_point.id}
-            phx-target={@myself}
-          >
-            {gettext("Hidden")}
-          </.button>
-          <.tooltip id={"assessment-point-#{@assessment_point.id}-hide-flag-tooltip"}>
-            {gettext("Students won't see marking results for this assessment point.")}
-          </.tooltip>
-        <% else %>
-          <.button
-            type="button"
-            size="xs"
-            theme="ghost"
-            icon_name="hero-eye-micro"
-            class="w-full"
-            phx-click="toggle_hidden"
-            phx-value-id={@assessment_point.id}
-            phx-target={@myself}
-          >
-            {gettext("Hide")}
-          </.button>
-          <.tooltip id={"assessment-point-#{@assessment_point.id}-hide-flag-tooltip"}>
-            {gettext(
-              "When hidden, students won't see marking results for this assessment point. Use this while marking is in progress."
-            )}
-          </.tooltip>
-        <% end %>
-      </div>
+      <.badge
+        :if={@assessment_point.is_hidden}
+        icon_name="hero-eye-slash-micro"
+        class="w-full mt-2"
+      >
+        {gettext("Hidden")}
+      </.badge>
       <.compare_header :if={@assessment_view == "compare"} />
     </div>
     """
@@ -406,6 +411,9 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
       |> assign(:entries_changes_map, %{})
       |> assign(:invalid_changes_set, MapSet.new())
       |> assign(:assessment_point_entry, nil)
+      |> assign(:command_palette_ap, nil)
+      |> assign(:assessment_point_overlay, nil)
+      |> assign(:composition_overlay_ap, nil)
       |> assign(:has_entry_details_change, false)
       |> assign(:has_assessment_points, false)
       |> assign(:assessment_points_count, 0)
@@ -494,6 +502,110 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
         socket
       ),
       do: {:ok, socket}
+
+  def update(%{action: {AssessmentPointCommandPaletteComponent, {:edit}}}, socket) do
+    ap = socket.assigns.command_palette_ap
+
+    socket =
+      socket
+      |> assign(:command_palette_ap, nil)
+      |> assign(:assessment_point_overlay, ap)
+
+    {:ok, socket}
+  end
+
+  def update(
+        %{action: {AssessmentPointCommandPaletteComponent, {:add_composition, type}}},
+        socket
+      ) do
+    ap = socket.assigns.command_palette_ap
+    {:ok, updated_ap} = Assessments.update_assessment_point(ap, %{composition_type: type})
+
+    ap =
+      Assessments.get_assessment_point!(updated_ap.id,
+        preloads: [curriculum_item: :curriculum_component, scale: :ordinal_values]
+      )
+
+    socket =
+      socket
+      |> stream_insert(:assessment_points, ap)
+      |> assign(:command_palette_ap, nil)
+      |> assign(:composition_overlay_ap, ap)
+
+    {:ok, socket}
+  end
+
+  def update(%{action: {AssessmentPointCommandPaletteComponent, {:manage_composition}}}, socket) do
+    ap = socket.assigns.command_palette_ap
+
+    socket =
+      socket
+      |> assign(:command_palette_ap, nil)
+      |> assign(:composition_overlay_ap, ap)
+
+    {:ok, socket}
+  end
+
+  def update(%{action: {AssessmentPointCommandPaletteComponent, {:toggle_hidden}}}, socket) do
+    ap = socket.assigns.command_palette_ap
+    {:ok, _} = Assessments.update_assessment_point(ap, %{is_hidden: !ap.is_hidden})
+
+    updated_ap =
+      Assessments.get_assessment_point!(ap.id,
+        preloads: [curriculum_item: :curriculum_component, scale: :ordinal_values]
+      )
+
+    socket =
+      socket
+      |> stream_insert(:assessment_points, updated_ap)
+      |> assign(:command_palette_ap, updated_ap)
+
+    {:ok, socket}
+  end
+
+  def update(%{action: {AssessmentPointFormOverlayComponent, {:updated, updated_ap}}}, socket) do
+    socket =
+      socket
+      |> stream_insert(:assessment_points, updated_ap)
+      |> assign(:assessment_point_overlay, nil)
+      |> delegate_navigation(put_flash: {:info, gettext("Assessment point updated successfully")})
+
+    {:ok, socket}
+  end
+
+  def update(%{action: {AssessmentPointFormOverlayComponent, _}}, socket) do
+    {:ok, assign(socket, :assessment_point_overlay, nil)}
+  end
+
+  def update(
+        %{action: {AssessmentPointCompositionOverlayComponent, {:composition_updated, ap_id}}},
+        socket
+      ) do
+    updated_ap =
+      Assessments.get_assessment_point!(ap_id,
+        preloads: [curriculum_item: :curriculum_component, scale: :ordinal_values]
+      )
+
+    {:ok, stream_insert(socket, :assessment_points, updated_ap)}
+  end
+
+  def update(
+        %{action: {AssessmentPointCompositionOverlayComponent, {:deleted, ap_id}}},
+        socket
+      ) do
+    updated_ap =
+      Assessments.get_assessment_point!(ap_id,
+        preloads: [curriculum_item: :curriculum_component, scale: :ordinal_values]
+      )
+
+    socket =
+      socket
+      |> stream_insert(:assessment_points, updated_ap)
+      |> assign(:composition_overlay_ap, nil)
+      |> delegate_navigation(put_flash: {:info, gettext("Grade composition deleted")})
+
+    {:ok, socket}
+  end
 
   def update(assigns, socket) do
     socket =
@@ -625,23 +737,26 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
     end
   end
 
-  def handle_event("toggle_hidden", %{"id" => id}, socket) do
+  def handle_event("open_command_palette", %{"id" => id}, socket) do
     ap =
       Assessments.get_assessment_point!(
         String.to_integer(id),
         preloads: [curriculum_item: :curriculum_component, scale: :ordinal_values]
       )
 
-    socket =
-      case Assessments.update_assessment_point(ap, %{is_hidden: !ap.is_hidden}) do
-        {:ok, updated_ap} ->
-          stream_insert(socket, :assessment_points, updated_ap)
+    {:noreply, assign(socket, :command_palette_ap, ap)}
+  end
 
-        {:error, _changeset} ->
-          put_flash(socket, :error, gettext("Error updating assessment point"))
-      end
+  def handle_event("close_command_palette", _, socket) do
+    {:noreply, assign(socket, :command_palette_ap, nil)}
+  end
 
-    {:noreply, socket}
+  def handle_event("close_assessment_point_form", _, socket) do
+    {:noreply, assign(socket, :assessment_point_overlay, nil)}
+  end
+
+  def handle_event("close_composition_overlay", _, socket) do
+    {:noreply, assign(socket, :composition_overlay_ap, nil)}
   end
 
   def handle_event("close_entry_details_overlay", _, socket) do

--- a/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
@@ -521,7 +521,11 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
         socket
       ) do
     ap = socket.assigns.command_palette_ap
-    {:ok, updated_ap} = Assessments.update_assessment_point(ap, %{composition_type: type})
+
+    {:ok, updated_ap} =
+      Assessments.update_assessment_point(socket.assigns.current_scope, ap, %{
+        composition_type: type
+      })
 
     ap =
       Assessments.get_assessment_point!(updated_ap.id,
@@ -552,7 +556,11 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
 
   def update(%{action: {AssessmentPointCommandPaletteComponent, {:toggle_hidden}}}, socket) do
     ap = socket.assigns.command_palette_ap
-    {:ok, _} = Assessments.update_assessment_point(ap, %{is_hidden: !ap.is_hidden})
+
+    {:ok, _} =
+      Assessments.update_assessment_point(socket.assigns.current_scope, ap, %{
+        is_hidden: !ap.is_hidden
+      })
 
     updated_ap =
       Assessments.get_assessment_point!(ap.id,

--- a/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex
@@ -24,12 +24,13 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
 
   alias Lanttern.Assessments
   alias Lanttern.Assessments.AssessmentPoint
-  alias Lanttern.Curricula.CurriculumItem
   alias Lanttern.Identity.Scope
   alias Lanttern.Identity.User
   alias Lanttern.LearningContext.Moment
   alias Lanttern.LearningContext.Strand
   alias Lanttern.Schools.Student
+
+  import LantternWeb.GradingComponents
 
   # shared components
   alias LantternWeb.Assessments.EntryCellComponent
@@ -85,7 +86,6 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
                   id={dom_id}
                   ap_header={ap_header}
                   assessment_view={@current_assessment_view}
-                  strand_id={@strand_id}
                 />
               </div>
               <div
@@ -182,7 +182,6 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
   attr :id, :string, required: true
   attr :ap_header, :any, required: true
   attr :assessment_view, :string, required: true
-  attr :strand_id, :integer, default: nil
 
   def assessment_point_header(assigns) do
     {header_struct, assessment_points_count} = assigns.ap_header
@@ -198,28 +197,15 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
     ~H"""
     <div id={@id} class="group pt-2 px-2" style={@grid_column_span_style}>
       <div class="h-full pb-2 border-b border-ltrn-light" style={@grid_column_span_style}>
-        <.assessment_point_header_struct header_struct={@header_struct} strand_id={@strand_id} />
+        <span class="flex items-center w-full text-sm font-display font-bold truncate">
+          <%= if match?(%Moment{}, @header_struct) do %>
+            {@header_struct.name}
+          <% else %>
+            {gettext("Goals assessment")}
+          <% end %>
+        </span>
       </div>
     </div>
-    """
-  end
-
-  attr :header_struct, :any, required: true, doc: "moment, strand, or curriculum item"
-  attr :strand_id, :integer, default: nil
-
-  def assessment_point_header_struct(%{header_struct: %Moment{}} = assigns) do
-    ~H"""
-    <span class="flex items-center w-full h-full p-1 rounded-sm text-sm font-display font-bold truncate">
-      {@header_struct.name}
-    </span>
-    """
-  end
-
-  def assessment_point_header_struct(%{header_struct: %Strand{}} = assigns) do
-    ~H"""
-    <p class="flex items-center h-full font-bold">
-      {gettext("Goals assessment")}
-    </p>
     """
   end
 
@@ -229,151 +215,74 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
   attr :id, :string, required: true
 
   def assessment_point(assigns) do
-    ~H"""
-    <div id={@id} class="flex flex-col p-2">
-      <div class="flex-1">
-        <.assessment_point_struct assessment_point={@assessment_point} url_params={@url_params} />
-      </div>
-      <.compare_header :if={@assessment_view == "compare"} />
-    </div>
-    """
-  end
+    display_name =
+      assigns.assessment_point.name || assigns.assessment_point.curriculum_item.name
 
-  attr :assessment_point, AssessmentPoint, required: true
-  attr :url_params, :map, required: true
+    tooltip_name =
+      if assigns.assessment_point.name do
+        assigns.assessment_point.name
+      else
+        ci = assigns.assessment_point.curriculum_item
+        "#{ci.curriculum_component.name}: #{ci.name}"
+      end
 
-  def assessment_point_struct(
-        %{assessment_point: %{curriculum_item: %CurriculumItem{}, moment_id: moment_id}} = assigns
-      )
-      when not is_nil(moment_id) do
-    ~H"""
-    <.link
-      patch={"?#{URI.encode_query(Map.put(@url_params, "edit_assessment_point", @assessment_point.id))}"}
-      class="flex flex-col p-1 rounded-sm hover:bg-ltrn-lightest"
-    >
-      <div
-        :if={@assessment_point.is_differentiation || @assessment_point.scale.type == "numeric"}
-        class="flex items-center gap-2 mb-1"
-      >
-        <.badge :if={@assessment_point.scale.type == "numeric"}>
-          {@assessment_point.scale.max_score}
-        </.badge>
-        <.badge :if={@assessment_point.is_differentiation} theme="diff">{gettext("Diff")}</.badge>
-      </div>
-      <p class={[
-        "flex-1 font-sans text-sm",
-        if(@assessment_point.is_differentiation, do: "line-clamp-2", else: "line-clamp-3")
-      ]}>
-        {@assessment_point.name}
-      </p>
-      <.tooltip id={"assessment-point-#{@assessment_point.id}-struct-tooltip"}>
-        <p>{@assessment_point.name}</p>
-        <p class="mt-2">
-          ({@assessment_point.curriculum_item.curriculum_component.name}) {@assessment_point.curriculum_item.name}
-        </p>
-        <p :if={@assessment_point.scale.type == "numeric"} class="mt-2">
-          {gettext("Max score: %{max}", max: @assessment_point.scale.max_score)}
-        </p>
-        <.markdown
-          :if={@assessment_point.report_info}
-          text={@assessment_point.report_info}
-          invert
-          strip_tags
-          size="sm"
-          class="mt-2"
-        />
-      </.tooltip>
-    </.link>
-    """
-  end
+    assigns =
+      assigns
+      |> assign(:display_name, display_name)
+      |> assign(:tooltip_name, tooltip_name)
 
-  def assessment_point_struct(
-        %{assessment_point: %{curriculum_item: %CurriculumItem{}}} = assigns
-      ) do
     ~H"""
-    <.link
-      patch={"?#{URI.encode_query(Map.put(@url_params, "edit_assessment_point", @assessment_point.id))}"}
-      class="flex flex-col p-1 rounded-sm hover:bg-ltrn-lightest"
-    >
-      <div class="flex items-center gap-2">
-        <.badge :if={@assessment_point.scale.type == "numeric"}>
-          {@assessment_point.scale.max_score}
-        </.badge>
-        <.badge class="truncate">
-          {@assessment_point.curriculum_item.curriculum_component.name}
-        </.badge>
-        <.badge :if={@assessment_point.is_differentiation} theme="diff">
-          {gettext("Diff")}
-        </.badge>
-        <.icon :if={@assessment_point.rubric_id} name="hero-view-columns-micro" class="w-4 h-4" />
-      </div>
-      <p class="flex-1 mt-1 font-sans text-sm line-clamp-2">
-        {@assessment_point.curriculum_item.name}
-      </p>
-      <.tooltip id={"assessment-point-#{@assessment_point.id}-struct-tooltip"}>
-        <p>{@assessment_point.curriculum_item.name}</p>
-        <p :if={@assessment_point.scale.type == "numeric"} class="mt-2">
-          {gettext("Max score: %{max}", max: @assessment_point.scale.max_score)}
-        </p>
-      </.tooltip>
-    </.link>
-    """
-  end
-
-  def assessment_point_struct(%{assessment_point: %{moment: %Moment{}}} = assigns) do
-    ~H"""
-    <div class="font-sans text-sm whitespace-nowrap">
-      <div class="block w-full p-1 rounded-sm overflow-hidden">
-        <div class="flex items-center gap-2">
-          <.badge :if={@assessment_point.scale.type == "numeric"}>
-            {@assessment_point.scale.max_score}
-          </.badge>
-          <.icon :if={@assessment_point.rubric_id} name="hero-view-columns-micro" class="w-4 h-4" />
-          <span class="font-bold">{@assessment_point.moment.name}</span> <br />
-        </div>
-        <span class="text-xs">{@assessment_point.name}</span>
-      </div>
-      <.tooltip id={"assessment-point-#{@assessment_point.id}-subheader-tooltip"}>
-        <p>{@assessment_point.moment.name}</p>
-        <p class="mt-2">{@assessment_point.name}</p>
-        <p :if={@assessment_point.scale.type == "numeric"} class="mt-2">
-          {gettext("Max score: %{max}", max: @assessment_point.scale.max_score)}
-        </p>
-        <.markdown
-          :if={@assessment_point.report_info}
-          text={@assessment_point.report_info}
-          invert
-          strip_tags
-          size="sm"
-          class="mt-2"
-        />
-      </.tooltip>
-    </div>
-    """
-  end
-
-  def assessment_point_struct(%{assessment_point: %{strand_id: strand_id}} = assigns)
-      when not is_nil(strand_id) do
-    ~H"""
-    <.link
-      patch={"?#{URI.encode_query(Map.put(@url_params, "edit_assessment_point", @assessment_point.id))}"}
-      class="flex flex-col p-1 rounded-sm hover:bg-ltrn-lightest"
-    >
-      <div class="font-sans whitespace-nowrap overflow-hidden">
-        <div class="flex items-center gap-2">
-          <.badge :if={@assessment_point.scale.type == "numeric"}>
-            {@assessment_point.scale.max_score}
-          </.badge>
-          <.icon :if={@assessment_point.rubric_id} name="hero-view-columns-micro" />
-          <span class="font-bold text-sm">{gettext("Goal assessment")}</span>
-        </div>
-        <span class="text-xs">{gettext("(Strand final assessment)")}</span>
-        <.tooltip
-          :if={@assessment_point.report_info || @assessment_point.scale.type == "numeric"}
-          id={"assessment-point-#{@assessment_point.id}-struct-tooltip"}
+    <div id={@id} class="flex flex-col p-1">
+      <div class="flex flex-1 gap-1">
+        <.link
+          patch={"?#{URI.encode_query(Map.put(@url_params, "edit_assessment_point", @assessment_point.id))}"}
+          class="flex flex-1 gap-2 p-1 rounded-sm hover:bg-ltrn-lightest"
         >
-          <p :if={@assessment_point.scale.type == "numeric"}>
-            {gettext("Max score: %{max}", max: @assessment_point.scale.max_score)}
+          <div class="flex flex-col flex-1">
+            <div class="self-start mb-1">
+              <%= if @assessment_point.scale.type == "numeric" do %>
+                <.badge>{@assessment_point.scale.max_score}</.badge>
+              <% else %>
+                <.ordinal_scale_range scale={@assessment_point.scale} />
+              <% end %>
+            </div>
+            <p class="flex-1 font-sans text-sm line-clamp-2">
+              {@display_name}
+            </p>
+          </div>
+          <div class="shrink-0 flex flex-col gap-1 text-ltrn-light">
+            <.icon
+              name="hero-view-columns-micro"
+              class={["size-3", if(@assessment_point.rubric_id, do: "text-ltrn-primary")]}
+            />
+            <.icon
+              name="hero-light-bulb-micro"
+              class={["size-3", if(@assessment_point.is_differentiation, do: "text-ltrn-diff-accent")]}
+            />
+            <.icon
+              name="hero-calculator-micro"
+              class={["size-3", if(@assessment_point.composition_type, do: "text-ltrn-primary")]}
+            />
+          </div>
+        </.link>
+        <.tooltip id={"assessment-point-#{@assessment_point.id}-tooltip"}>
+          <p>{@tooltip_name}</p>
+          <p class="mt-2">
+            <%= if @assessment_point.scale.type == "numeric" do %>
+              {gettext("Max score: %{max}", max: @assessment_point.scale.max_score)}
+            <% else %>
+              {@assessment_point.scale.name}
+            <% end %>
+          </p>
+          <p :if={@assessment_point.rubric_id} class="mt-2">{gettext("Uses rubric")}</p>
+          <p :if={@assessment_point.is_differentiation} class="mt-2">
+            {gettext("Differentiation assessment")}
+          </p>
+          <p :if={@assessment_point.composition_type == :sum} class="mt-2">
+            {gettext("Sum-based grade composition")}
+          </p>
+          <p :if={@assessment_point.composition_type == :avg} class="mt-2">
+            {gettext("Average-based grade composition")}
           </p>
           <.markdown
             :if={@assessment_point.report_info}
@@ -385,7 +294,8 @@ defmodule LantternWeb.Assessments.AssessmentsGridComponent do
           />
         </.tooltip>
       </div>
-    </.link>
+      <.compare_header :if={@assessment_view == "compare"} />
+    </div>
     """
   end
 

--- a/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
@@ -589,6 +589,8 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
     not (str == "" or valid_numeric_score?(str, max_score))
   end
 
+  defp score_invalid?(_, _, _), do: false
+
   defp valid_numeric_score?(str, max_score) do
     if Regex.match?(~r/^\d+([,.]\d+)?$/, str) do
       case Float.parse(String.replace(str, ",", ".")) do
@@ -599,8 +601,6 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
       false
     end
   end
-
-  defp score_invalid?(_, _, _), do: false
 
   defp normalize_numeric_score(params) do
     params

--- a/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
@@ -54,7 +54,7 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
             phx-change="change"
             phx-target={@myself}
             class={[
-              "relative flex-1 w-full h-full",
+              "relative flex-1 w-full h-full min-w-0",
               @is_invalid && "outline outline-4 outline-offset-1 outline-ltrn-alert-accent",
               !@is_invalid && @has_changes && "outline outline-4 outline-offset-1 outline-ltrn-dark"
             ]}
@@ -64,6 +64,7 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
               scale_type={@entry.scale_type}
               ov_options={@ov_options}
               field={@field}
+              input_id={"entry-#{@id}-#{@field.name}"}
               style={if(@has_changes, do: "background-color: white", else: @field_style)}
             />
             <.missing_indicator entry={@entry} />
@@ -119,6 +120,7 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
   attr :field, :map, required: true
   attr :ov_options, :list
   attr :style, :string
+  attr :input_id, :string, required: true
 
   def marking_input(%{scale_type: "ordinal"} = assigns) do
     current_label =
@@ -130,17 +132,17 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
 
     ~H"""
     <div class="relative w-full h-full">
-      <input type="hidden" id={@field.id} name={@field.name} value={@field.value || ""} />
+      <input type="hidden" id={@input_id} name={@field.name} value={@field.value || ""} />
       <div
         class={[
-          "flex items-center justify-center w-full h-full rounded-xs font-mono text-sm truncate px-1",
-          is_nil(@current_label) && "bg-ltrn-lighter"
+          "flex items-center justify-center w-full h-full rounded-xs font-mono text-sm px-1",
+          is_nil(@current_label) && "text-ltrn-subtle bg-ltrn-lighter"
         ]}
         style={if @current_label, do: @style}
       >
-        <span class={[is_nil(@current_label) && "text-ltrn-subtle"]}>
+        <div class="whitespace-nowrap overflow-hidden text-clip">
           {@current_label || "—"}
-        </span>
+        </div>
       </div>
       <ul
         class="hidden absolute z-30 left-0 top-full mt-0.5 min-w-max rounded-sm shadow-md bg-white ring-1 ring-ltrn-lighter overflow-y-auto max-h-48"

--- a/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
@@ -586,20 +586,17 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
 
   defp score_invalid?(value, "numeric", %{max_score: max_score}) do
     str = to_string(value)
+    not (str == "" or valid_numeric_score?(str, max_score))
+  end
 
-    if str == "" do
-      false
-    else
-      if Regex.match?(~r/^\d+([,.]\d+)?$/, str) do
-        normalized = String.replace(str, ",", ".")
-
-        case Float.parse(normalized) do
-          {score, ""} -> score < 0.0 || score > max_score
-          _ -> true
-        end
-      else
-        true
+  defp valid_numeric_score?(str, max_score) do
+    if Regex.match?(~r/^\d+([,.]\d+)?$/, str) do
+      case Float.parse(String.replace(str, ",", ".")) do
+        {score, ""} -> score >= 0.0 and score <= max_score
+        _ -> false
       end
+    else
+      false
     end
   end
 

--- a/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
+++ b/lib/lanttern_web/live/shared/assessments/entry_cell_component.ex
@@ -175,7 +175,8 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
     ~H"""
     <.base_input
       name={@field.name}
-      type="number"
+      type="text"
+      inputmode="decimal"
       phx-debounce="1000"
       value={format_score_input_value(@field.value)}
       errors={@field.errors}
@@ -499,12 +500,14 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
   # event handlers
 
   @impl true
-  def handle_event("change", %{"assessment_point_entry" => params}, socket) do
+  def handle_event("change", %{"assessment_point_entry" => raw_params}, socket) do
     %{
       entry: entry,
       view: view,
       entry_value: entry_value
     } = socket.assigns
+
+    params = normalize_numeric_score(raw_params)
 
     form =
       entry
@@ -587,12 +590,31 @@ defmodule LantternWeb.Assessments.EntryCellComponent do
     if str == "" do
       false
     else
-      case Float.parse(str) do
-        {score, _} -> score < 0.0 || score > max_score
-        :error -> false
+      if Regex.match?(~r/^\d+([,.]\d+)?$/, str) do
+        normalized = String.replace(str, ",", ".")
+
+        case Float.parse(normalized) do
+          {score, ""} -> score < 0.0 || score > max_score
+          _ -> true
+        end
+      else
+        true
       end
     end
   end
 
   defp score_invalid?(_, _, _), do: false
+
+  defp normalize_numeric_score(params) do
+    params
+    |> maybe_normalize_score_field("score")
+    |> maybe_normalize_score_field("student_score")
+  end
+
+  defp maybe_normalize_score_field(params, field) do
+    case Map.get(params, field) do
+      value when is_binary(value) -> Map.put(params, field, String.replace(value, ",", "."))
+      _ -> params
+    end
+  end
 end

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -24,7 +24,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.ex:11
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.html.heex:3
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:3
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:64
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:93
 #: lib/lanttern_web/live/shared/assessments/student_assessment_point_details_overlay_component.ex:81
 #: lib/lanttern_web/live/shared/menu_component.ex:453
 #, elixir-autogen, elixir-format
@@ -116,8 +116,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tag_card_component.ex:69
 #: lib/lanttern_web/live/pages/settings/lesson_templates/lesson_template_card_component.ex:101
 #: lib/lanttern_web/live/pages/settings/school_ai_config/school_ai_config_live.ex:38
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:110
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:81
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:109
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:82
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:154
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:137
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:277
@@ -205,8 +205,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tag_card_component.ex:72
 #: lib/lanttern_web/live/pages/settings/lesson_templates/lesson_template_card_component.ex:104
 #: lib/lanttern_web/live/pages/settings/school_ai_config/school_ai_config_live.ex:41
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:113
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:83
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:112
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:84
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:157
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:139
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:279
@@ -217,7 +217,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:50
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:172
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:149
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:163
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:168
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:75
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:337
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:107
@@ -446,7 +446,7 @@ msgid "Assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:52
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:46
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Couldn't find strand"
 msgstr ""
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Edit strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:95
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Strand deleted"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:153
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:129
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:173
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:149
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:154
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:50
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:60
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:63
@@ -560,11 +560,11 @@ msgstr ""
 msgid "Are you sure?"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:305
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:348
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:101
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:51
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:286
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:108
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:79
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:68
 #: lib/lanttern_web/live/shared/assessments/student_assessment_point_details_overlay_component.ex:57
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:55
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "No assessment points for this strand yet"
 msgstr ""
@@ -653,12 +653,12 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:61
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:14
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:91
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "Scale"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:93
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:64
 #, elixir-autogen, elixir-format
 msgid "Select a scale"
 msgstr ""
@@ -726,12 +726,12 @@ msgstr ""
 msgid "Strand has linked assessment points."
 msgstr ""
 
-#: lib/lanttern/assessments/assessment_point.ex:259
+#: lib/lanttern/assessments/assessment_point.ex:262
 #, elixir-autogen, elixir-format
 msgid "Assessment point has linked entries."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:74
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:76
 #: lib/lanttern_web/live/shared/learning_context/moment_details_overlay_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "Couldn't find moment"
@@ -742,7 +742,7 @@ msgstr ""
 msgid "Create new moment"
 msgstr ""
 
-#: lib/lanttern/assessments/assessment_point.ex:128
+#: lib/lanttern/assessments/assessment_point.ex:131
 #, elixir-autogen, elixir-format
 msgid "Curriculum item already added to this strand"
 msgstr ""
@@ -752,7 +752,7 @@ msgstr ""
 msgid "Edit moment"
 msgstr ""
 
-#: lib/lanttern/assessments/assessment_point.ex:139
+#: lib/lanttern/assessments/assessment_point.ex:142
 #, elixir-autogen, elixir-format
 msgid "Error linking rubric. Check if it exists and uses the same scale used in the assessment point."
 msgstr ""
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:105
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Strand has linked moments and/or assessment points (goals). Deleting it would cause some data loss."
 msgstr ""
@@ -827,7 +827,7 @@ msgstr ""
 msgid "Strand has linked moments."
 msgstr ""
 
-#: lib/lanttern/assessments/assessment_point.ex:147
+#: lib/lanttern/assessments/assessment_point.ex:150
 #, elixir-autogen, elixir-format
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr ""
@@ -995,8 +995,6 @@ msgstr ""
 #: lib/lanttern_web/components/reporting_components.ex:83
 #: lib/lanttern_web/components/reporting_components.ex:439
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:297
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:260
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:305
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:78
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:150
 #, elixir-autogen, elixir-format
@@ -1421,8 +1419,8 @@ msgstr ""
 msgid "Strand already linked to report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:62
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:120
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:61
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:121
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Strand goal"
@@ -1510,7 +1508,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:111
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Use the differentiation flag above when creating assessment points related to a curriculum level differentiation."
 msgstr ""
@@ -1561,7 +1559,7 @@ msgstr ""
 msgid "Filter report cards by year"
 msgstr ""
 
-#: lib/lanttern/assessments/assessment_point.ex:133
+#: lib/lanttern/assessments/assessment_point.ex:136
 #, elixir-autogen, elixir-format
 msgid "Name is required"
 msgstr ""
@@ -1605,19 +1603,19 @@ msgstr ""
 msgid "About this assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:99
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "Report information"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:663
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:727
 #, elixir-autogen, elixir-format
 msgid "1 entry updated"
 msgid_plural "%{count} entries updated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:151
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:156
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
@@ -1681,7 +1679,7 @@ msgstr ""
 msgid "Strands reports"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:129
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:134
 #, elixir-autogen, elixir-format
 msgid "1 change"
 msgid_plural "%{count} changes"
@@ -1993,14 +1991,14 @@ msgstr ""
 #: lib/lanttern_web/components/ilp_components.ex:169
 #: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:74
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:13
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:398
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:355
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:134
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr ""
 
 #: lib/lanttern_web/components/ilp_components.ex:187
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:395
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:352
 #, elixir-autogen, elixir-format
 msgid "Teacher"
 msgstr ""
@@ -2082,12 +2080,12 @@ msgstr ""
 msgid "Score before retake"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:143
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:148
 #, elixir-autogen, elixir-format
 msgid "You are registering students self-assessments"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:162
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Save self-assessments"
 msgstr ""
@@ -2102,11 +2100,6 @@ msgstr[1] ""
 #: lib/lanttern_web/components/grades_reports_components.ex:950
 #, elixir-autogen, elixir-format
 msgid "There is a manual grade change that will be overwritten by this operation. Are you sure you want to proceed?"
-msgstr ""
-
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:369
-#, elixir-autogen, elixir-format
-msgid "(Strand final assessment)"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/settings/agents/agent_card_component.ex:149
@@ -2150,15 +2143,14 @@ msgstr ""
 msgid "Compare teacher/students"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:367
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:230
 #, elixir-autogen, elixir-format
 msgid "Goal assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:76
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:165
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:220
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:166
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:237
 #, elixir-autogen, elixir-format
 msgid "Goals assessment"
 msgstr ""
@@ -2911,7 +2903,7 @@ msgstr ""
 msgid "Loading profiles"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:624
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:625
 #, elixir-autogen, elixir-format
 msgid "New assessment point"
 msgstr ""
@@ -4398,22 +4390,23 @@ msgstr ""
 msgid "Add diff rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:290
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Assessment point and entries deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:287
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Assessment point created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:289
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:288
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:273
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:571
 #, elixir-autogen, elixir-format
 msgid "Assessment point updated successfully"
 msgstr ""
@@ -4444,7 +4437,7 @@ msgstr ""
 msgid "Edit rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:667
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:731
 #, elixir-autogen, elixir-format
 msgid "Error updating assessment point entries"
 msgstr ""
@@ -5119,7 +5112,7 @@ msgstr ""
 msgid "Moment (optional)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:99
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:100
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:85
 #: lib/lanttern_web/live/pages/strands/id/overview_component.ex:55
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:358
@@ -5626,7 +5619,7 @@ msgstr ""
 msgid " (Draft)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:49
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:50
 #, elixir-autogen, elixir-format
 msgid "Add assessment info"
 msgstr ""
@@ -5646,29 +5639,29 @@ msgstr ""
 msgid "Are you sure? All linked lessons will also be deleted."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:25
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:26
 #, elixir-autogen, elixir-format
 msgid "Assessment information"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:417
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:418
 #, elixir-autogen, elixir-format
 msgid "Assessment point created"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:465
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:466
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:538
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:432
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:433
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "Assessment point updated"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:89
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:90
 #, elixir-autogen, elixir-format
 msgid "Assessment points"
 msgstr ""
@@ -5704,13 +5697,15 @@ msgstr ""
 msgid "Delete lessons too"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:56
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:57
 #, elixir-autogen, elixir-format
 msgid "Edit assessment info"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:650
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:651
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:402
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:25
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:195
 #, elixir-autogen, elixir-format
 msgid "Edit assessment point"
 msgstr ""
@@ -5762,7 +5757,7 @@ msgid "Manage lesson tags below"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:8
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:130
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:131
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Marking"
@@ -5788,7 +5783,7 @@ msgstr ""
 msgid "New lesson tag"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:159
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:160
 #, elixir-autogen, elixir-format
 msgid "No assessment points in this moment yet"
 msgstr ""
@@ -5839,7 +5834,7 @@ msgstr ""
 msgid "School-wide knowledge shared with all AI agents. Include information about your school's philosophy, curriculum approach, and other context."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:106
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:107
 #, elixir-autogen, elixir-format
 msgid "Select moment to create the assessment point in"
 msgstr ""
@@ -5849,7 +5844,7 @@ msgstr ""
 msgid "Something went wrong when trying to delete the lesson tag"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:70
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Strand assessment info"
 msgstr ""
@@ -5873,12 +5868,12 @@ msgstr ""
 msgid "Toggle lesson tag card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:30
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:31
 #, elixir-autogen, elixir-format
 msgid "Use this area to share assessment information with students (e.g. grade composition)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:301
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:344
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Uses rubric in assessment"
@@ -6148,7 +6143,7 @@ msgstr ""
 msgid "Lesson assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:323
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:366
 #, elixir-autogen, elixir-format
 msgid "Lesson:"
 msgstr ""
@@ -6658,7 +6653,7 @@ msgstr ""
 msgid "Lesson Curriculum"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:638
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:639
 #, elixir-autogen, elixir-format
 msgid "New strand goal"
 msgstr ""
@@ -6709,7 +6704,7 @@ msgstr ""
 msgid "%{name} grading composition not setup yet"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:249
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:253
 #, elixir-autogen, elixir-format
 msgid "Add composition"
 msgstr ""
@@ -6720,13 +6715,14 @@ msgstr ""
 msgid "Assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:265
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:269
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Average"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:183
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Average-based grade composition"
 msgstr ""
@@ -6741,7 +6737,7 @@ msgstr ""
 msgid "Composition type"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:256
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Create composition using"
 msgstr ""
@@ -6761,13 +6757,14 @@ msgstr ""
 msgid "Setup composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:274
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:278
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Sum"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:182
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:321
 #, elixir-autogen, elixir-format
 msgid "Sum-based grade composition"
 msgstr ""
@@ -6787,14 +6784,14 @@ msgstr ""
 msgid "must be \"numeric\" or \"ordinal\""
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:25
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "1 filter"
 msgid_plural "%{count} filters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:46
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Assign at least one class to the strand to view the assessment grid"
 msgstr ""
@@ -6804,7 +6801,7 @@ msgstr ""
 msgid "Assign classes"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:51
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Assign classes to strand"
 msgstr ""
@@ -6820,17 +6817,17 @@ msgstr ""
 msgid "Assigned classes"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:295
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:299
 #, elixir-autogen, elixir-format
 msgid "Average-based"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:70
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "By class"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:80
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "By grade composition"
 msgstr ""
@@ -6845,30 +6842,27 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:102
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Clear all filters"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:69
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Filter assessment points"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:92
+#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:93
 #, elixir-autogen, elixir-format
 msgid "Has attachment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:93
+#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:94
 #, elixir-autogen, elixir-format
 msgid "Has differentiation rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:274
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:315
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:339
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:375
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:311
 #, elixir-autogen, elixir-format
 msgid "Max score: %{max}"
 msgstr ""
@@ -6878,27 +6872,110 @@ msgstr ""
 msgid "No filters applied"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:156
+#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:158
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:136
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:141
 #, elixir-autogen, elixir-format
 msgid "Some values are out of range"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/learning_context/strand_class_assignment_overlay_component.ex:178
+#: lib/lanttern_web/live/shared/learning_context/strand_class_assignment_overlay_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "Strand classes updated"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:294
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:298
 #, elixir-autogen, elixir-format
 msgid "Sum-based"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:290
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:294
 #, elixir-autogen, elixir-format
 msgid "Uses composition"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:45
+#, elixir-autogen, elixir-format
+msgid "Add average-based composition"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:37
+#, elixir-autogen, elixir-format
+msgid "Add sum-based composition"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:318
+#, elixir-autogen, elixir-format
+msgid "Differentiation assessment"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/strand_class_assignment_overlay_component.ex:183
+#, elixir-autogen, elixir-format
+msgid "Failed to update class assignments"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:605
+#, elixir-autogen, elixir-format
+msgid "Grade composition deleted"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:316
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:341
+#, elixir-autogen, elixir-format
+msgid "Hidden"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:81
+#, elixir-autogen, elixir-format
+msgid "Hidden from students"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:332
+#, elixir-autogen, elixir-format
+msgid "Hide"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:88
+#, elixir-autogen, elixir-format
+msgid "Hide from students"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:61
+#, elixir-autogen, elixir-format
+msgid "Manage grade composition"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:319
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:84
+#, elixir-autogen, elixir-format
+msgid "Students won't see marking results for this assessment point."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:65
+#, elixir-autogen, elixir-format
+msgid "This assessment point uses a sum-based grade composition."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "This assessment point uses an average-based grade composition."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:49
+#, elixir-autogen, elixir-format
+msgid "Use grade composition to calculate entries based on sum or average of other assessment points."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:316
+#, elixir-autogen, elixir-format
+msgid "Uses rubric"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:335
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "When hidden, students won't see marking results for this assessment point. Use this while marking is in progress."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr ""
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.ex:11
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.html.heex:3
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:3
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:64
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:93
 #: lib/lanttern_web/live/shared/assessments/student_assessment_point_details_overlay_component.ex:81
 #: lib/lanttern_web/live/shared/menu_component.ex:453
 #, elixir-autogen, elixir-format
@@ -116,8 +116,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tag_card_component.ex:69
 #: lib/lanttern_web/live/pages/settings/lesson_templates/lesson_template_card_component.ex:101
 #: lib/lanttern_web/live/pages/settings/school_ai_config/school_ai_config_live.ex:38
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:110
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:81
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:109
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:82
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:154
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:137
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:277
@@ -205,8 +205,8 @@ msgstr ""
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tag_card_component.ex:72
 #: lib/lanttern_web/live/pages/settings/lesson_templates/lesson_template_card_component.ex:104
 #: lib/lanttern_web/live/pages/settings/school_ai_config/school_ai_config_live.ex:41
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:113
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:83
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:112
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:84
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:157
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:139
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:279
@@ -217,7 +217,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:50
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:172
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:149
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:163
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:168
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:75
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:337
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:107
@@ -446,7 +446,7 @@ msgid "Assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:52
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:46
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Couldn't find strand"
 msgstr ""
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Edit strand"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:95
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Strand deleted"
 msgstr ""
@@ -531,7 +531,7 @@ msgstr ""
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:153
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:129
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:173
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:149
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:154
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:50
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:60
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:63
@@ -560,11 +560,11 @@ msgstr ""
 msgid "Are you sure?"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:305
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:348
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:101
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:51
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:286
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:108
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:79
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:68
 #: lib/lanttern_web/live/shared/assessments/student_assessment_point_details_overlay_component.ex:57
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:55
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "No assessment points for this strand yet"
 msgstr ""
@@ -653,12 +653,12 @@ msgstr ""
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:61
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:14
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:91
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "Scale"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:93
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:64
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Select a scale"
 msgstr ""
@@ -726,12 +726,12 @@ msgstr ""
 msgid "Strand has linked assessment points."
 msgstr ""
 
-#: lib/lanttern/assessments/assessment_point.ex:259
+#: lib/lanttern/assessments/assessment_point.ex:262
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point has linked entries."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:74
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:76
 #: lib/lanttern_web/live/shared/learning_context/moment_details_overlay_component.ex:113
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Couldn't find moment"
@@ -742,7 +742,7 @@ msgstr ""
 msgid "Create new moment"
 msgstr ""
 
-#: lib/lanttern/assessments/assessment_point.ex:128
+#: lib/lanttern/assessments/assessment_point.ex:131
 #, elixir-autogen, elixir-format
 msgid "Curriculum item already added to this strand"
 msgstr ""
@@ -752,7 +752,7 @@ msgstr ""
 msgid "Edit moment"
 msgstr ""
 
-#: lib/lanttern/assessments/assessment_point.ex:139
+#: lib/lanttern/assessments/assessment_point.ex:142
 #, elixir-autogen, elixir-format
 msgid "Error linking rubric. Check if it exists and uses the same scale used in the assessment point."
 msgstr ""
@@ -817,7 +817,7 @@ msgstr ""
 msgid "Something went wrong"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:105
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:107
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strand has linked moments and/or assessment points (goals). Deleting it would cause some data loss."
 msgstr ""
@@ -827,7 +827,7 @@ msgstr ""
 msgid "Strand has linked moments."
 msgstr ""
 
-#: lib/lanttern/assessments/assessment_point.ex:147
+#: lib/lanttern/assessments/assessment_point.ex:150
 #, elixir-autogen, elixir-format
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr ""
@@ -995,8 +995,6 @@ msgstr ""
 #: lib/lanttern_web/components/reporting_components.ex:83
 #: lib/lanttern_web/components/reporting_components.ex:439
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:297
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:260
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:305
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:78
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:150
 #, elixir-autogen, elixir-format
@@ -1421,8 +1419,8 @@ msgstr ""
 msgid "Strand already linked to report card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:62
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:120
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:61
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:121
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strand goal"
@@ -1510,7 +1508,7 @@ msgstr ""
 msgid "Type"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:111
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Use the differentiation flag above when creating assessment points related to a curriculum level differentiation."
 msgstr ""
@@ -1561,7 +1559,7 @@ msgstr ""
 msgid "Filter report cards by year"
 msgstr ""
 
-#: lib/lanttern/assessments/assessment_point.ex:133
+#: lib/lanttern/assessments/assessment_point.ex:136
 #, elixir-autogen, elixir-format
 msgid "Name is required"
 msgstr ""
@@ -1605,19 +1603,19 @@ msgstr ""
 msgid "About this assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:99
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "Report information"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:663
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:727
 #, elixir-autogen, elixir-format
 msgid "1 entry updated"
 msgid_plural "%{count} entries updated"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:151
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:156
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr ""
@@ -1681,7 +1679,7 @@ msgstr ""
 msgid "Strands reports"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:129
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "1 change"
 msgid_plural "%{count} changes"
@@ -1993,14 +1991,14 @@ msgstr ""
 #: lib/lanttern_web/components/ilp_components.ex:169
 #: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:74
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:13
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:398
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:355
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:134
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Student"
 msgstr ""
 
 #: lib/lanttern_web/components/ilp_components.ex:187
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:395
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:352
 #, elixir-autogen, elixir-format
 msgid "Teacher"
 msgstr ""
@@ -2082,12 +2080,12 @@ msgstr ""
 msgid "Score before retake"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:143
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:148
 #, elixir-autogen, elixir-format
 msgid "You are registering students self-assessments"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:162
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:167
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Save self-assessments"
 msgstr ""
@@ -2102,11 +2100,6 @@ msgstr[1] ""
 #: lib/lanttern_web/components/grades_reports_components.ex:950
 #, elixir-autogen, elixir-format
 msgid "There is a manual grade change that will be overwritten by this operation. Are you sure you want to proceed?"
-msgstr ""
-
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:369
-#, elixir-autogen, elixir-format
-msgid "(Strand final assessment)"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/settings/agents/agent_card_component.ex:149
@@ -2150,15 +2143,14 @@ msgstr ""
 msgid "Compare teacher/students"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:367
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:230
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Goal assessment"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:76
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:165
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:220
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:166
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:237
 #, elixir-autogen, elixir-format
 msgid "Goals assessment"
 msgstr ""
@@ -2911,7 +2903,7 @@ msgstr ""
 msgid "Loading profiles"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:624
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:625
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New assessment point"
 msgstr ""
@@ -4398,22 +4390,23 @@ msgstr ""
 msgid "Add diff rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:290
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Assessment point and entries deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:287
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:272
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point created successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:289
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:274
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point deleted successfully"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:288
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:273
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:571
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point updated successfully"
 msgstr ""
@@ -4444,7 +4437,7 @@ msgstr ""
 msgid "Edit rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:667
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:731
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Error updating assessment point entries"
 msgstr ""
@@ -5119,7 +5112,7 @@ msgstr ""
 msgid "Moment (optional)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:99
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:100
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:85
 #: lib/lanttern_web/live/pages/strands/id/overview_component.ex:55
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:358
@@ -5626,7 +5619,7 @@ msgstr ""
 msgid " (Draft)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:49
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:50
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add assessment info"
 msgstr ""
@@ -5646,29 +5639,29 @@ msgstr ""
 msgid "Are you sure? All linked lessons will also be deleted."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:25
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:26
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment information"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:417
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:418
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point created"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:465
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:466
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:538
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point deleted"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:432
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:433
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:523
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment point updated"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:89
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:90
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Assessment points"
 msgstr ""
@@ -5704,13 +5697,15 @@ msgstr ""
 msgid "Delete lessons too"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:56
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:57
 #, elixir-autogen, elixir-format
 msgid "Edit assessment info"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:650
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:651
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:402
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:25
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:195
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Edit assessment point"
 msgstr ""
@@ -5762,7 +5757,7 @@ msgid "Manage lesson tags below"
 msgstr ""
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:8
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:130
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:131
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:42
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Marking"
@@ -5788,7 +5783,7 @@ msgstr ""
 msgid "New lesson tag"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:159
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:160
 #, elixir-autogen, elixir-format, fuzzy
 msgid "No assessment points in this moment yet"
 msgstr ""
@@ -5839,7 +5834,7 @@ msgstr ""
 msgid "School-wide knowledge shared with all AI agents. Include information about your school's philosophy, curriculum approach, and other context."
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:106
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:107
 #, elixir-autogen, elixir-format
 msgid "Select moment to create the assessment point in"
 msgstr ""
@@ -5849,7 +5844,7 @@ msgstr ""
 msgid "Something went wrong when trying to delete the lesson tag"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:70
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:71
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Strand assessment info"
 msgstr ""
@@ -5873,12 +5868,12 @@ msgstr ""
 msgid "Toggle lesson tag card"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:30
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:31
 #, elixir-autogen, elixir-format
 msgid "Use this area to share assessment information with students (e.g. grade composition)"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:301
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:344
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:47
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Uses rubric in assessment"
@@ -6148,7 +6143,7 @@ msgstr ""
 msgid "Lesson assessment"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:323
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:366
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Lesson:"
 msgstr ""
@@ -6658,7 +6653,7 @@ msgstr ""
 msgid "Lesson Curriculum"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:638
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:639
 #, elixir-autogen, elixir-format, fuzzy
 msgid "New strand goal"
 msgstr ""
@@ -6709,7 +6704,7 @@ msgstr ""
 msgid "%{name} grading composition not setup yet"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:249
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:253
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Add composition"
 msgstr ""
@@ -6720,13 +6715,14 @@ msgstr ""
 msgid "Assessment point"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:265
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:269
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Average"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:183
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Average-based grade composition"
 msgstr ""
@@ -6741,7 +6737,7 @@ msgstr ""
 msgid "Composition type"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:256
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Create composition using"
 msgstr ""
@@ -6761,13 +6757,14 @@ msgstr ""
 msgid "Setup composition"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:274
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:278
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Sum"
 msgstr ""
 
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:182
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:321
 #, elixir-autogen, elixir-format
 msgid "Sum-based grade composition"
 msgstr ""
@@ -6787,14 +6784,14 @@ msgstr ""
 msgid "must be \"numeric\" or \"ordinal\""
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:25
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "1 filter"
 msgid_plural "%{count} filters"
 msgstr[0] ""
 msgstr[1] ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:46
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Assign at least one class to the strand to view the assessment grid"
 msgstr ""
@@ -6804,7 +6801,7 @@ msgstr ""
 msgid "Assign classes"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:51
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Assign classes to strand"
 msgstr ""
@@ -6820,17 +6817,17 @@ msgstr ""
 msgid "Assigned classes"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:295
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:299
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Average-based"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:70
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:69
 #, elixir-autogen, elixir-format, fuzzy
 msgid "By class"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:80
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:79
 #, elixir-autogen, elixir-format, fuzzy
 msgid "By grade composition"
 msgstr ""
@@ -6845,30 +6842,27 @@ msgstr ""
 msgid "Clear"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:102
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:101
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Clear all filters"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:69
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:68
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Filter assessment points"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:92
+#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:93
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Has attachment"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:93
+#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:94
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Has differentiation rubric"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:274
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:315
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:339
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:375
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:311
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Max score: %{max}"
 msgstr ""
@@ -6878,27 +6872,110 @@ msgstr ""
 msgid "No filters applied"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:156
+#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:158
 #, elixir-autogen, elixir-format, fuzzy
 msgid "None"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:136
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:141
 #, elixir-autogen, elixir-format
 msgid "Some values are out of range"
 msgstr ""
 
-#: lib/lanttern_web/live/shared/learning_context/strand_class_assignment_overlay_component.ex:178
+#: lib/lanttern_web/live/shared/learning_context/strand_class_assignment_overlay_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "Strand classes updated"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:294
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:298
 #, elixir-autogen, elixir-format
 msgid "Sum-based"
 msgstr ""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:290
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:294
 #, elixir-autogen, elixir-format, fuzzy
 msgid "Uses composition"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:45
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Add average-based composition"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:37
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Add sum-based composition"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:318
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Differentiation assessment"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/learning_context/strand_class_assignment_overlay_component.ex:183
+#, elixir-autogen, elixir-format
+msgid "Failed to update class assignments"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:605
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Grade composition deleted"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:316
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:341
+#, elixir-autogen, elixir-format
+msgid "Hidden"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:81
+#, elixir-autogen, elixir-format
+msgid "Hidden from students"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:332
+#, elixir-autogen, elixir-format
+msgid "Hide"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:88
+#, elixir-autogen, elixir-format
+msgid "Hide from students"
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:61
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Manage grade composition"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:319
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:84
+#, elixir-autogen, elixir-format
+msgid "Students won't see marking results for this assessment point."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:65
+#, elixir-autogen, elixir-format
+msgid "This assessment point uses a sum-based grade composition."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "This assessment point uses an average-based grade composition."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:49
+#, elixir-autogen, elixir-format
+msgid "Use grade composition to calculate entries based on sum or average of other assessment points."
+msgstr ""
+
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:316
+#, elixir-autogen, elixir-format, fuzzy
+msgid "Uses rubric"
+msgstr ""
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:335
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "When hidden, students won't see marking results for this assessment point. Use this while marking is in progress."
 msgstr ""

--- a/priv/gettext/pt_BR/LC_MESSAGES/default.po
+++ b/priv/gettext/pt_BR/LC_MESSAGES/default.po
@@ -24,7 +24,7 @@ msgstr "Ações"
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.ex:11
 #: lib/lanttern_web/live/pages/curriculum/curricula_live.html.heex:3
 #: lib/lanttern_web/live/pages/curriculum/id/curriculum_live.html.heex:3
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:64
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:93
 #: lib/lanttern_web/live/shared/assessments/student_assessment_point_details_overlay_component.ex:81
 #: lib/lanttern_web/live/shared/menu_component.ex:453
 #, elixir-autogen, elixir-format
@@ -116,8 +116,8 @@ msgstr "Aplicando filtros..."
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tag_card_component.ex:69
 #: lib/lanttern_web/live/pages/settings/lesson_templates/lesson_template_card_component.ex:101
 #: lib/lanttern_web/live/pages/settings/school_ai_config/school_ai_config_live.ex:38
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:110
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:81
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:109
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:82
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:154
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:137
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:277
@@ -205,8 +205,8 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tag_card_component.ex:72
 #: lib/lanttern_web/live/pages/settings/lesson_templates/lesson_template_card_component.ex:104
 #: lib/lanttern_web/live/pages/settings/school_ai_config/school_ai_config_live.ex:41
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:113
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:83
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:112
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:84
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:157
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:139
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:279
@@ -217,7 +217,7 @@ msgstr "Nova trilha"
 #: lib/lanttern_web/live/shared/agents/agent_form_component.ex:50
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:172
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:149
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:163
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:168
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:75
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:337
 #: lib/lanttern_web/live/shared/attachments/attachment_area_component.ex:107
@@ -446,7 +446,7 @@ msgid "Assessment"
 msgstr "Avaliação"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:52
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:46
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:48
 #, elixir-autogen, elixir-format
 msgid "Couldn't find strand"
 msgstr "Não foi possível encontrar a trilha"
@@ -500,7 +500,7 @@ msgstr "Deletar"
 msgid "Edit strand"
 msgstr "Editar trilha"
 
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:95
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:97
 #, elixir-autogen, elixir-format
 msgid "Strand deleted"
 msgstr "Trilha deletada"
@@ -531,7 +531,7 @@ msgstr "Adicionar rubrica"
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:153
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:129
 #: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:173
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:149
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:154
 #: lib/lanttern_web/live/shared/curricula/curriculum_form_component.ex:50
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_entry_overlay_component.ex:60
 #: lib/lanttern_web/live/shared/grades_reports/student_grades_report_final_entry_overlay_component.ex:63
@@ -560,11 +560,11 @@ msgstr "Adicionar rubrica"
 msgid "Are you sure?"
 msgstr "Você tem certeza?"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:305
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:348
 #: lib/lanttern_web/live/pages/strands/id/strand_rubrics_component.ex:101
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:51
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:286
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:108
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:79
 #: lib/lanttern_web/live/shared/assessments/entry_details_overlay_component.ex:34
 #: lib/lanttern_web/live/shared/assessments/strand_goal_details_overlay_component.ex:68
 #: lib/lanttern_web/live/shared/assessments/student_assessment_point_details_overlay_component.ex:57
@@ -605,7 +605,7 @@ msgstr "Diferenciação"
 msgid "Edit"
 msgstr "Editar"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:55
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:60
 #, elixir-autogen, elixir-format
 msgid "No assessment points for this strand yet"
 msgstr "Nenhum ponto de avaliação para esta trilha ainda"
@@ -653,12 +653,12 @@ msgstr "Posição"
 
 #: lib/lanttern_web/live/pages/grades_report/grades_reports_live.html.heex:61
 #: lib/lanttern_web/live/pages/grades_report/id/grades_report_live.html.heex:14
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:91
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:62
 #, elixir-autogen, elixir-format
 msgid "Scale"
 msgstr "Escala"
 
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:93
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:64
 #, elixir-autogen, elixir-format
 msgid "Select a scale"
 msgstr "Selecione uma escala"
@@ -726,12 +726,12 @@ msgstr "Este ponto de avaliação já possui alguns registros. Deletá-lo irá c
 msgid "Strand has linked assessment points."
 msgstr "Trilha possui pontos de avaliação conectados."
 
-#: lib/lanttern/assessments/assessment_point.ex:259
+#: lib/lanttern/assessments/assessment_point.ex:262
 #, elixir-autogen, elixir-format
 msgid "Assessment point has linked entries."
 msgstr "Ponto de avaliação possui registros vinculados."
 
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:74
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:76
 #: lib/lanttern_web/live/shared/learning_context/moment_details_overlay_component.ex:113
 #, elixir-autogen, elixir-format
 msgid "Couldn't find moment"
@@ -742,7 +742,7 @@ msgstr "Não foi possível encontrar o momento"
 msgid "Create new moment"
 msgstr "Criar novo momento"
 
-#: lib/lanttern/assessments/assessment_point.ex:128
+#: lib/lanttern/assessments/assessment_point.ex:131
 #, elixir-autogen, elixir-format
 msgid "Curriculum item already added to this strand"
 msgstr "Parâmetro curricular já adicionado à esta trilha"
@@ -752,7 +752,7 @@ msgstr "Parâmetro curricular já adicionado à esta trilha"
 msgid "Edit moment"
 msgstr "Editar momento"
 
-#: lib/lanttern/assessments/assessment_point.ex:139
+#: lib/lanttern/assessments/assessment_point.ex:142
 #, elixir-autogen, elixir-format
 msgid "Error linking rubric. Check if it exists and uses the same scale used in the assessment point."
 msgstr "Erro ao vincular rubrica. Confira se ela existe e usa a mesma escala utilizada no ponto de avaliação."
@@ -817,7 +817,7 @@ msgstr "Nenhum momento para esta trilha ainda"
 msgid "Something went wrong"
 msgstr "Algo deu errado"
 
-#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:105
+#: lib/lanttern_web/live/pages/strands/id/strand_live.ex:107
 #, elixir-autogen, elixir-format
 msgid "Strand has linked moments and/or assessment points (goals). Deleting it would cause some data loss."
 msgstr "Trilha com momentos e/ou pontos de avaliação (objetivos) conectados. Deletá-la causaria perda de dados."
@@ -827,7 +827,7 @@ msgstr "Trilha com momentos e/ou pontos de avaliação (objetivos) conectados. D
 msgid "Strand has linked moments."
 msgstr "Trilha possui momentos conectados."
 
-#: lib/lanttern/assessments/assessment_point.ex:147
+#: lib/lanttern/assessments/assessment_point.ex:150
 #, elixir-autogen, elixir-format
 msgid "You may already have some entries for this assessment point. Changing the scale when entries exist is not allowed, as it would cause data loss."
 msgstr "Você já deve possuir registros para este ponto de avaliação. Alterar a escala quando registros já existem não é permitido, pois acarretaria perda de dados."
@@ -995,8 +995,6 @@ msgstr "Ciclo já adicionado à este relatório de nota"
 #: lib/lanttern_web/components/reporting_components.ex:83
 #: lib/lanttern_web/components/reporting_components.ex:439
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:297
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:260
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:305
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:78
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:150
 #, elixir-autogen, elixir-format
@@ -1421,8 +1419,8 @@ msgstr "Favoritar trilha"
 msgid "Strand already linked to report card"
 msgstr "Trilha já vinculada ao report card"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:62
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:120
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:61
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:121
 #: lib/lanttern_web/live/shared/grading/grade_composition_overlay_component.ex:35
 #, elixir-autogen, elixir-format
 msgid "Strand goal"
@@ -1510,7 +1508,7 @@ msgstr "A nota do ciclo pai é calculada com baseem seus sub ciclos. Ex: a nota 
 msgid "Type"
 msgstr "Tipo"
 
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:111
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:82
 #, elixir-autogen, elixir-format
 msgid "Use the differentiation flag above when creating assessment points related to a curriculum level differentiation."
 msgstr "Utilize a marcação de diferenciação ao criar pontos de avaliação relacionados à diferenciação no nível do currículo."
@@ -1561,7 +1559,7 @@ msgstr "Filtrar report cards por ciclo"
 msgid "Filter report cards by year"
 msgstr "Filtrar report cards por ano"
 
-#: lib/lanttern/assessments/assessment_point.ex:133
+#: lib/lanttern/assessments/assessment_point.ex:136
 #, elixir-autogen, elixir-format
 msgid "Name is required"
 msgstr "Nome obrigatório"
@@ -1605,19 +1603,19 @@ msgstr "Você precisa estar logado para acessar esta página."
 msgid "About this assessment"
 msgstr "Sobre esta avaliação"
 
-#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:99
+#: lib/lanttern_web/live/shared/assessments/assessment_point_form_overlay_component.ex:70
 #, elixir-autogen, elixir-format
 msgid "Report information"
 msgstr "Informações do relatório"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:663
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:727
 #, elixir-autogen, elixir-format
 msgid "1 entry updated"
 msgid_plural "%{count} entries updated"
 msgstr[0] "1 registro atualizado"
 msgstr[1] "%{count} registros atualizados"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:151
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:156
 #, elixir-autogen, elixir-format
 msgid "Discard"
 msgstr "Descartar"
@@ -1681,7 +1679,7 @@ msgstr "Opcional"
 msgid "Strands reports"
 msgstr "Relatórios das trilhas"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:129
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:134
 #, elixir-autogen, elixir-format
 msgid "1 change"
 msgid_plural "%{count} changes"
@@ -1993,14 +1991,14 @@ msgstr "Anexos"
 #: lib/lanttern_web/components/ilp_components.ex:169
 #: lib/lanttern_web/live/pages/school/staff/id/students_records_component.ex:74
 #: lib/lanttern_web/live/pages/students_records/students_records_live.html.heex:13
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:398
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:355
 #: lib/lanttern_web/live/shared/schools/student_form_overlay_component.ex:134
 #, elixir-autogen, elixir-format
 msgid "Student"
 msgstr "Estudante"
 
 #: lib/lanttern_web/components/ilp_components.ex:187
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:395
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:352
 #, elixir-autogen, elixir-format
 msgid "Teacher"
 msgstr "Professor"
@@ -2082,12 +2080,12 @@ msgstr "Nível anterior à recuperação"
 msgid "Score before retake"
 msgstr "Pontuação anterior à recuperação"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:143
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:148
 #, elixir-autogen, elixir-format
 msgid "You are registering students self-assessments"
 msgstr "Você está registrando autoavaliações de estudantes"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:162
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:167
 #, elixir-autogen, elixir-format
 msgid "Save self-assessments"
 msgstr "Salvar autoavaliações"
@@ -2103,11 +2101,6 @@ msgstr[1] "%{count} notas parcialmente atualizadas (apenas composições, notas 
 #, elixir-autogen, elixir-format
 msgid "There is a manual grade change that will be overwritten by this operation. Are you sure you want to proceed?"
 msgstr "A nota atribuída manualmente será sobrescrita por esta operação. Você tem certeza que deseja proceder?"
-
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:369
-#, elixir-autogen, elixir-format
-msgid "(Strand final assessment)"
-msgstr "(Avaliação final da trilha)"
 
 #: lib/lanttern_web/live/pages/settings/agents/agent_card_component.ex:149
 #: lib/lanttern_web/live/pages/settings/lesson_tags/lesson_tag_card_component.ex:97
@@ -2150,15 +2143,14 @@ msgstr "Comparar avaliações de professor e estudantes"
 msgid "Compare teacher/students"
 msgstr "Comparar professor/estudantes"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:367
 #: lib/lanttern_web/live/shared/rubrics/rubric_form_overlay_component.ex:230
 #, elixir-autogen, elixir-format
 msgid "Goal assessment"
 msgstr "Avaliação de objetivo"
 
 #: lib/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component.ex:76
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:165
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:220
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:166
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:237
 #, elixir-autogen, elixir-format
 msgid "Goals assessment"
 msgstr "Avaliação de objetivos"
@@ -2911,7 +2903,7 @@ msgstr "Carregando ciclos"
 msgid "Loading profiles"
 msgstr "Carregando perfis"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:624
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:625
 #, elixir-autogen, elixir-format
 msgid "New assessment point"
 msgstr "Novo ponto de avaliação"
@@ -4398,22 +4390,23 @@ msgstr "Adicionar outra rubrica para avaliar este objetivo"
 msgid "Add diff rubric"
 msgstr "Adicionar rubrica de diferenciação"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:290
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:275
 #, elixir-autogen, elixir-format
 msgid "Assessment point and entries deleted successfully"
 msgstr "Ponto de avaliação e registros deletados com sucesso"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:287
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:272
 #, elixir-autogen, elixir-format
 msgid "Assessment point created successfully"
 msgstr "Ponto de avaliação criado com sucesso"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:289
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:274
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted successfully"
 msgstr "Ponto de avaliação deletado com sucesso"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:288
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.ex:273
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:571
 #, elixir-autogen, elixir-format
 msgid "Assessment point updated successfully"
 msgstr "Ponto de avaliação atualizado com sucesso"
@@ -4444,7 +4437,7 @@ msgstr "Editar rubrica de diferenciação"
 msgid "Edit rubric"
 msgstr "Editar rubrica"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:667
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:731
 #, elixir-autogen, elixir-format
 msgid "Error updating assessment point entries"
 msgstr "Erro ao atualizar registros de ponto de avaliação"
@@ -5119,7 +5112,7 @@ msgstr "Subtítulo da mensagem"
 msgid "Moment (optional)"
 msgstr "Momento (opcional)"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:99
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:100
 #: lib/lanttern_web/live/pages/strands/id/lessons_component.ex:85
 #: lib/lanttern_web/live/pages/strands/id/overview_component.ex:55
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.html.heex:358
@@ -5626,7 +5619,7 @@ msgstr "trilha"
 msgid " (Draft)"
 msgstr " (Rascunho)"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:49
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:50
 #, elixir-autogen, elixir-format
 msgid "Add assessment info"
 msgstr "Adicionar informações de avaliação"
@@ -5646,29 +5639,29 @@ msgstr "Descrição do agente"
 msgid "Are you sure? All linked lessons will also be deleted."
 msgstr "Tem certeza? Todas as aulas vinculadas também serão excluídas."
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:25
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:26
 #, elixir-autogen, elixir-format
 msgid "Assessment information"
 msgstr "Informações de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:417
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:418
 #, elixir-autogen, elixir-format
 msgid "Assessment point created"
 msgstr "Ponto de avaliação criado"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:465
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:466
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:538
 #, elixir-autogen, elixir-format
 msgid "Assessment point deleted"
 msgstr "Ponto de avaliação excluído"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:432
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:433
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:523
 #, elixir-autogen, elixir-format
 msgid "Assessment point updated"
 msgstr "Ponto de avaliação atualizado"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:89
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:90
 #, elixir-autogen, elixir-format
 msgid "Assessment points"
 msgstr "Pontos de avaliação"
@@ -5704,13 +5697,15 @@ msgstr "Não foi possível excluir o momento."
 msgid "Delete lessons too"
 msgstr "Excluir aulas também"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:56
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:57
 #, elixir-autogen, elixir-format
 msgid "Edit assessment info"
 msgstr "Editar informações de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:650
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:651
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:402
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:25
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:195
 #, elixir-autogen, elixir-format
 msgid "Edit assessment point"
 msgstr "Editar ponto de avaliação"
@@ -5762,7 +5757,7 @@ msgid "Manage lesson tags below"
 msgstr "Gerencie as tags de aula abaixo"
 
 #: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:8
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:130
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:131
 #: lib/lanttern_web/live/pages/strands/id/strand_live.html.heex:42
 #, elixir-autogen, elixir-format
 msgid "Marking"
@@ -5788,7 +5783,7 @@ msgstr "O momento possui aulas vinculadas."
 msgid "New lesson tag"
 msgstr "Nova tag de aula"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:159
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:160
 #, elixir-autogen, elixir-format
 msgid "No assessment points in this moment yet"
 msgstr "Nenhum ponto de avaliação neste momento ainda"
@@ -5839,7 +5834,7 @@ msgstr "Conhecimento da escola"
 msgid "School-wide knowledge shared with all AI agents. Include information about your school's philosophy, curriculum approach, and other context."
 msgstr "Conhecimento compartilhado com todos os agentes de IA. Inclua informações sobre a filosofia da sua escola, abordagem curricular e outros contextos relevantes."
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:106
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:107
 #, elixir-autogen, elixir-format
 msgid "Select moment to create the assessment point in"
 msgstr "Selecione o momento para criar o ponto de avaliação"
@@ -5849,7 +5844,7 @@ msgstr "Selecione o momento para criar o ponto de avaliação"
 msgid "Something went wrong when trying to delete the lesson tag"
 msgstr "Algo deu errado ao tentar excluir a tag de aula"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:70
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:71
 #, elixir-autogen, elixir-format
 msgid "Strand assessment info"
 msgstr "Informações de avaliação da trilha"
@@ -5873,12 +5868,12 @@ msgstr "Este momento possui aulas vinculadas. O que você gostaria de fazer?"
 msgid "Toggle lesson tag card"
 msgstr "Alternar card da tag de aula"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:30
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:31
 #, elixir-autogen, elixir-format
 msgid "Use this area to share assessment information with students (e.g. grade composition)"
 msgstr "Use esta área para compartilhar informações de avaliação com os estudantes (ex.: composição das notas)"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:301
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:344
 #: lib/lanttern_web/live/pages/strands/lesson/id/lesson_live.ex:47
 #, elixir-autogen, elixir-format
 msgid "Uses rubric in assessment"
@@ -6148,7 +6143,7 @@ msgstr "Você deseja desvincular de \"%{linked_lesson}\" e vincular a \"%{this_l
 msgid "Lesson assessment"
 msgstr "Avaliação da aula"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:323
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:366
 #, elixir-autogen, elixir-format
 msgid "Lesson:"
 msgstr "Aula:"
@@ -6658,7 +6653,7 @@ msgstr "Parâmetro curricular já vinculado à esta trilha"
 msgid "Lesson Curriculum"
 msgstr "Currículo da Aula"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:638
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:639
 #, elixir-autogen, elixir-format
 msgid "New strand goal"
 msgstr "Novo objetivo da trilha"
@@ -6709,7 +6704,7 @@ msgstr "Turmas extras"
 msgid "%{name} grading composition not setup yet"
 msgstr "Composição de notas de %{name} ainda não configurada"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:249
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:253
 #, elixir-autogen, elixir-format
 msgid "Add composition"
 msgstr "Adicionar composição"
@@ -6720,13 +6715,14 @@ msgstr "Adicionar composição"
 msgid "Assessment point"
 msgstr "Ponto de avaliação"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:265
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:269
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Average"
 msgstr "Média"
 
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:183
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:324
 #, elixir-autogen, elixir-format
 msgid "Average-based grade composition"
 msgstr "Composição de nota baseada na média"
@@ -6741,7 +6737,7 @@ msgstr "Componente não pode ser o mesmo do ponto de avaliação pai"
 msgid "Composition type"
 msgstr "Tipo de composição"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:256
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:260
 #, elixir-autogen, elixir-format
 msgid "Create composition using"
 msgstr "Criar composição usando"
@@ -6761,13 +6757,14 @@ msgstr "Selecione os pontos de avaliação para compor a nota"
 msgid "Setup composition"
 msgstr "Configurar composição"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:274
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:278
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:36
 #, elixir-autogen, elixir-format
 msgid "Sum"
 msgstr "Soma"
 
 #: lib/lanttern_web/live/shared/assessment_composition/assessment_point_composition_overlay_component.ex:182
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:321
 #, elixir-autogen, elixir-format
 msgid "Sum-based grade composition"
 msgstr "Composição de nota baseada em soma"
@@ -6787,14 +6784,14 @@ msgstr "não pode estar em branco quando o tipo é numérico"
 msgid "must be \"numeric\" or \"ordinal\""
 msgstr "deve ser \"numérica\" ou \"ordinal\""
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:25
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:24
 #, elixir-autogen, elixir-format
 msgid "1 filter"
 msgid_plural "%{count} filters"
 msgstr[0] "1 filtro"
 msgstr[1] "%{count} filtros"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:46
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:51
 #, elixir-autogen, elixir-format
 msgid "Assign at least one class to the strand to view the assessment grid"
 msgstr "Atribua ao menos uma turma à trilha para visualizar a matriz de avaliação"
@@ -6804,7 +6801,7 @@ msgstr "Atribua ao menos uma turma à trilha para visualizar a matriz de avalia�
 msgid "Assign classes"
 msgstr "Atribuir turmas"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:51
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:50
 #, elixir-autogen, elixir-format
 msgid "Assign classes to strand"
 msgstr "Atribuir turma à trilha"
@@ -6820,17 +6817,17 @@ msgstr "Atribuir turmas à esta trilha"
 msgid "Assigned classes"
 msgstr "Turmas atribuídas"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:295
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:299
 #, elixir-autogen, elixir-format
 msgid "Average-based"
 msgstr "Baseado na média"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:70
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:69
 #, elixir-autogen, elixir-format
 msgid "By class"
 msgstr "Por turma"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:80
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:79
 #, elixir-autogen, elixir-format
 msgid "By grade composition"
 msgstr "Por composição de nota"
@@ -6845,30 +6842,27 @@ msgstr "Turma já atribuída a esta trilha"
 msgid "Clear"
 msgstr "Limpar"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:102
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:101
 #, elixir-autogen, elixir-format
 msgid "Clear all filters"
 msgstr "Limpar todos filtros"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:69
+#: lib/lanttern_web/live/pages/strands/id/assessment/marking/marking_live.html.heex:68
 #, elixir-autogen, elixir-format
 msgid "Filter assessment points"
 msgstr "Filtrar pontos de avaliação"
 
-#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:92
+#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:93
 #, elixir-autogen, elixir-format
 msgid "Has attachment"
 msgstr "Possuí anexo"
 
-#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:93
+#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:94
 #, elixir-autogen, elixir-format
 msgid "Has differentiation rubric"
 msgstr "Possui rubrica de diferenciação"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:274
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:315
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:339
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:375
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:311
 #, elixir-autogen, elixir-format
 msgid "Max score: %{max}"
 msgstr "Pontuação máxima: %{max}"
@@ -6878,27 +6872,110 @@ msgstr "Pontuação máxima: %{max}"
 msgid "No filters applied"
 msgstr "Nenhum filtro aplicado"
 
-#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:156
+#: lib/lanttern_web/live/shared/assessments/entry_cell_component.ex:158
 #, elixir-autogen, elixir-format
 msgid "None"
 msgstr "Nenhnum"
 
-#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:136
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:141
 #, elixir-autogen, elixir-format
 msgid "Some values are out of range"
 msgstr "Alguns valores estão fora do intervalo"
 
-#: lib/lanttern_web/live/shared/learning_context/strand_class_assignment_overlay_component.ex:178
+#: lib/lanttern_web/live/shared/learning_context/strand_class_assignment_overlay_component.ex:177
 #, elixir-autogen, elixir-format
 msgid "Strand classes updated"
 msgstr "Turmas da trilha atualizadas"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:294
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:298
 #, elixir-autogen, elixir-format
 msgid "Sum-based"
 msgstr "Baseado na soma"
 
-#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:290
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:294
 #, elixir-autogen, elixir-format
 msgid "Uses composition"
 msgstr "Utiliza composição"
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:45
+#, elixir-autogen, elixir-format
+msgid "Add average-based composition"
+msgstr "Adicionar composição baseada na média"
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:37
+#, elixir-autogen, elixir-format
+msgid "Add sum-based composition"
+msgstr "Adicionar composição baseada na soma"
+
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:318
+#, elixir-autogen, elixir-format
+msgid "Differentiation assessment"
+msgstr "Avaliação de diferenciação"
+
+#: lib/lanttern_web/live/shared/learning_context/strand_class_assignment_overlay_component.ex:183
+#, elixir-autogen, elixir-format
+msgid "Failed to update class assignments"
+msgstr "Falha ao atualizar atribuição de turmas"
+
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:605
+#, elixir-autogen, elixir-format
+msgid "Grade composition deleted"
+msgstr "Composição de nota deletada"
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:316
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:341
+#, elixir-autogen, elixir-format
+msgid "Hidden"
+msgstr "Oculto"
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:81
+#, elixir-autogen, elixir-format
+msgid "Hidden from students"
+msgstr "Oculto para estudantes"
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:332
+#, elixir-autogen, elixir-format
+msgid "Hide"
+msgstr "Ocultar"
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:88
+#, elixir-autogen, elixir-format
+msgid "Hide from students"
+msgstr "Ocultar dos estudantes"
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:61
+#, elixir-autogen, elixir-format
+msgid "Manage grade composition"
+msgstr "Gerenciar composição de nota"
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:319
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:84
+#, elixir-autogen, elixir-format
+msgid "Students won't see marking results for this assessment point."
+msgstr "Estudantes não visualizarão os resultados deste ponto de avaliação."
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:65
+#, elixir-autogen, elixir-format
+msgid "This assessment point uses a sum-based grade composition."
+msgstr "Este ponto de avaliação utiliza composição de nota baseada na soma."
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:67
+#, elixir-autogen, elixir-format
+msgid "This assessment point uses an average-based grade composition."
+msgstr "Este ponto de avaliação utiliza composição de nota baseada na média."
+
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:49
+#, elixir-autogen, elixir-format
+msgid "Use grade composition to calculate entries based on sum or average of other assessment points."
+msgstr "Use a composição de nota para calcular a nota baseada na soma ou média de outros pontos de avaliação."
+
+#: lib/lanttern_web/live/shared/assessments/assessments_grid_component.ex:316
+#, elixir-autogen, elixir-format
+msgid "Uses rubric"
+msgstr "Utiliza rubrica"
+
+#: lib/lanttern_web/live/pages/strands/id/assessment_component.ex:335
+#: lib/lanttern_web/live/shared/assessments/assessment_point_command_palette_component.ex:91
+#, elixir-autogen, elixir-format
+msgid "When hidden, students won't see marking results for this assessment point. Use this while marking is in progress."
+msgstr "Quando oculto, estudantes não visualizarão os resultados deste ponto de avaliação. Utilize esta opção quando a marcação estiver em progresso."

--- a/priv/repo/migrations/20260523022439_add_is_hidden_to_assessment_points.exs
+++ b/priv/repo/migrations/20260523022439_add_is_hidden_to_assessment_points.exs
@@ -1,0 +1,9 @@
+defmodule Lanttern.Repo.Migrations.AddIsHiddenToAssessmentPoints do
+  use Ecto.Migration
+
+  def change do
+    alter table(:assessment_points) do
+      add :is_hidden, :boolean, null: false, default: false
+    end
+  end
+end

--- a/priv/repo/migrations/20260525160614_create_assessment_points_log.exs
+++ b/priv/repo/migrations/20260525160614_create_assessment_points_log.exs
@@ -1,0 +1,38 @@
+defmodule Lanttern.Repo.Migrations.CreateAssessmentPointsLog do
+  use Ecto.Migration
+
+  @prefix "log"
+
+  def change do
+    create table(:assessment_points, prefix: @prefix) do
+      add :assessment_point_id, :bigint, null: false
+      add :profile_id, :bigint, null: false
+      add :operation, :text, null: false
+      add :name, :text
+      add :datetime, :utc_datetime
+      add :description, :text
+      add :report_info, :text
+      add :position, :integer
+      add :is_differentiation, :boolean, default: false
+      add :is_hidden, :boolean, default: false
+      add :composition_type, :text
+      add :curriculum_item_id, :bigint
+      add :scale_id, :bigint
+      add :rubric_id, :bigint
+      add :lesson_id, :bigint
+      add :moment_id, :bigint
+      add :strand_id, :bigint
+
+      timestamps(updated_at: false)
+    end
+
+    create constraint(
+             :assessment_points,
+             :valid_operations,
+             prefix: @prefix,
+             check: "operation IN ('CREATE', 'UPDATE', 'DELETE')"
+           )
+
+    create index(:assessment_points, [:assessment_point_id], prefix: @prefix)
+  end
+end

--- a/test/lanttern/assessments_test.exs
+++ b/test/lanttern/assessments_test.exs
@@ -8,9 +8,11 @@ defmodule Lanttern.AssessmentsTest do
 
   describe "assessment_points" do
     alias Lanttern.Assessments.AssessmentPoint
+    alias Lanttern.Assessments.AssessmentPointLog
 
     import Lanttern.AssessmentsFixtures
 
+    alias Lanttern.IdentityFixtures
     alias Lanttern.RubricsFixtures
 
     @invalid_attrs %{name: nil, date: nil, description: nil}
@@ -99,6 +101,7 @@ defmodule Lanttern.AssessmentsTest do
     end
 
     test "create_assessment_point/1 with valid data creates a assessment point" do
+      scope = IdentityFixtures.scope_fixture()
       curriculum_item = insert(:curriculum_item)
       scale = insert(:scale)
 
@@ -111,7 +114,7 @@ defmodule Lanttern.AssessmentsTest do
       }
 
       assert {:ok, %AssessmentPoint{} = assessment_point} =
-               Assessments.create_assessment_point(valid_attrs)
+               Assessments.create_assessment_point(scope, valid_attrs)
 
       assert assessment_point.name == "some name"
       assert assessment_point.datetime == ~U[2023-08-02 15:30:00Z]
@@ -119,7 +122,10 @@ defmodule Lanttern.AssessmentsTest do
       assert assessment_point.curriculum_item_id == curriculum_item.id
       assert assessment_point.scale_id == scale.id
 
-      # assert log
+      assert [%AssessmentPointLog{} = log] = Repo.all(AssessmentPointLog)
+      assert log.assessment_point_id == assessment_point.id
+      assert log.profile_id == scope.profile_id
+      assert log.operation == "CREATE"
     end
 
     test "create_assessment_point/1 with valid data containing classes creates an assessment point with linked classes" do
@@ -144,7 +150,7 @@ defmodule Lanttern.AssessmentsTest do
       }
 
       assert {:ok, %AssessmentPoint{} = assessment_point} =
-               Assessments.create_assessment_point(valid_attrs)
+               Assessments.create_assessment_point(%Lanttern.Identity.Scope{}, valid_attrs)
 
       assert assessment_point.name == "some name"
       assert Enum.find(assessment_point.classes, fn c -> c.id == class_1.id end)
@@ -174,7 +180,7 @@ defmodule Lanttern.AssessmentsTest do
       }
 
       assert {:ok, %AssessmentPoint{} = assessment_point} =
-               Assessments.create_assessment_point(valid_attrs)
+               Assessments.create_assessment_point(%Lanttern.Identity.Scope{}, valid_attrs)
 
       assert assessment_point.name == "some name"
       assert Enum.find(assessment_point.entries, fn e -> e.student_id == student_1.id end)
@@ -196,17 +202,19 @@ defmodule Lanttern.AssessmentsTest do
         moment_id: nil
       }
 
+      scope = %Lanttern.Identity.Scope{}
+
       # assessment point in strand context should be ok without name
       assert {:ok, %AssessmentPoint{}} =
-               Assessments.create_assessment_point(%{attrs | strand_id: strand.id})
+               Assessments.create_assessment_point(scope, %{attrs | strand_id: strand.id})
 
       # assessment point in moment should return error without name
       assert {:error, %Ecto.Changeset{}} =
-               Assessments.create_assessment_point(%{attrs | moment_id: moment.id})
+               Assessments.create_assessment_point(scope, %{attrs | moment_id: moment.id})
 
       # assessment point in moment should be ok with name
       assert {:ok, %AssessmentPoint{}} =
-               Assessments.create_assessment_point(%{
+               Assessments.create_assessment_point(scope, %{
                  attrs
                  | moment_id: moment.id,
                    name: "some name"
@@ -214,10 +222,12 @@ defmodule Lanttern.AssessmentsTest do
     end
 
     test "create_assessment_point/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Assessments.create_assessment_point(@invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} =
+               Assessments.create_assessment_point(%Lanttern.Identity.Scope{}, @invalid_attrs)
     end
 
     test "update_assessment_point/2 with valid data updates the assessment" do
+      scope = IdentityFixtures.scope_fixture()
       assessment_point = assessment_point_fixture()
 
       update_attrs = %{
@@ -227,11 +237,16 @@ defmodule Lanttern.AssessmentsTest do
       }
 
       assert {:ok, %AssessmentPoint{} = assessment_point} =
-               Assessments.update_assessment_point(assessment_point, update_attrs)
+               Assessments.update_assessment_point(scope, assessment_point, update_attrs)
 
       assert assessment_point.name == "some updated name"
       assert assessment_point.datetime == ~U[2023-08-03 15:30:00Z]
       assert assessment_point.description == "some updated description"
+
+      assert [%AssessmentPointLog{} = log] = Repo.all(AssessmentPointLog)
+      assert log.assessment_point_id == assessment_point.id
+      assert log.profile_id == scope.profile_id
+      assert log.operation == "UPDATE"
     end
 
     test "update_assessment_point/2 with valid data containing classes updates the assessment point" do
@@ -246,7 +261,11 @@ defmodule Lanttern.AssessmentsTest do
       }
 
       assert {:ok, %AssessmentPoint{} = assessment_point} =
-               Assessments.update_assessment_point(assessment_point, update_attrs)
+               Assessments.update_assessment_point(
+                 %Lanttern.Identity.Scope{},
+                 assessment_point,
+                 update_attrs
+               )
 
       assert assessment_point.name == "some updated name"
       assert length(assessment_point.classes) == 2
@@ -258,21 +277,34 @@ defmodule Lanttern.AssessmentsTest do
       assessment = assessment_point_fixture()
 
       assert {:error, %Ecto.Changeset{}} =
-               Assessments.update_assessment_point(assessment, @invalid_attrs)
+               Assessments.update_assessment_point(
+                 %Lanttern.Identity.Scope{},
+                 assessment,
+                 @invalid_attrs
+               )
 
       assert assessment == Assessments.get_assessment_point!(assessment.id)
     end
 
     test "delete_assessment_point/1 deletes the assessment point" do
+      scope = IdentityFixtures.scope_fixture()
       assessment_point = assessment_point_fixture()
-      assert {:ok, %AssessmentPoint{}} = Assessments.delete_assessment_point(assessment_point)
+
+      assert {:ok, %AssessmentPoint{}} =
+               Assessments.delete_assessment_point(scope, assessment_point)
 
       assert_raise Ecto.NoResultsError, fn ->
         Assessments.get_assessment_point!(assessment_point.id)
       end
+
+      assert [%AssessmentPointLog{} = log] = Repo.all(AssessmentPointLog)
+      assert log.assessment_point_id == assessment_point.id
+      assert log.profile_id == scope.profile_id
+      assert log.operation == "DELETE"
     end
 
     test "delete_assessment_point_and_entries/1 deletes the assessment point and all related entries" do
+      scope = IdentityFixtures.scope_fixture()
       assessment_point = assessment_point_fixture()
 
       _entry =
@@ -282,11 +314,16 @@ defmodule Lanttern.AssessmentsTest do
         })
 
       assert {:ok, %{delete_assessment_point: %AssessmentPoint{}}} =
-               Assessments.delete_assessment_point_and_entries(assessment_point)
+               Assessments.delete_assessment_point_and_entries(scope, assessment_point)
 
       assert_raise Ecto.NoResultsError, fn ->
         Assessments.get_assessment_point!(assessment_point.id)
       end
+
+      assert [%AssessmentPointLog{} = log] = Repo.all(AssessmentPointLog)
+      assert log.assessment_point_id == assessment_point.id
+      assert log.profile_id == scope.profile_id
+      assert log.operation == "DELETE"
     end
 
     test "change_assessment_point/1 returns an assessment point changeset with datetime related virtual fields" do
@@ -322,7 +359,7 @@ defmodule Lanttern.AssessmentsTest do
       }
 
       assert {:ok, %AssessmentPoint{} = assessment_point} =
-               Assessments.create_assessment_point(valid_attrs)
+               Assessments.create_assessment_point(%Lanttern.Identity.Scope{}, valid_attrs)
 
       assert assessment_point.name == "some assessment point name abc"
       assert assessment_point.curriculum_item_id == curriculum_item.id
@@ -1331,7 +1368,7 @@ defmodule Lanttern.AssessmentsTest do
       }
 
       assert {:ok, %AssessmentPoint{} = assessment_point} =
-               Assessments.create_assessment_point(valid_attrs)
+               Assessments.create_assessment_point(%Lanttern.Identity.Scope{}, valid_attrs)
 
       assert assessment_point.name == "some assessment point name abc"
       assert assessment_point.curriculum_item_id == curriculum_item.id

--- a/test/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component_test.exs
+++ b/test/lanttern_web/live/pages/shared/strand_report/strand_report_assessment_component_test.exs
@@ -58,6 +58,72 @@ defmodule LantternWeb.StrandReportLive.StrandReportAssessmentComponentTest do
       assert view |> has_element?("[id*='assessment-point']", "Assessment Point Alpha")
     end
 
+    test "does not show hidden assessment points", context do
+      %{conn: conn, student: student} = register_and_log_in_student(context)
+
+      report_card = report_card_fixture()
+
+      _student_report_card =
+        student_report_card_fixture(%{
+          report_card_id: report_card.id,
+          student_id: student.id,
+          allow_student_access: true
+        })
+
+      strand = LearningContextFixtures.strand_fixture()
+
+      strand_report =
+        strand_report_fixture(%{report_card_id: report_card.id, strand_id: strand.id})
+
+      moment =
+        LearningContextFixtures.moment_fixture(%{strand_id: strand.id, name: "Moment Alpha"})
+
+      scale = insert(:scale, type: "ordinal", breakpoints: [0.4, 0.8])
+      ov = insert(:ordinal_value, scale_id: scale.id)
+      ci = insert(:curriculum_item)
+
+      ap_visible =
+        assessment_point_fixture(%{
+          name: "AP Visible",
+          moment_id: moment.id,
+          scale_id: scale.id,
+          curriculum_item_id: ci.id
+        })
+
+      ap_hidden =
+        assessment_point_fixture(%{
+          name: "AP Hidden",
+          moment_id: moment.id,
+          scale_id: scale.id,
+          curriculum_item_id: ci.id,
+          is_hidden: true
+        })
+
+      _entry_visible =
+        assessment_point_entry_fixture(%{
+          assessment_point_id: ap_visible.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: scale.type,
+          ordinal_value_id: ov.id
+        })
+
+      _entry_hidden =
+        assessment_point_entry_fixture(%{
+          assessment_point_id: ap_hidden.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: scale.type,
+          ordinal_value_id: ov.id
+        })
+
+      {:ok, view, _html} =
+        live(conn, "#{@live_view_path_base}/#{strand_report.id}/assessment")
+
+      assert view |> has_element?("[id*='assessment-point']", "AP Visible")
+      refute view |> has_element?("[id*='assessment-point']", "AP Hidden")
+    end
+
     test "does not show assessment points that have no entry for the student", context do
       %{conn: conn, student: student} = register_and_log_in_student(context)
 
@@ -94,6 +160,157 @@ defmodule LantternWeb.StrandReportLive.StrandReportAssessmentComponentTest do
 
       refute view |> has_element?("h4", "Moment Beta")
       refute view |> has_element?("[id*='assessment-point']", "AP Without Entry")
+    end
+
+    test "does not show hidden strand goal cards", context do
+      %{conn: conn, student: student} = register_and_log_in_student(context)
+
+      report_card = report_card_fixture()
+
+      _student_report_card =
+        student_report_card_fixture(%{
+          report_card_id: report_card.id,
+          student_id: student.id,
+          allow_student_access: true
+        })
+
+      strand = LearningContextFixtures.strand_fixture()
+
+      strand_report =
+        strand_report_fixture(%{report_card_id: report_card.id, strand_id: strand.id})
+
+      scale = insert(:scale, type: "ordinal", breakpoints: [0.4, 0.8])
+      ov = insert(:ordinal_value, scale_id: scale.id)
+      ci_visible = insert(:curriculum_item, name: "Curriculum Item Visible")
+      ci_hidden = insert(:curriculum_item, name: "Curriculum Item Hidden")
+
+      ap_visible =
+        assessment_point_fixture(%{
+          strand_id: strand.id,
+          scale_id: scale.id,
+          curriculum_item_id: ci_visible.id
+        })
+
+      ap_hidden =
+        assessment_point_fixture(%{
+          strand_id: strand.id,
+          scale_id: scale.id,
+          curriculum_item_id: ci_hidden.id,
+          is_hidden: true
+        })
+
+      _entry_visible =
+        assessment_point_entry_fixture(%{
+          assessment_point_id: ap_visible.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: scale.type,
+          ordinal_value_id: ov.id
+        })
+
+      _entry_hidden =
+        assessment_point_entry_fixture(%{
+          assessment_point_id: ap_hidden.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: scale.type,
+          ordinal_value_id: ov.id
+        })
+
+      {:ok, view, _html} =
+        live(conn, "#{@live_view_path_base}/#{strand_report.id}/assessment")
+
+      assert view |> has_element?("[id^='goal-']", "Curriculum Item Visible")
+      refute view |> has_element?("[id^='goal-']", "Curriculum Item Hidden")
+    end
+  end
+
+  describe "StrandGoalDetailsOverlayComponent" do
+    test "does not show hidden moment assessment points in formative assessment section",
+         context do
+      %{conn: conn, student: student} = register_and_log_in_student(context)
+
+      report_card = report_card_fixture()
+
+      _student_report_card =
+        student_report_card_fixture(%{
+          report_card_id: report_card.id,
+          student_id: student.id,
+          allow_student_access: true
+        })
+
+      strand = LearningContextFixtures.strand_fixture()
+
+      strand_report =
+        strand_report_fixture(%{report_card_id: report_card.id, strand_id: strand.id})
+
+      scale = insert(:scale, type: "ordinal", breakpoints: [0.4, 0.8])
+      ov = insert(:ordinal_value, scale_id: scale.id)
+      ci = insert(:curriculum_item)
+
+      strand_goal_ap =
+        assessment_point_fixture(%{
+          strand_id: strand.id,
+          scale_id: scale.id,
+          curriculum_item_id: ci.id
+        })
+
+      _strand_goal_entry =
+        assessment_point_entry_fixture(%{
+          assessment_point_id: strand_goal_ap.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: scale.type,
+          ordinal_value_id: ov.id
+        })
+
+      moment_visible =
+        LearningContextFixtures.moment_fixture(%{strand_id: strand.id, name: "Moment Visible"})
+
+      moment_hidden =
+        LearningContextFixtures.moment_fixture(%{strand_id: strand.id, name: "Moment Hidden"})
+
+      ap_in_visible_moment =
+        assessment_point_fixture(%{
+          moment_id: moment_visible.id,
+          curriculum_item_id: ci.id,
+          scale_id: scale.id
+        })
+
+      ap_in_hidden_moment =
+        assessment_point_fixture(%{
+          moment_id: moment_hidden.id,
+          curriculum_item_id: ci.id,
+          scale_id: scale.id,
+          is_hidden: true
+        })
+
+      _entry_visible =
+        assessment_point_entry_fixture(%{
+          assessment_point_id: ap_in_visible_moment.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: scale.type,
+          ordinal_value_id: ov.id
+        })
+
+      _entry_hidden =
+        assessment_point_entry_fixture(%{
+          assessment_point_id: ap_in_hidden_moment.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: scale.type,
+          ordinal_value_id: ov.id
+        })
+
+      {:ok, view, _html} =
+        live(
+          conn,
+          "#{@live_view_path_base}/#{strand_report.id}/assessment/strand_goal/#{strand_goal_ap.id}"
+        )
+
+      assert view |> has_element?("#moments-assessment-points-and-entries", "Moment Visible")
+      refute view |> has_element?("#moments-assessment-points-and-entries", "Moment Hidden")
     end
   end
 

--- a/test/lanttern_web/live/pages/strands/id/assessment/marking/marking_live_test.exs
+++ b/test/lanttern_web/live/pages/strands/id/assessment/marking/marking_live_test.exs
@@ -173,7 +173,7 @@ defmodule LantternWeb.MarkingLiveTest do
       conn
       |> visit("#{@live_view_path}/#{strand.id}/assessment/marking?classes_ids=#{class.id}")
       |> assert_has("div", text: student.name)
-      |> assert_has("span", text: ordinal_value_1.name)
+      |> assert_has("div", text: ordinal_value_1.name)
     end
 
     test "displays student self-assessment in student view", %{
@@ -188,7 +188,7 @@ defmodule LantternWeb.MarkingLiveTest do
         "#{@live_view_path}/#{strand.id}/assessment/marking?classes_ids=#{class.id}&assessment_view=student"
       )
       |> assert_has("div", text: student.name)
-      |> assert_has("span", text: ordinal_value_2.name)
+      |> assert_has("div", text: ordinal_value_2.name)
     end
 
     test "displays both assessments in compare view", %{

--- a/test/lanttern_web/live/pages/strands/id/assessment_component_test.exs
+++ b/test/lanttern_web/live/pages/strands/id/assessment_component_test.exs
@@ -405,4 +405,46 @@ defmodule LantternWeb.StrandLive.AssessmentComponentTest do
       |> assert_has("button", text: "Add composition")
     end
   end
+
+  describe "toggle_hidden" do
+    test "clicking 'Hide' changes button label to 'Hidden'", %{conn: conn} do
+      strand = insert(:strand)
+      moment = insert(:moment, strand: strand)
+      scale = insert(:scale)
+      ci = insert(:curriculum_item)
+
+      AssessmentsFixtures.assessment_point_fixture(%{
+        name: "Visible AP",
+        moment_id: moment.id,
+        scale_id: scale.id,
+        curriculum_item_id: ci.id,
+        is_hidden: false
+      })
+
+      conn
+      |> visit("#{@live_view_base_path}/#{strand.id}/assessment")
+      |> click_button("Hide")
+      |> assert_has("button", text: "Hidden")
+    end
+
+    test "clicking 'Hidden' changes button label back to 'Hide'", %{conn: conn} do
+      strand = insert(:strand)
+      moment = insert(:moment, strand: strand)
+      scale = insert(:scale)
+      ci = insert(:curriculum_item)
+
+      AssessmentsFixtures.assessment_point_fixture(%{
+        name: "Test AP",
+        moment_id: moment.id,
+        scale_id: scale.id,
+        curriculum_item_id: ci.id,
+        is_hidden: true
+      })
+
+      conn
+      |> visit("#{@live_view_base_path}/#{strand.id}/assessment")
+      |> click_button("Hidden")
+      |> assert_has("button", text: "Hide")
+    end
+  end
 end

--- a/test/lanttern_web/live/pages/strands/id/assessment_component_test.exs
+++ b/test/lanttern_web/live/pages/strands/id/assessment_component_test.exs
@@ -314,7 +314,11 @@ defmodule LantternWeb.StrandLive.AssessmentComponentTest do
       strand = insert(:strand)
       moment = insert(:moment, strand: strand)
       ap = insert(:assessment_point, name: "AP with avg composition", moment_id: moment.id)
-      {:ok, _} = Assessments.update_assessment_point(ap, %{composition_type: "avg"})
+
+      {:ok, _} =
+        Assessments.update_assessment_point(%Lanttern.Identity.Scope{}, ap, %{
+          composition_type: "avg"
+        })
 
       conn
       |> visit("#{@live_view_base_path}/#{strand.id}/assessment")
@@ -325,7 +329,11 @@ defmodule LantternWeb.StrandLive.AssessmentComponentTest do
       strand = insert(:strand)
       moment = insert(:moment, strand: strand)
       ap = insert(:assessment_point, name: "AP with avg composition", moment_id: moment.id)
-      {:ok, _} = Assessments.update_assessment_point(ap, %{composition_type: "avg"})
+
+      {:ok, _} =
+        Assessments.update_assessment_point(%Lanttern.Identity.Scope{}, ap, %{
+          composition_type: "avg"
+        })
 
       conn
       |> visit("#{@live_view_base_path}/#{strand.id}/assessment")
@@ -338,7 +346,12 @@ defmodule LantternWeb.StrandLive.AssessmentComponentTest do
       strand = insert(:strand)
       moment = insert(:moment, strand: strand)
       ap = insert(:assessment_point, name: "Parent AP", moment_id: moment.id)
-      {:ok, parent_ap} = Assessments.update_assessment_point(ap, %{composition_type: "avg"})
+
+      {:ok, parent_ap} =
+        Assessments.update_assessment_point(%Lanttern.Identity.Scope{}, ap, %{
+          composition_type: "avg"
+        })
+
       sibling_ap = insert(:assessment_point, name: "Sibling AP", moment_id: moment.id)
       insert(:assessment_point_component, parent: parent_ap, component: sibling_ap)
 
@@ -352,7 +365,12 @@ defmodule LantternWeb.StrandLive.AssessmentComponentTest do
       strand = insert(:strand)
       moment = insert(:moment, strand: strand)
       ap = insert(:assessment_point, name: "Parent AP", moment_id: moment.id)
-      {:ok, _} = Assessments.update_assessment_point(ap, %{composition_type: "avg"})
+
+      {:ok, _} =
+        Assessments.update_assessment_point(%Lanttern.Identity.Scope{}, ap, %{
+          composition_type: "avg"
+        })
+
       sibling_ap = insert(:assessment_point, name: "Sibling AP to select", moment_id: moment.id)
 
       conn
@@ -368,7 +386,12 @@ defmodule LantternWeb.StrandLive.AssessmentComponentTest do
       strand = insert(:strand)
       moment = insert(:moment, strand: strand)
       ap = insert(:assessment_point, name: "Parent AP", moment_id: moment.id)
-      {:ok, parent_ap} = Assessments.update_assessment_point(ap, %{composition_type: "avg"})
+
+      {:ok, parent_ap} =
+        Assessments.update_assessment_point(%Lanttern.Identity.Scope{}, ap, %{
+          composition_type: "avg"
+        })
+
       sibling_ap = insert(:assessment_point, name: "Sibling AP", moment_id: moment.id)
       insert(:assessment_point_component, parent: parent_ap, component: sibling_ap)
 
@@ -388,7 +411,12 @@ defmodule LantternWeb.StrandLive.AssessmentComponentTest do
       strand = insert(:strand)
       moment = insert(:moment, strand: strand)
       ap = insert(:assessment_point, name: "Parent AP", moment_id: moment.id)
-      {:ok, parent_ap} = Assessments.update_assessment_point(ap, %{composition_type: "avg"})
+
+      {:ok, parent_ap} =
+        Assessments.update_assessment_point(%Lanttern.Identity.Scope{}, ap, %{
+          composition_type: "avg"
+        })
+
       sibling_ap = insert(:assessment_point, name: "Sibling AP", moment_id: moment.id)
       insert(:assessment_point_component, parent: parent_ap, component: sibling_ap)
 

--- a/test/lanttern_web/live/pages/student_report_cards/id/student_report_card_live_test.exs
+++ b/test/lanttern_web/live/pages/student_report_cards/id/student_report_card_live_test.exs
@@ -148,6 +148,69 @@ defmodule LantternWeb.StudentReportCardLiveTest do
       assert view |> has_element?("h2", "Some report card name abc")
     end
 
+    test "does not display entry badges for hidden assessment points", context do
+      %{conn: conn, student: student} = register_and_log_in_student(context)
+
+      cycle = SchoolsFixtures.cycle_fixture(%{name: "Cycle 2024"})
+
+      report_card =
+        report_card_fixture(%{school_cycle_id: cycle.id, name: "Some report card name abc"})
+
+      student_report_card =
+        student_report_card_fixture(%{
+          report_card_id: report_card.id,
+          student_id: student.id,
+          allow_student_access: true
+        })
+
+      strand =
+        LearningContextFixtures.strand_fixture(%{name: "Strand DDD"})
+
+      strand_report =
+        strand_report_fixture(%{report_card_id: report_card.id, strand_id: strand.id})
+
+      scale = insert(:scale, type: "ordinal")
+      ov_visible = insert(:ordinal_value, scale: scale, short_name: "ovx")
+      ov_hidden = insert(:ordinal_value, scale: scale, short_name: "ovy")
+
+      ap_visible =
+        AssessmentsFixtures.assessment_point_fixture(%{
+          strand_id: strand.id,
+          scale_id: scale.id
+        })
+
+      ap_hidden =
+        AssessmentsFixtures.assessment_point_fixture(%{
+          strand_id: strand.id,
+          scale_id: scale.id,
+          is_hidden: true
+        })
+
+      _entry_visible =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          assessment_point_id: ap_visible.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: "ordinal",
+          ordinal_value_id: ov_visible.id
+        })
+
+      _entry_hidden =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          assessment_point_id: ap_hidden.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: "ordinal",
+          ordinal_value_id: ov_hidden.id
+        })
+
+      {:ok, view, _html} = live(conn, "#{@live_view_path_base}/#{student_report_card.id}")
+
+      assert view |> has_element?("h5", "Strand DDD")
+      assert view |> has_element?("#strand-report-#{strand_report.id}", "ovx")
+      refute view |> has_element?("#strand-report-#{strand_report.id}", "ovy")
+    end
+
     test "display student report card correctly for guardians", context do
       %{conn: conn, student: student} = register_and_log_in_guardian(context)
 

--- a/test/lanttern_web/live/pages/student_strands/student_strands_live_test.exs
+++ b/test/lanttern_web/live/pages/student_strands/student_strands_live_test.exs
@@ -1,6 +1,9 @@
 defmodule LantternWeb.StudentStrandsLiveTest do
   use LantternWeb.ConnCase
 
+  import Lanttern.Factory
+
+  alias Lanttern.AssessmentsFixtures
   alias Lanttern.LearningContextFixtures
   alias Lanttern.ReportingFixtures
   alias Lanttern.SchoolsFixtures
@@ -55,6 +58,77 @@ defmodule LantternWeb.StudentStrandsLiveTest do
 
       assert view |> has_element?("h5", "AAA")
       assert view |> has_element?("h5", "BBB")
+    end
+
+    test "does not display entry particles for hidden assessment points",
+         %{conn: conn, user: user, student: student} do
+      parent_cycle_id = user.current_profile.current_school_cycle.id
+
+      cycle =
+        SchoolsFixtures.cycle_fixture(%{
+          school_id: student.school_id,
+          parent_cycle_id: parent_cycle_id
+        })
+
+      report_card = ReportingFixtures.report_card_fixture(%{school_cycle_id: cycle.id})
+
+      _student_report_card =
+        ReportingFixtures.student_report_card_fixture(%{
+          report_card_id: report_card.id,
+          student_id: student.id,
+          allow_student_access: true
+        })
+
+      strand = LearningContextFixtures.strand_fixture(%{name: "CCC"})
+
+      strand_report =
+        ReportingFixtures.strand_report_fixture(%{
+          report_card_id: report_card.id,
+          strand_id: strand.id
+        })
+
+      moment = LearningContextFixtures.moment_fixture(%{strand_id: strand.id})
+
+      scale = insert(:scale, type: "ordinal")
+      ov_visible = insert(:ordinal_value, scale: scale, short_name: "ovx")
+      ov_hidden = insert(:ordinal_value, scale: scale, short_name: "ovy")
+
+      ap_visible =
+        AssessmentsFixtures.assessment_point_fixture(%{
+          moment_id: moment.id,
+          scale_id: scale.id
+        })
+
+      ap_hidden =
+        AssessmentsFixtures.assessment_point_fixture(%{
+          moment_id: moment.id,
+          scale_id: scale.id,
+          is_hidden: true
+        })
+
+      _entry_visible =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          assessment_point_id: ap_visible.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: "ordinal",
+          ordinal_value_id: ov_visible.id
+        })
+
+      _entry_hidden =
+        AssessmentsFixtures.assessment_point_entry_fixture(%{
+          assessment_point_id: ap_hidden.id,
+          student_id: student.id,
+          scale_id: scale.id,
+          scale_type: "ordinal",
+          ordinal_value_id: ov_hidden.id
+        })
+
+      {:ok, view, _html} = live(conn, @live_view_path)
+
+      assert view |> has_element?("h5", "CCC")
+      assert view |> has_element?("#student-strand-report-#{strand_report.id}", "ovx")
+      refute view |> has_element?("#student-strand-report-#{strand_report.id}", "ovy")
     end
   end
 end

--- a/test/support/fixtures/assessments_fixtures.ex
+++ b/test/support/fixtures/assessments_fixtures.ex
@@ -17,7 +17,7 @@ defmodule Lanttern.AssessmentsFixtures do
         scale_id: Lanttern.GradingFixtures.maybe_gen_scale_id(attrs),
         curriculum_item_id: maybe_gen_curriculum_item_id(attrs)
       })
-      |> Lanttern.Assessments.create_assessment_point()
+      |> then(&Lanttern.Assessments.create_assessment_point(%Lanttern.Identity.Scope{}, &1))
 
     assessment_point
   end


### PR DESCRIPTION
### Summary

Implements student access control for assessment points by adding an `is_hidden` flag that hides selected assessment points from all student-facing views, along with audit logging for all assessment point mutations.

### Related Issues

- Closes #540

### What This PR Does

- **Student visibility control**: Adds `is_hidden` field to `AssessmentPoint`, allowing teachers to hide specific assessment points from students. Hidden APs are filtered out of student strands, student report cards, and strand report views.
- **Command palette for AP management**: Introduces a new command palette component for assessment point actions (including toggling hidden state) directly from the assessment grid column headers.
- **Audit logging**: Tracks all `create`, `update`, and `delete` mutations on assessment points via a new `AssessmentPointLog` schema and the existing `AuditLog` pipeline. Context functions now accept `Scope` as their first parameter.
- **Composition overlay**: Opens in setup mode automatically when a new assessment point is created, streamlining the configuration flow.
- **Grid improvements**: Replaces number inputs with text inputs for numeric scores (preserving cursor position), fixes duplicate input IDs and cell overflow, and extracts a dedicated `GradingComponents` module with redesigned AP column headers.
- **Tooltip fix**: Enforces singleton tooltip visibility to clear stuck tooltips.

### Impact and Scope

- `Lanttern.Assessments` context: `create_assessment_point/2` and `update_assessment_point/3` now require `Scope` as the first argument (breaking change for callers)
- New DB migration: `is_hidden` boolean column on `assessment_points`
- New DB migration: `assessment_points_log` table for audit trail
- `LearningContext` and `Reporting` contexts updated to filter hidden APs for student-scoped queries
- New `GradingComponents` module extracted from the grid component

### Testing Considerations

- Tests added for hidden AP filtering across student strands, student report cards, and strand report views
- Audit log behavior covered in `assessments_test.exs`
- Marking live tests updated to reflect the new `Scope`-first function signatures

---

Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>